### PR TITLE
Fix image URL for webhooks post

### DIFF
--- a/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
+++ b/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Taking control of our website with Jekyll and webhooks
-image:
+image: /assets/blog/new-jekyll-site/header.png
 description: How we moved our website to Jekyll, left Tumblr behind, and set up automatic deployment with webhooks.
 authors:
  - eric


### PR DESCRIPTION
I thought I included this in my last PR, turns out I forgot to commit it. It's not instrumental to fixing the feature, I just noticed along the way that our webhooks post had failed to specify an `image` field. This fixes that, so it uses the header image as the share image.
