### PR TITLE
Add public Hub deployment webhook endpoint

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -93,6 +93,21 @@ server {
       proxy_send_timeout    30;
       proxy_read_timeout    30;
   }
+  location /hub/deploy {
+    proxy_pass http://localhost:4002/;
+    proxy_http_version 1.1;
+    proxy_redirect off;
+
+      proxy_set_header Host   $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_max_temp_file_size 0;
+
+      proxy_connect_timeout 10;
+      proxy_send_timeout    30;
+      proxy_read_timeout    30;
+  }
 
   # Redirect /code/<project> to the corresponding GitHub page
   location /code {


### PR DESCRIPTION
I haven't pushed this config update, but everything's ready on the Hub side (well, technically once 18F/hub#57 goes in, but the `hookshot` task is running on 18f.gsa.gov).

cc: @afeld @gboone @konklone 