### PR TITLE
Adds CORS to the production and staging sites

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -34,16 +34,19 @@ server {
   location / {
       root   /home/site/production/current/_site;
       default_type text/html;
+      include cors.rules;
   }
 
   location /dashboard {
       root /home/site/production/dashboard/_site;
       default_type text/html;
+      include cors.rules;
   }
 
   location /hub {
       root /home/site/production/hub/_site_public;
       default_type text/html;
+      include cors.rules;
   }
 
   # proxy to hydra, cover up for their lack of HTTPS
@@ -125,9 +128,13 @@ server {
   location / {
       root   /home/site/staging/current/_site;
       default_type text/html;
+
+      include cors.rules;
   }
   location /dashboard {
     root /home/site/staging/dashboard/_site;
+
+    include cors.rules;
   }
 
   # production hook runs on port 3000

--- a/deploy/cors.rules
+++ b/deploy/cors.rules
@@ -1,0 +1,3 @@
+add_header Access-Control-Allow-Headers "X-Requested-With";
+add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS";
+add_header Access-Control-Allow-Origin "*";


### PR DESCRIPTION
For the public paths that have content for people to read (aka not the webhooks).

I'd like to test this out on the staging server manually before merging. I'll indicate when that's done.

Fixed #507.