### PR TITLE
Use httpvshttps.com for the speed link, slightly tweak paragraph

### DIFF
--- a/_posts/2014-11-13-why-we-use-https-in-every-gov-website-we-make.md
+++ b/_posts/2014-11-13-why-we-use-https-in-every-gov-website-we-make.md
@@ -44,7 +44,9 @@ As we build web APIs that we want the public to rely on, secure connections are 
 
 The most common concern people raise about HTTPS is performance. Encryption requires computation, and can make some kinds of caching more difficult. Fortunately, in the last several years, there has been tremendous investment in HTTPS by the private sector.
 
-Google has been engineering and publishing major speed improvements to OpenSSL's [encryption](https://www.imperialviolet.org/2010/06/25/overclocking-ssl.html) and [privacy](https://www.imperialviolet.org/2011/11/22/forwardsecret.html) for years, and their work on SPDY allows websites to achieve [serious performance improvements](https://thethemefoundry.com/blog/why-we-dont-use-a-cdn-spdy-ssl/). As major technology firms like [Facebook](http://lists.w3.org/Archives/Public/ietf-http-wg/2012JulSep/0251.html) and [Twitter](https://blog.twitter.com/2013/forward-secrecy-at-twitter) invest in universal encryption, their engineering and best practices have improved the ecosystem for everyone.
+Google has been engineering and publishing major speed improvements to OpenSSL's [encryption](https://www.imperialviolet.org/2010/06/25/overclocking-ssl.html) and [privacy](https://www.imperialviolet.org/2011/11/22/forwardsecret.html) for years, and their work on SPDY allows websites to achieve [serious speed improvements](https://www.httpvshttps.com/) over plain HTTP. 
+
+As major technology firms like [Facebook](http://lists.w3.org/Archives/Public/ietf-http-wg/2012JulSep/0251.html) and [Twitter](https://blog.twitter.com/2013/forward-secrecy-at-twitter) invest in universal encryption, their engineering and best practices have improved the ecosystem for everyone.
 
 In 2014, the biggest performance priority for HTTPS is to just [get it deployed more widely](https://istlsfastyet.com) so that these optimizations can continue.
 


### PR DESCRIPTION
The main change here is to swap out one URL for one to https://www.httpvshttps.com, which I think does a more visceral job of demonstrating the benefits of SPDY.
