### PR TITLE
Closes #260 by filtering html from post excerpts

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -35,7 +35,7 @@ layout: bare
             </div>
 
             <div class="blog-snippet" itemprop="articleBody">
-              {{ post.excerpt }}
+              <p>{{ post.excerpt | strip_html }}</p>
             </div>
 
             <div class="blog-continue">

--- a/pages/index.html
+++ b/pages/index.html
@@ -80,7 +80,7 @@ permalink: /
         </p>
       </div>
       <div class="blog-snippet" itemprop="articleBody">
-        {{ post.excerpt }}
+        <p>{{ post.excerpt |strip_html }}</p>
         <p><a href="{{ post.url }}">Continue reading...</a></p>
       </div>
     {% endfor %}


### PR DESCRIPTION
- The issue was that post excerpts would look inconsistent depending on
  whether they used the <!-- more --> tag or a manual excerpt
- This commit filters whatever html may or may not be in an excerpt and
  wraps the excerpt in a <p> tag. The consequence is that all excerpts,
  even if they span multiple lines will be displayed on the homepage or an
  archive in a single `<p>`
- closes #260 and #259
