### PR TITLE
Delink headers above prev/next

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,12 +37,14 @@
         <section class="blog-pagination">
           <div>
             {% if page.previous %}
-                <a href="{{ page.previous.url }}"><h1>Previous Post</h1> {{ page.previous.title }}</a>
+                <h1>Previous Post</h1>
+                <a href="{{ page.previous.url }}">{{ page.previous.title }}</a>
             {% endif %}
           </div>
           <div>
             {% if page.next %}
-                <a href="{{ page.next.url }}"><h1>Next Post</h1> {{ page.next.title }}</a>
+                <h1>Next Post</h1>
+                <a href="{{ page.next.url }}">{{ page.next.title }}</a>
             {% endif %}
           </div>
         </section>


### PR DESCRIPTION
The links to previous and next blog posts looked jarring to me as a 2-line collective link.

Before:

![before](https://cloud.githubusercontent.com/assets/4592/5210903/a0f13da4-75a3-11e4-92df-a5d85f38549a.png)

After:

![after](https://cloud.githubusercontent.com/assets/4592/5210904/a2b6091c-75a3-11e4-816e-083220d5b841.png)

Fixes #315.
