### PR TITLE
Proposed 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,72 +1,21 @@
-<!doctype html>
-<html>
-<head>
+---
+layout: default
+---
 
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<section class="fours">
+  <div class="container">
+    <div class="fours-content">
+      <h1>404</h1>
+      <h2>We looked so hard for this page, <br/>
+        but just couldn't find it.</h2>
+    </div>
+  </div>
+</section>
 
-<link href='//fonts.googleapis.com/css?family=Raleway:400,700|Open+Sans:300,600' rel='stylesheet' type='text/css'>
+<section class="container">
+  <div class="fours-content">
+    <p>Try checking out 18F's <a href="/">homepage</a> or <a href="/news/">blog</a>.</p>
+    <p>Or, <a href="mailto:18f@gsa.gov">contact us</a> if you can't find what you're looking for.</p>
+  </div>
+<section>
 
-<style>
-body {
-  background-color: #18F;
-  font-family: Open Sans, Arial, sans-serif;
-  color: white;
-}
-
-#four {
-  font-size: 250pt;
-  line-height: 360px;
-  text-align: center;
-  display: block;
-}
-
-p, footer {
-  display: block;
-  text-align: center;
-  background-color: #fff;
-  color: #333;
-}
-
-p {margin: 0; padding: 15px 30px 15px 30px;}
-footer {margin: 0; padding: 30px;}
-
-a, a:visited {color: #143883;}
-
-p {
-  font-size: 30pt;
-}
-
-footer {font-size: 10pt;}
-
-@media (max-width: 700px) {
-  #four {
-    font-size: 120pt;
-    line-height: 220px;
-  }
-
-  p {font-size: 20pt;}
-}
-
-</style>
-
-</head>
-<body>
-
-<span id="four">404</span>
-
-<p>
-  We searched the United States but were unable to satisfy your request.
-</p>
-
-<p>
-  You can return to 18F's <a href="/">homepage</a> or <a href="/news/">blog</a>, or <a href="mailto:18f@gsa.gov">contact us</a> if you feel there's been a terrible mistake.
-</p>
-
-<footer style="display: none">
-  WE LOOKED SO HARD FOR THIS PAGE BUT WE JUST COULDN'T FIND IT
-</footer>
-
-</body>
-</html>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -741,6 +741,42 @@ $tiniest: new-breakpoint(max-width 390px);
 	display: inline-block;
 }
 
+// 404
+//********************************************************
+.fours {
+	background-color: $blue;
+	color: white;
+	padding-top: 130px;
+	padding-bottom: 130px;
+	margin-bottom: 30px;
+}
+.fours-content {
+	@include span-columns(6);
+	@include shift(3);
+	text-align: center;
+	h1 {
+		font-family: $base-font-family;
+		font-weight: 500;
+		font-size: 9em;
+	}
+	h2 {
+		font-size: 1.4em;
+		padding-top: 10px;
+		line-height: 1.3em;
+	}
+	p {
+		margin: 0;
+		font-size: 0.9em;
+	}
+	p+p {
+		margin-bottom: 100px;
+	}
+	@include media($tiny) {
+	@include span-columns(12);
+	@include shift(0);
+	}
+}
+
 // Footer
 //********************************************************
 .footer {


### PR DESCRIPTION
I've put together a fun 404 page -- maybe it is too fun, tell me what you think. The way Jekyll handles 404 pages is just straight HTML, no layouts or includes, so it's an extremely bare template with an inline `<style>` block for everything. The background is `#18F`.

Desktop:

![404-desktop](https://cloud.githubusercontent.com/assets/4592/4298940/57c74c10-3e2e-11e4-83cb-1bf31fd894eb.png)

Mobile:

![404-mobile](https://cloud.githubusercontent.com/assets/4592/4298943/66a82e16-3e2e-11e4-8bdb-00480c05593b.png)

What do people think? Will this fly?
