### PR TITLE
Add scripts for performing common tasks to make it easier to contribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: ruby
 rvm:
   - 2.1.2
 
-install:
-  - gem install jekyll
-  - gem install jekyll-sitemap
-
-script: "LANG=\"en_US.UTF-8\" LC_ALL=\"en_US.UTF-8\" jekyll build"
+install: script/bootstrap
+script: script/cibuild
 
 notifications:
   email:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,8 @@
-**CONTRIBUTORS TAKE NOTE:** We work off the `staging` branch, so be sure to base your work on `staging` -- we don't event have a `master` branch.
+**CONTRIBUTORS TAKE NOTE:** We work off the `staging` branch, so be sure to base your work on `staging` -- we don't even have a `master` branch.
+
+## Where Contributions Go
+
+Submit contributions to https://github.com/18F/18f.gsa.gov as a pull request to the `staging` branch.
 
 ## Public domain
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a guide to how 18F manages blogging, and technical guidelines for getting yo
 This is a [Jekyll](http://jekyllrb.com) website. Install Jekyll through Rubygems (you may need `sudo`), Bourbon, and Jekyll Sitemap:
 
 ```bash
-gem install jekyll bourbon jekyll-sitemap
+script/bootstrap
 ```
 
 You will also need **Python 2.7** installed and active, because syntax highlighting depends on [Pygments](http://pygments.org/). A `.python-version` file is included in this repository for those using [`pyenv`](https://github.com/yyuu/pyenv).
@@ -43,10 +43,12 @@ So yes: this project requires Ruby, Python, and Node (for now). Aren't static si
 Launch with Jekyll:
 
 ```bash
-jekyll serve
+script/server
 ```
 
 The site will be visible at `http://localhost:4000`.
+
+Before submitting a pull request, please ensure `script/cibuild` runs and exits cleanly.
 
 ### Deploying the site
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-
+highlighter: pygments
 markdown: redcarpet
 redcarpet:
   extensions:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+command -v python > /dev/null || (echo "Please install Python." && exit 1)
+command -v node > /dev/null || (echo "Please install NodeJS." && exit 1)
+command -v ruby > /dev/null || (echo "Please install Ruby." && exit 1)
+
+echo "Installing gem dependencies..."
 gem install jekyll bourbon jekyll-sitemap
+command -v rbenv > /dev/null && rbenv rehash
+true

--- a/script/build
+++ b/script/build
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-jekyll build

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-jekyll build
-test -z "$(which htmlproof)" && gem install html-proofer
-html-proof _site
+LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" jekyll build


### PR DESCRIPTION
It's easy to contribute when everything is right there, sitting in front of you, with semantic names. Want to boot up the server? Run `script/server`. Want to install the dependencies of the project? No problem. Just run `script/bootstrap`.

These kinds of scripts make it easier to contribute to a site, both for external contributors (like me!) and for internal contributors, like you.
