### PR TITLE
Add some space on the left of the bare logo sidebar

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -554,13 +554,13 @@ $tiniest: new-breakpoint(max-width 390px);
 		padding-left: 20px;
 		&:first-of-type{
 			padding-top: 20px;
-		} 
+		}
 		&:last-of-type {
 			padding-top: 20px;
 		}
 		a {
 			text-decoration: underline;
-			&:hover, 
+			&:hover,
 			&:focus {
 				text-decoration: none;
 			}
@@ -830,6 +830,9 @@ $tiniest: new-breakpoint(max-width 390px);
 }
 .bare-logo {
 	@include span-columns(2);
+
+	padding-left: 20px;
+
 	a {
 		text-decoration: none;
 		i {


### PR DESCRIPTION
Under non-wide circumstances, the blog's sidebar would get squished right up to the side.

Before:

![before](https://cloud.githubusercontent.com/assets/4592/5210846/56aab4ce-75a2-11e4-9572-69df6d10be09.png)

After:

![after](https://cloud.githubusercontent.com/assets/4592/5210848/58fe55be-75a2-11e4-9f29-4fa7a76906b2.png)

Fixes #311.
