### PR TITLE
Adds a script for quickly creating a new post

### DIFF
--- a/script/post
+++ b/script/post
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require 'fileutils'
 require 'jekyll'
-require 'pry'
 require 'optparse'
 require 'yaml'
 
@@ -9,13 +8,14 @@ options = {}
 OptionParser.new do |opts|
 	opts.banner = "Usage: script/post [options]"
 
-	opts.on('-t', '--title TITLE', 'Post title') { |v| options[:title] = v }
+	opts.on('-t', '--title TITLE', 'Post title (Required)') { |v| options[:title] = v }
 	opts.on('-d', '--date DATE', 'Date published (default, today)') { |v| options[:date] = v }
 	opts.on('-i', '--image IMAGE', 'Post image') { |v| options[:image] = v }
 	opts.on('-a', '--author AUTHOR', 'Post author (comma separated)') { |v| options[:author] = v }
 	opts.on('-g', '--tags TAGS', 'Tags for this post (comma separated)') { |v| options[:tags] = v }
-	opts.on('-c', '--content CONTENT', 'The text of the blog post (not the most efficient way to write)') { |v| options[:content] = v}
+	opts.on('-c', '--content CONTENT', 'The text of the blog post (not the most efficient)') { |v| options[:content] = v}
 end.parse!
+raise OptionParser::MissingArgument if options[:title].nil?
 
 unless options[:date]
 	date = Date.today.to_s
@@ -25,8 +25,8 @@ end
 
 title = options[:title]
 slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
-authors = options[:author].strip.split(', ')
-tags = options[:tags].strip.split(', ')
+authors = options[:author].strip.split(', ') unless options[:author].nil?
+tags = options[:tags].strip.split(', ') unless options[:tags].nil?
 
 filename = "#{date}-#{slug}.md"
 path = File.join(Jekyll.configuration['source'], "_posts", filename)
@@ -37,8 +37,8 @@ frontmatter[:layout] = 'post'
 frontmatter[:image] = options[:image]
 frontmatter[:tags] = tags
 frontmatter[:authors] = authors
-frontmatter[:description] = ''
-frontmatter[:excerpt] = ''
+frontmatter[:description] = nil
+frontmatter[:excerpt] = nil
 
 content = options[:content]
 
@@ -49,4 +49,3 @@ contents = YAML.load(content.to_json)
 content_yml = YAML.dump(contents)
 
 File.open(path, 'w') { |file| file.write(yaml + content_yml) }
-#FileUtils.write('w', path+filename)

--- a/script/post
+++ b/script/post
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'jekyll'
+require 'pry'
+require 'optparse'
+require 'yaml'
+
+options = {}
+OptionParser.new do |opts|
+	opts.banner = "Usage: script/post [options]"
+
+	opts.on('-t', '--title TITLE', 'Post title') { |v| options[:title] = v }
+	opts.on('-d', '--date DATE', 'Date published (default, today)') { |v| options[:date] = v }
+	opts.on('-i', '--image IMAGE', 'Post image') { |v| options[:image] = v }
+	opts.on('-a', '--author AUTHOR', 'Post author (comma separated)') { |v| options[:author] = v }
+	opts.on('-g', '--tags TAGS', 'Tags for this post (comma separated)') { |v| options[:tags] = v }
+	opts.on('-c', '--content CONTENT', 'The text of the blog post (not the most efficient way to write)') { |v| options[:content] = v}
+end.parse!
+
+unless options[:date]
+	date = Date.today.to_s
+else
+	date = Date.parse(options[:date]).strftime("%Y-%m-%d")
+end
+
+title = options[:title]
+slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+authors = options[:author].strip.split(', ')
+tags = options[:tags].strip.split(', ')
+
+filename = "#{date}-#{slug}.md"
+path = File.join(Jekyll.configuration['source'], "_posts", filename)
+frontmatter = {}
+frontmatter[:title] = title
+frontmatter[:date] = date
+frontmatter[:layout] = 'post'
+frontmatter[:image] = options[:image]
+frontmatter[:tags] = tags
+frontmatter[:authors] = authors
+frontmatter[:description] = ''
+frontmatter[:excerpt] = ''
+
+content = options[:content]
+
+load = YAML.load(frontmatter.to_json)
+yaml = YAML.dump(load)
+
+contents = YAML.load(content.to_json)
+content_yml = YAML.dump(contents)
+
+File.open(path, 'w') { |file| file.write(yaml + content_yml) }
+#FileUtils.write('w', path+filename)


### PR DESCRIPTION
A new script for creating posts quickly and uniformly.
```
Usage: script/post [options]
    -t, --title TITLE                Post title
    -d, --date DATE                  Date published (default, today)
    -i, --image IMAGE                Post image
    -a, --author AUTHOR              Post author (comma separated)
    -g, --tags TAGS                  Tags for this post (comma separated)
    -c, --content CONTENT            The text of the blog post (not the most efficient)
```
Will create a new markdown file in the user's `_posts` directory with all the correct front matter fields ready to go. A command like `script/post -t "New post" -d "January 6, 2015"` will create a markdown file:
```
---
title: New Post
date: '2015-01-06'
layout: post
image: 
tags: 
authors: 
description: 
excerpt: 
--- 
...
```
`script/post -t "Chicago" -d "2015-01-06" -a "raphy, boone" -g "chicago, 18F, how we work"` will create:
```
---
title: Chicago
date: '2015-01-09'
layout: post
image: 
tags:
- how we work
- 18F
- Chicago
authors:
- boone
- raphy
description: ''
excerpt: ''
--- 
...
```