### PR TITLE
Adds functionality for sending tweets on publish

### DIFF
--- a/_plugins/generate_tweet.rb
+++ b/_plugins/generate_tweet.rb
@@ -1,4 +1,5 @@
-if ENV['PRODUCTION']
+require 'pry'
+if ENV['JEKYLL_ENV'] == 'production'
   require 'twitter'
 end
 module Jekyll
@@ -7,11 +8,11 @@ module Jekyll
     safe true
     def initialize(site)
       @site           = site
-      @tw_api_key     = ENV['TW_API_KEY']     || false    # 'Missing Consumer Key (API Key)'
-      @tw_api_secret  = ENV['TW_API_SECRET']    || false  # 'Missing Consumer Secret (API SECRET)'
-      @tw_token       = ENV['TW_TOKEN']  || false         # 'Missing Access Token'
-      @tw_secret      = ENV['TW_SECRET']  || false        # 'Missing Access Token Secret'
-      @production     = ENV['PRODUCTION'] || false
+      @tw_api_key     = ENV['TW_API_KEY'] || false    # 'Missing Consumer Key (API Key)'
+      @tw_api_secret  = ENV['TW_API_SECRET'] || false  # 'Missing Consumer Secret (API SECRET)'
+      @tw_token       = ENV['TW_TOKEN'] || false         # 'Missing Access Token'
+      @tw_secret      = ENV['TW_SECRET'] || false        # 'Missing Access Token Secret'
+      @jekyll_env     = ENV['JEKYLL_ENV'] || false
     end
 
     def prepare_api()
@@ -39,9 +40,9 @@ module Jekyll
     def prepare_update(site, client)
       for post in site.posts
         if post_new?(site.dest, post.id)
-          title = post.title || ""
-          desc = post.data['description'] || ""
-          url = site.config['url'] + post.url || ""
+          tweet = post.tweet
+          binding.pry
+          url = site.config['url'] + post.url
         else
           tweet = false
         end
@@ -60,12 +61,12 @@ module Jekyll
     end
 
     def generate(site)
-      if  @production == true
+      if  @jekyll_env == 'production'
         client = prepare_api()
         tweet_content = prepare_update(site, client)
         send_tweet(tweet_content, client)
       else
-        puts "      Your tweet about could not be sent because this is not a production environment."
+        puts "      Your tweet about could not be sent because this is not a #{@jekyll_env} environment."
       end
     end
   end

--- a/_plugins/generate_tweet.rb
+++ b/_plugins/generate_tweet.rb
@@ -1,0 +1,75 @@
+if ENV['PRODUCTION']
+  require 'twitter'
+end
+module Jekyll
+
+  class AutoTweet < Generator
+    safe true
+    def initialize(site)
+      @site           = site
+      @tw_api_key     = ENV['TW_API_KEY']     || false    # 'Missing Consumer Key (API Key)'
+      @tw_api_secret  = ENV['TW_API_SECRET']    || false  # 'Missing Consumer Secret (API SECRET)'
+      @tw_token       = ENV['TW_TOKEN']  || false         # 'Missing Access Token'
+      @tw_secret      = ENV['TW_SECRET']  || false        # 'Missing Access Token Secret'
+      @production     = ENV['PRODUCTION'] || false
+    end
+
+    def prepare_api()
+      client = Twitter::REST::Client.new do |config|
+        config.consumer_key        = @tw_api_key
+        config.consumer_secret     = @tw_api_secret
+        config.access_token        = @tw_token
+        config.access_token_secret = @tw_secret
+      end
+      return client
+    end
+
+    def send_tweet(tweet_content, client)
+      client.update(tweet_content)
+    end
+
+    def post_new?(dest, id)
+      if File.exists?(File.join(dest, id, 'index.html'))
+        return false
+      else
+        return true
+      end
+    end
+
+    def prepare_update(site, client)
+      for post in site.posts
+        if post_new?(site.dest, post.id)
+          title = post.title || ""
+          desc = post.data['description'] || ""
+          url = site.config['url'] + post.url || ""
+        else
+          tweet = false
+        end
+      end
+      if title && desc
+        url_size = client.configuration.short_url_length_https
+        max_length = 140-url_size
+        begin_tweet = "New post from @#{client.current_user.username}: #{title}"
+        if begin_tweet.length < max_length
+          remain = max_length - begin_tweet.length
+          end_tweet = desc[0, remain-3]
+          tweet = "#{begin_tweet}, #{end_tweet} #{url}"
+        end
+      end
+      return tweet
+    end
+
+    def generate(site)
+      client = prepare_api()
+      tweet_content = prepare_update(site, client)
+      if ! tweet_content
+        return
+      elsif @production == true
+        send_tweet(tweet_content, client)
+      else
+        puts "      Your tweet about could not be sent because this is not a production environment."
+      end
+    end
+  end
+
+end

--- a/_plugins/generate_tweet.rb
+++ b/_plugins/generate_tweet.rb
@@ -60,11 +60,9 @@ module Jekyll
     end
 
     def generate(site)
-      client = prepare_api()
-      tweet_content = prepare_update(site, client)
-      if ! tweet_content
-        return
-      elsif @production == true
+      if  @production == true
+        client = prepare_api()
+        tweet_content = prepare_update(site, client)
         send_tweet(tweet_content, client)
       else
         puts "      Your tweet about could not be sent because this is not a production environment."


### PR DESCRIPTION
Another one I'm very open to feedback on. This plugin requires the "twitter" gem be installed on production environments only—which is nice. It does assume we want these tweets to be structured the same way. I'm thinking that's too rigid and that we'd want to create a front-matter entry for "twitter" and use that instead. These are easy to do if that's what we want.

- By default, will use the 'description' field from a post's front-matter  along with the title and url to send a tweet
- Requires setting environment variables `TW_API_KEY`, `TW_API_SECRET`, `TW_TOKEN`, and `TW_SECRET` for twitter authentication.
- Requires environment variable to be set designating the production environment (export PRODUCTION=true should be set on the production server)

One flaw of this plugin is that it only supports publishing one blog post at a time. I don't really know if that's a bug or a feature. It's a little hard for me to imagine _us_ publishing more than one post at a time and wanting each of them to tweet immediately. But that doesn't mean it shouldn't be possible.

That said, it would be a difficult feature to build out if it becomes a need.

I'm also _pretty sure_ it will cannot happen, but builds will fail if the production environment attempts to send a duplicate tweet. This is because the Twitter gem throws an exception if it gets a 403 back from the API. I think it's impossible for the plugin to actually attempt it because if the post already exists in the built site, the post should get skipped.