### PR TITLE
remove Lena Trudeau from team page

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,11 +376,6 @@ We're always looking for curious people with diverse skill-sets. Let's talk at 1
         </div>
         <!--  -->
         <div class="col-md-3 col-sm-6 col-xs-6 bio">
-          <img class="img-circle team-img" src="images/team/lena-bw.jpg" data-color="images/team/lena.jpg" alt="Photo of Lena Trudeau">
-          <h4>Lena Trudeau</h4>
-        </div>
-        <!--  -->
-        <div class="col-md-3 col-sm-6 col-xs-6 bio">
           <img class="img-circle team-img" src="images/team/raphy-bw.jpg" data-color="images/team/raphy.jpg" alt="Photo of Raphael Villas">
           <h4>Raphael Villas</h4>
         </div>


### PR DESCRIPTION
Like the Habs from the playoffs, @lenatrudeau is the first to leave us. Farewell, Prime Minister. We miss you already.
