### PR TITLE
Adds a rel=canonical link tag to the top of our posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,8 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
+<link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+
 <!-- Mobile Specific Metas
 ================================================== -->
 <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
This way, staging will refer Google et al to production.

Fixes #284.
