### PR TITLE
Add publish date to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,9 @@
 
   <div class="bare-content" role="main" itemscope itemprop="mainContentOfPage">
     <section class="blog-posting" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
-      <h1>{{page.title}}</h1>
+      <time>{{ page.date | date: "%B %-d, %Y" }} </time>
+      <h1>{{ page.title }}</h1>
+
 
       {{ content }}
     </section>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -404,6 +404,10 @@ $tiniest: new-breakpoint(max-width 390px);
 }
 
 .blog-posting {
+  time {
+    display: block;
+    margin-bottom: 10px;
+  }
 	h1 + p {
 		padding-top: 10px;
 	}


### PR DESCRIPTION
Adds published dates to posts. Looks like this:

![dates](https://cloud.githubusercontent.com/assets/4592/4397146/6be97e9c-443d-11e4-8068-55d90ec76e41.png)

Uses a `<time>` tag that's a block with a bottom margin. Styling improvements welcome!

Date formatting reference: http://alanwsmith.com/jekyll-liquid-date-formatting-examples

Closes #245.
