### PR TITLE
move javascript from header to footer

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -85,17 +85,11 @@ http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-A
 <link href="/assets/css/styles.css" rel="stylesheet">
 <link href="/assets/css/pygments-theme.css" rel="stylesheet">
 
-<!-- JS
-================================================== -->
-<script src="/assets/js/jquery-2.1.1.min.js"></script>
-<script src="/assets/js/responsiveslides.min.js"></script>
 
 <!-- IE
 ================================================== -->
 <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!--[if lt IE 9]>
-  <script src="/assets/js/ie8/html5shiv.js"></script>
-  <script src="/assets/js/ie8/respond.js"></script>
   <link href="/assets/css/ie8/ie.css" rel="stylesheet">
 <![endif]-->
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,7 +1,20 @@
+<!-- JS
+================================================== -->
+<script src="/assets/js/jquery-2.1.1.min.js"></script>
+<script src="/assets/js/responsiveslides.min.js"></script>
+
+
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!--[if IE 9 ]>
+  <script src="/assets/js/ie8/html5shiv.js"></script>
+  <script src="/assets/js/ie8/respond.js"></script>
+-->
+
 <!--
   IE detection, used to guide console formatting in subsequent include
 -->
 <script type="text/javascript">window._ie9 = false;</script>
+
 <!--[if IE 9 ]>
   <script type="text/javascript">window._ie9 = true;</script>
 <![endif]-->


### PR DESCRIPTION
Moves any `.js` includes from the header to the footer, at [Google's suggestion](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2F18f.gsa.gov&tab=desktop).

Fixes #282.
