### PR TITLE
add a link to edit this page in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,9 +11,11 @@
     </div>
     <div>
       <h1>Fork Our Code</h1>
-      <a href="https://github.com/18f"><i class="icon-github2"></i> github.com/18F</a>
+      <a href="https://github.com/18F"><i class="icon-github2"></i> github.com/18F</a>
       <br/>
       <a href="https://github.com/presidential-innovation-fellows"><i class="icon-github2"></i> github.com/presidential-innovation-fellows</a>
+      <br/>
+      <a href="https://github.com/18F/18f.gsa.gov/edit/staging/{{ page.path }}">Edit this page</a>
       <br/>
       <a href="/developer/">Developer resources</a>
     </div>


### PR DESCRIPTION
Adds a link in the footer to `Edit this page`, which links to the edit page in GitHub for whatever page the user is on.

![fork our code](https://cloud.githubusercontent.com/assets/4592/5210954/c8c94ee2-75a4-11e4-9164-98f75c7c784d.png)

I think we could come up with a more prominent and integrated place for this sort of thing, and I hope we do that in the coming redesign.

Fixes #302.
