### PR TITLE
Adds a fabric file, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,35 @@ The site will be visible at `http://localhost:4000`.
 
 You don't need to worry about this for normal development. But on the staging and production server, this project uses [Node](http://nodejs.org) and [`hookshot`](https://github.com/coreh/hookshot) to receive GitHub post-receive webhooks and update the project.
 
-Install Node however you want. We use a fork of `hookshot` with a bugfix, until [this pull request](https://github.com/coreh/hookshot/pull/5) is merged.
+This project includes [fabric tasks](http://www.fabfile.org/) for easy remote stop/start/restart of the hook processes on the 18F website.
 
-Install dependencies with:
+You will need:
+
+* authorized access to the 18F site server
+* an `18f-site` entry in your `$HOME/.ssh/config` with the necessary credentials
+* to `pip install fabric`, and have your active `python` when running it be 2.X
+
+With that, you can start, stop, and restart the staging and production hooks like so:
+
+```
+fab stop
+fab start
+fab restart
+```
+
+Provide `--set env=production` to any of those commands to apply it to the production hook.
+
+#### Setting it up yourself
+
+Install the Node dependencies with:
 
 ```bash
-npm install https://github.com/VesQ/hookshot/tarball/master
+npm install hookshot
 npm install minimist
 npm install -g forever
 ```
 
 18F's web server uses the `hookshot` command to listen for hooks on either of two ports.
-
-```bash
-hookshot -r refs/heads/staging -p 3000 "echo 'HOOKS' && cd /home/eric/18f/18f.gsa.gov && git pull && jekyll build > build.out"
-```
-
 
 From `/deploy`, run the hook with the appropriate port and command. It can be helpful to have `forever` and your command both log to the same file.
 
@@ -64,47 +77,6 @@ forever restart deploy/hookshot.js -p 3000 -b your-branch -c "cd $HOME/18f/18f.g
 ```
 
 On our web server, 18F runs two separate hooks.
-
-#### Staging hook
-
-Starting (from the project root):
-
-```bash
-forever start -l $HOME/hookshot.log -a deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
-Restarting (anywhere):
-
-```bash
-forever restart deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
-Stopping (anywhere):
-
-```bash
-forever stop deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
-#### Production hook
-
-Starting (from the project root):
-
-```bash
-forever start -l $HOME/hookshot.log -a deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
-Restarting (anywhere):
-
-```bash
-forever restart deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
-Stopping (anywhere):
-
-```bash
-forever stop deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
-```
-
 
 You may wish to use [ngrok](https://ngrok.com/) or [localtunnel](https://localtunnel.me/) in development, to test out the webhook.
 

--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -1,0 +1,58 @@
+import time
+from fabric.api import run, execute, env
+
+"""
+Manage auto-deploy webhooks remotely.
+
+Staging hook:
+
+  forever start -l $HOME/hookshot.log -a deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
+  forever restart deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
+  forever stop deploy/hookshot.js -p 3000 -b staging -c "cd $HOME/staging/current && git pull && jekyll build >> $HOME/hookshot.log"
+
+Production hook:
+
+  forever start -l $HOME/hookshot.log -a deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
+  forever restart deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
+  forever stop deploy/hookshot.js -p 4000 -b production -c "cd $HOME/production/current && git pull && jekyll build >> $HOME/hookshot.log"
+"""
+
+# which hook to restart. defaults to staging, override with:
+#   fab [command] --set env=production"
+environment = env.get('env', 'staging')
+
+port = {
+  "staging": 3000,
+  "production": 4000
+}[environment]
+
+# expects an SSH entry named '18f-site', rather than hardcoded server details
+env.use_ssh_config = True
+env.hosts = ["18f-site"]
+
+home = "/home/site"
+log = "%s/hookshot.log" % home
+current = "%s/%s/current" % (home, environment)
+
+# principal command to run upon update
+command = "cd %s && git pull && jekyll build >> %s" % (current, log)
+
+## can be run on their own
+
+def start():
+  run(
+    "cd %s && forever start -l %s -a deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, log, port, environment, command)
+  )
+
+def stop():
+  run(
+    "cd %s && forever stop deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, port, environment, command)
+  )
+
+def restart():
+  run(
+    "cd %s && forever restart deploy/hookshot.js -p %i -b %s -c \"%s\""
+    % (current, port, environment, command)
+  )


### PR DESCRIPTION
This allows the webhook to be controlled remotely. I added instructions to the README, moved the copious `forever` commands to the `fabfile.py`'s comments, and emphasized in the README how to use the webhooks we have rather than develop on your own.
