### PR TITLE
Add links to subscribe to our blog by email and feed

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -318,6 +318,13 @@ $tiniest: new-breakpoint(max-width 390px);
 
 // News and blog pages
 //********************************************************
+.bare {
+	p.subscribe {
+		margin-top: 20px;
+		margin-bottom: 0px;
+	}
+}
+
 .blog-entry {
 	@extend %section-padding; //standard padding for all sections
 	padding-top: 25px; //compensates for padding in top row of news section
@@ -554,13 +561,13 @@ $tiniest: new-breakpoint(max-width 390px);
 		padding-left: 20px;
 		&:first-of-type{
 			padding-top: 20px;
-		} 
+		}
 		&:last-of-type {
 			padding-top: 20px;
 		}
 		a {
 			text-decoration: underline;
-			&:hover, 
+			&:hover,
 			&:focus {
 				text-decoration: none;
 			}

--- a/news/index.html
+++ b/news/index.html
@@ -3,6 +3,11 @@ layout: bare
 ---
 <section>
   <h1># news</h1>
+
+  <p class="subscribe">
+    Subscribe to updates <a href="https://ifttt.com/recipes/214709-a-new-18f-blog-post-email-me-a-link-to-go-read-it-right-away">by email</a>, or through <a href="/feed/">our RSS feed</a>.
+  </p>
+
   <div class="container blog-entry {{tag}}" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
 
     {% for post in paginator.posts %}


### PR DESCRIPTION
Adds a subscribe link to email, and to our feed, at the top of the page. It looks like this:

![news subscribe](https://cloud.githubusercontent.com/assets/4592/5210379/85df9fec-7599-11e4-9421-169ef4ce918b.png)

Fixes #371. Thanks to @gbinal for pointing this out.
