### PR TITLE
Plugin to insert the 'name' field into PIF data

### DIFF
--- a/_plugins/pif_data.rb
+++ b/_plugins/pif_data.rb
@@ -1,0 +1,7 @@
+module Jekyll
+  class PifData < Generator
+    def generate(site)
+      (site.data['pif_team'] || []).each {|name, data| data['name'] = name}
+    end
+  end
+end


### PR DESCRIPTION
@gboone This causes the PIF pictures to reappear, since the `name` corresponds to the key value of `_data/pif_team.json` that gets stripped out by the `group_by` filter in `pages/pif/fellows/*`.