### PR TITLE
move /code redirect to production site

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -68,6 +68,7 @@ server {
       proxy_send_timeout    30;
       proxy_read_timeout    30;
   }
+
   location /dashboard/deploy {
     proxy_pass http://localhost:4001/;
     proxy_http_version 1.1;
@@ -84,6 +85,11 @@ server {
       proxy_read_timeout    30;
   }
 
+  # Redirect /code/<project> to the corresponding GitHub page
+  location /code {
+    rewrite ^/code/(.*)$ https://github.com/18F/$1 redirect;
+    return 403;
+  }
 
   access_log  /home/site/production/nginx_access.log main;
   error_log  /home/site/production/nginx_error.log;
@@ -157,12 +163,6 @@ server {
     proxy_connect_timeout 10;
     proxy_send_timeout    30;
     proxy_read_timeout    30;
-  }
-
-  # Redirect /code/<project> to the corresponding GitHub page
-  location /code {
-    rewrite ^/code/(.*)$ https://github.com/18F/$1 redirect;
-    return 403;
   }
 
 


### PR DESCRIPTION
This was on the staging site, but should be on the production site only.

cc @seanherron 
