### PR TITLE
Fixes hero width on screens > 1600px

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -26,8 +26,13 @@
         z-index  : $images;
         top      : 0;
         left     : 0;
+        width    : 100%;
         @each $vendor in $vendorsList {
             #{$vendor}animation: #{$animationSettings};
+        }
+
+        img {
+        	width : 100%
         }  
 
         @for $i from 2 through $images {


### PR DESCRIPTION
Should fix the issue where on larger screens the hero image would not fill the available space.
