### PR TITLE
Removes grayscale hover filter at small sizes.

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -576,6 +576,9 @@ $tiniest: new-breakpoint(max-width 390px);
         		height: 100px;
     			width: 100px;
     			margin: 0.3em auto;
+	        	-webkit-filter: none;
+	        	-moz-filter: none;
+	        	filter: none;
         	}
         	@include media($tiniest) {
         		height: 85px;


### PR DESCRIPTION
Removes grayscale hover filter at small sizes since touchscreens don't have a hover. This also resolves an Android Chrome issue whereby the CSS grayscale filter renders poorly. Closes #202 .

Current cutoff is `$tiny: new-breakpoint(max-width 590px);`
