### PR TITLE
Add contributing instructions to special file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+**CONTRIBUTORS TAKE NOTE:** We work off the `devel` branch, so be sure to pull that branch and submit your pull request to `devel` not `master`.


### PR DESCRIPTION
GitHub floats a CONTRIBUTING file in front of people filing issues and stuff. I don't know, whatever.
