### PR TITLE
Fix the Hub API's content-type for JSON

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -43,6 +43,7 @@ server {
 
   location /hub {
       root /home/site/production/hub/_site_public;
+      index index.html api.json;
       default_type text/html;
   }
 


### PR DESCRIPTION
This is in reference to both 18F/hub#99 and 18F/hub#145. I also updated `/etc/nginx/nginx.conf` to update `gzip_types` to include `application/json application/javascript`. The changes are already running in production, and confirmed via [Postman](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm?hl=en).

cc: @gboone @konklone 