### PR TITLE
Use non-redundant alt text for team photos

### DIFF
--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -28,7 +28,7 @@ module Jekyll
       image = File.join 'assets', 'images', 'team', "#{name}.jpg"
       if File.exist?(File.join(Jekyll.sites[0].config['source'], image))
         "<div class='bio'>\n
-          <a><img class='img-circle team-img bio-clip' src='/#{image}' alt='#{info['full_name']}'>\n
+          <a><img class='img-circle team-img bio-clip' src='/#{image}' alt='18F team member #{info['full_name']}'>\n
           <h1>#{info['full_name']}</h1></a>\n
         </div>"
       end


### PR DESCRIPTION
Resolves all 60 errors generated by [pa11y](http://pa11y.org)/[HTML CodeSniffer](https://squizlabs.github.io/HTML_CodeSniffer/).

Sample error:

![screen shot 2015-03-03 at 2 42 25 pm](https://cloud.githubusercontent.com/assets/86790/6470801/490177a0-c1b4-11e4-93a5-ae981ee4df9e.png)

We still have some warnings to take a look at, but now we have zero errors:

![screen shot 2015-03-03 at 2 48 42 pm](https://cloud.githubusercontent.com/assets/86790/6470839/755fe570-c1b4-11e4-89f4-2ee6b14bbc28.png)