### PR TITLE
Import pif_team data from the public Hub API

### DIFF
--- a/_data/import-public.rb
+++ b/_data/import-public.rb
@@ -10,7 +10,7 @@ require 'open-uri'
 DATA_DIR = File.dirname __FILE__
 DATA_BASEURL = 'https://18f.gsa.gov/hub/api/'
 
-['team', 'projects'].each do |category|
+['team', 'projects', 'pif_team'].each do |category|
   open("#{DATA_BASEURL}#{category}/") do |data|
     open(File.join(DATA_DIR, "#{category}.json"), 'w') do |f|
       f.write(data.read)

--- a/pages/pif/fellows/index.html
+++ b/pages/pif/fellows/index.html
@@ -10,5 +10,5 @@ title: Meet the Fellows - Round 3
 		<li><a href= "/pif/fellows/round-1">Round 1</a></li>
 	</ul>
 </nav>
-{% assign people = site.data.team | where: "pif-round", 3 | group_by: "project" %}
+{% assign people = site.data.pif_team | where: "pif-round", 3 | group_by: "project" %}
 {% include_relative list.html %}


### PR DESCRIPTION
@gboone Once 18F/hub#191 is merged into the public Hub, this will import `_data/pif_team.json` and use that to generate the PIF page.