### PR TITLE
Fixes open graph description

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,7 +32,6 @@
   <title>{{ site.title }}</title>
   <meta property="og:title" content="{{ site.title | xml_escape }}" />
 {% endif %}
-  <pre>{{ page }}</pre>
 {% if page.description %}
   <meta name="description" content="{{ page.description | xml_escape }}">
   <meta property="og:description" content="{{ page.description | xml_escape }}" />


### PR DESCRIPTION
Currently almost every blog post gets "18F builds effective, user-centric digital services focused on the interaction between government and the people and businesses it serves" for the open graph description when
shared. (See: http://www.google.com/webmasters/tools/richsnippets?q=https%3A%2F%2F18f.gsa.gov%2F2014%2F10%2F21%2Fhow-to-run-your-own-3-sprint-agile-workshop%2F, for example). This happens when pages or posts are missing a description value in the front-matter.

To address this I've added a second conditional that checks for a post or page excerpt if the description is missing. This should make open graph data more descriptive when shared. 
