### PR TITLE
Update Mirage references to Discovery

### DIFF
--- a/pages/rfpez.md
+++ b/pages/rfpez.md
@@ -12,7 +12,7 @@ Your feedback about the RFP-EZ pilot has been invaluable in informing 18F's next
 
 * **FBOpen:** [fbopen.gsa.gov](https://fbopen.gsa.gov) is a simple search interface for finding opportunities to do business with the U.S. Government. The website is built on the [FBOpen API](https://18f.github.io/fbopen/), which is free to use. Learn more from the [launch announcement](http://18fblog.tumblr.com/post/81293178801/announcing-fbopen-government-opportunities-made-easier) and the [FBOpen repository on GitHub](https://github.com/18f/fbopen).
 
-* **Mirage** is a market research tool for contract specialists purchasing on the [GSA OASIS procurement vehicle](http://www.gsa.gov/portal/content/161367). Learn more at the [Mirage repository on GitHub](https://github.com/18f/mirage).
+* **Discovery** is a market research tool for contract specialists purchasing on the [GSA OASIS procurement vehicle](http://www.gsa.gov/portal/content/161367). Learn more at the [Discovery repository on GitHub](https://github.com/18f/discovery).
 
 * **SBIR-EZ** will simplify the experience of participating in the Small Business Innovation Research Program. Learn more at the [Air Force SBIR-EZ repository on GitHub](https://github.com/18F/afsbirez).
 


### PR DESCRIPTION
Just updating the language on our RFP-EZ landing page to refer to OASIS Discovery instead of OASIS Mirage.