### PR TITLE
ignore rvm config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.log
 /node_modules
 /.sass-cache/
+.rvmrc
+


### PR DESCRIPTION
not everyone likes to use rvm, but I want a config file so adding to .gitignore
