### PR TITLE
For tiny media size, expand header to 12 columns.

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -742,6 +742,9 @@ $tiniest: new-breakpoint(max-width 390px);
 			@include span-columns(12);
 		}
 	}
+	@include media($tiny) {
+		@include span-columns(12);
+	}
 	margin-top: -6px;
 }
 .bare-content {

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -5,14 +5,14 @@
 // Import all scss, ending with custom styles
 // *******************************************
 
-// bourbon.io 
+// bourbon.io
 @import 'bourbon/bourbon';
 
 // bitters.bourbon.io
 @import 'base/base';
 
 // neat.bourbon.io
-@import 'neat/neat'; 
+@import 'neat/neat';
 
 // custom styles
-@import "custom";
+@import 'custom';


### PR DESCRIPTION
Reported to @konklone, but he told me there was a repo for it so here I am.

Before and after:

![screen shot 2014-11-15 at 9 44 18 pm](https://cloud.githubusercontent.com/assets/237985/5060615/f583522c-6d14-11e4-8982-a905b50df80d.png)
