### PR TITLE
Fix tag link in archive layout

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -27,7 +27,7 @@ layout: bare
                 Tagged /
                 <span class="blog-tags" itemprop="keywords">
                   {% for tag in post.tags %}
-                    <a href="/tags/{{ tag }}">{{ tag }}</a>
+                    <a href="/{{ site.tag_dir }}/{{ tag }}">{{ tag }}</a>
                     /
                   {% endfor %}
                 </span>


### PR DESCRIPTION
Updated to include config variable that now sets that tag directory. The layout that was causing problems had not been updated. Now it has been :)
