### PR TITLE
Copyright disclaimer on team photos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@
 
 Submit contributions to https://github.com/18F/18f.gsa.gov as a pull request to the `staging` branch.
 
+## Team photos
+
+Individual 18F team photos (as of commit-time, in `assets/images/team/`) are not covered by the below public domain dedication. The contributor of each photo (generally, the individual teammate in question), by contributing it, is affirming that 18F has appropriate permission to include the photo in this repository and display it on the website.
+
 ## Public domain
 
 This project is in the public domain within the United States, and

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,7 @@
+Individual 18F team photos (as of commit-time, in `assets/images/team/`) are not covered by the below public domain dedication. The contributor of each photo (generally, the individual teammate in question), by contributing it, is affirming that 18F has appropriate permission to include the photo in this repository and display it on the website.
+
+------
+
 As a work of the United States Government, this project is in the
 public domain within the United States.
 


### PR DESCRIPTION
@ultrasaurus raised the point that teammates may not wish to dedicate their image to the public domain. I am not certain that dedicating a photo to the public domain causes you to lose control over your likeness, but want to be responsive to the concern.

This PR adds a small section to the `LICENSE` and `CONTRIBUTING` files that exempts teammate photos from the public domain dedication. Since the copyright in photos is generally held by the photographer, not the subject, that basically means that the contributor has to know that the copyright holder (the photographer) is okay with hosting their photo here. I'm very comfortable running under the assumption that this is already the case for all the photos here, and will be going forward, but it's relevant to mention.

cc @mwweinberg