### PR TITLE
Team resizing

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -551,7 +551,7 @@ $tiniest: new-breakpoint(max-width 390px);
 		color: $red;
 		font-size: 1.2em;
 		@include media($smallest) {
-			font-size: 0.75em;
+			font-size: 0.70em;
 		}
 		@include media($tiny) {
 			font-size: 0.70em;


### PR DESCRIPTION
Issuing a new pull request for the resizing work off of the staging branch. Thanks for letting me know! Here is the text from the original pull request. 

So I am addressing the resizing Issue #295: When the screen width is > 605px and < 778px the photos would link break where a team member's name spans two lines.

@meiqimichelle could you take a look and let me know what you think? Any feedback would be great.

I have not touched the different break points that Michelle set up. I wanted to stay away from that to keep it clean. So I first started with increasing the margin between members when the page is resized but quickly noticed that what was affecting the break was the text size. I then made the font smaller to give room for longer names.

Here is the `_custom.sass`

![screen shot 2014-11-21 at 11 32 57 am](https://cloud.githubusercontent.com/assets/7362915/5146697/38d4d066-717d-11e4-9e8f-135dc86b43c2.png)

Here is the output: 

![screen shot 2014-11-21 at 11 36 22 am](https://cloud.githubusercontent.com/assets/7362915/5146701/4a3f9dcc-717d-11e4-95a0-ef070c3a86e9.png)
