### PR TITLE
Integrate Kate's notes on db-subsetter, also add a colon

### DIFF
--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -30,12 +30,12 @@ poses a dilemma: the full production dataset is too unwieldy to
 duplicate to the test and development environments.  Projects
 are typically tested against small hand-written test databases
 instead, but those simple constructs can't
-duplicate the quirks and complexities of the production data set&#8212;and
+duplicate the quirks and complexities of the production data set &#8212; and
 the most subtle application bugs will only be revealed when
 applied to those quirks.
 
 Using a small subset of real production data is the ideal, but for
-relational databases that's hard to accomplish&#8212;the mesh
+relational databases that's hard to accomplish &#8212; the mesh
 of foreign key relationships between tables make extracting a limited
 yet valid subset of its tuples can feel like trying to cut a little sweater
 out of a big sweater without snipping any yarns.
@@ -56,7 +56,7 @@ rdbms-subsetter postgresql://:@/proddb postgresql://:@/testdb 0.001
 
 It should work against
 [any database that SQLAlchemy supports](http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#supported-databases).
-It guarantees referential integrity "upward"&#8212;every child
+It guarantees referential integrity "upward" &#8212; every child
 record will have its required parent record.
 It also fills records "downward,"
 providing child records for each parent record...but within
@@ -85,13 +85,13 @@ Available options include:
 Like any open source project, we welcome your
 [bug reports, feature requests](https://github.com/18F/rdbms-subsetter/issues),
 and code contributions.
-Since we're 18F, filing any bugs you find&#8212;and optionally writing tests for them, or even fixing them&#8212;is not just encouraged, it's downright patriotic.
+Since we're 18F, filing any bugs you find &#8212; and optionally writing tests for them, or even fixing them &#8212; is not just encouraged, it's downright patriotic.
 _(cue inspiring music)_
 
 For open-source enthusiasts, the potential to release work
 as open-source projects is exciting and motivating.  At 18F,
 our [Default to Open](https://github.com/18F/open-source-policy/)
 policy means that releasing our work isn't a favor to beg
-management for.  It's our everyday way of working&#8212;no questions asked and no hoops to jump through&#8212;and one
+management for.  It's our everyday way of working &#8212; no questions asked and no hoops to jump through &#8212; and one
 of the joys of being on the 18F team.
 

--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -36,8 +36,8 @@ applied to those quirks.
 
 Using a small subset of real production data is the ideal, but for
 relational databases that's hard to accomplish &#8212; the mesh
-of foreign key relationships between tables make extracting a limited
-yet valid subset of its tuples can feel like trying to cut a little sweater
+of foreign key relationships between tables can make extracting a limited
+yet valid subset of its tuples feel like trying to cut a little sweater
 out of a big sweater without snipping any yarns.
 
 ![Don't break any yarns.](/assets/blog/db-testing-tool/cut_sweater.jpg)

--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -15,6 +15,8 @@ tags:
 - open source
 - developer
 - culture
+
+published: false
 ---
 <p class="authors">
   by {% author catherine %}

--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -59,7 +59,7 @@ It should work against
 It guarantees referential integrity "upward" &#8212; every child
 record will have its required parent record.
 It also fills records "downward,"
-providing child records for each parent record...but within
+providing child records for each parent record &#8230; but within
 limits (optionally tuned with `--children`) to avoid
 requiring the entire production database.
 

--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -30,12 +30,12 @@ poses a dilemma: the full production dataset is too unwieldy to
 duplicate to the test and development environments.  Projects
 are typically tested against small hand-written test databases
 instead, but those simple constructs can't
-duplicate the quirks and complexities of the production data set – and
+duplicate the quirks and complexities of the production data set&#8212;and
 the most subtle application bugs will only be revealed when
 applied to those quirks.
 
 Using a small subset of real production data is the ideal, but for
-relational databases that's hard to accomplish – the mesh
+relational databases that's hard to accomplish&#8212;the mesh
 of foreign key relationships between tables make extracting a limited
 yet valid subset of its tuples can feel like trying to cut a little sweater
 out of a big sweater without snipping any yarns.
@@ -56,10 +56,10 @@ rdbms-subsetter postgresql://:@/proddb postgresql://:@/testdb 0.001
 
 It should work against
 [any database that SQLAlchemy supports](http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#supported-databases).
-It guarantees referential integrity "upward" -- every child
+It guarantees referential integrity "upward"&#8212;every child
 record will have its required parent record.
 It also fills records "downward,"
-providing child records for each parent record... but within
+providing child records for each parent record...but within
 limits (optionally tuned with `--children`) to avoid
 requiring the entire production database.
 
@@ -85,16 +85,13 @@ Available options include:
 Like any open source project, we welcome your
 [bug reports, feature requests](https://github.com/18F/rdbms-subsetter/issues),
 and code contributions.
-Since we're 18F, filing any bugs you find --
-and optionally writing tests for them, or even fixing them --
-is not just encouraged, it's downright patriotic.
+Since we're 18F, filing any bugs you find&#8212;and optionally writing tests for them, or even fixing them&#8212;is not just encouraged, it's downright patriotic.
 _(cue inspiring music)_
 
 For open-source enthusiasts, the potential to release work
 as open-source projects is exciting and motivating.  At 18F,
 our [Default to Open](https://github.com/18F/open-source-policy/)
 policy means that releasing our work isn't a favor to beg
-management for.  It's our everyday way of working --
-no questions asked and no hoops to jump through -- and one
+management for.  It's our everyday way of working&#8212;no questions asked and no hoops to jump through&#8212;and one
 of the joys of being on the 18F team.
 

--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -30,12 +30,12 @@ poses a dilemma: the full production dataset is too unwieldy to
 duplicate to the test and development environments.  Projects
 are typically tested against small hand-written test databases
 instead, but those simple constructs can't
-duplicate the quirks and complexities of the production data set -- and
+duplicate the quirks and complexities of the production data set – and
 the most subtle application bugs will only be revealed when
 applied to those quirks.
 
 Using a small subset of real production data is the ideal, but for
-relational databases that's hard to accomplish - the mesh
+relational databases that's hard to accomplish – the mesh
 of foreign key relationships between tables make extracting a limited
 yet valid subset of its tuples can feel like trying to cut a little sweater
 out of a big sweater without snipping any yarns.
@@ -58,12 +58,12 @@ It should work against
 [any database that SQLAlchemy supports](http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#supported-databases).
 It guarantees referential integrity "upward" -- every child
 record will have its required parent record.
-It also fills records "downward",
+It also fills records "downward,"
 providing child records for each parent record... but within
 limits (optionally tuned with `--children`) to avoid
 requiring the entire production database.
 
-Available options include
+Available options include:
 
 <dl>
   <dt>--logarithmic</dt>


### PR DESCRIPTION
I integrated @kategarklavs' edits in https://github.com/18F/18f.gsa.gov/pull/451#issuecomment-69217164, and added a colon before the list of commands. 