### PR TITLE
Correct accidentally relative path to prevent dead links.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
       <br/>
       <a href="https://github.com/presidential-innovation-fellows"><i class="icon-github2"></i> github.com/presidential-innovation-fellows</a>
       <br/>
-      <a href="./developer/">Developer resources</a>
+      <a href="/developer/">Developer resources</a>
     </div>
     <div>
       <h1>Policies</h1>


### PR DESCRIPTION
Hi guys and gals.

Just noticed a little mistake in the footer when I was browsing around today - your developer resources link was relative to the present path, where it should have been relative to the site as a whole.

You might want to consider adding spacing the size of an icon to it as well, to bring it in alignment with the other links in that column.  It looks a little off, to me at least, to have it not in line with the rest of the things there, but I wasn't quite sure of a good fix for it myself.  Food for thought!
