### PR TITLE
Add humans.txt

### DIFF
--- a/pages/humans.txt
+++ b/pages/humans.txt
@@ -1,0 +1,14 @@
+---
+layout: null
+permalink: /humans.txt
+---
+/* TEAM */
+{% for member in site.data.team | sort: "last_name" %}
+Name: {{ member[1].full_name }}
+Handle: {{ member[0] }}
+{% if member[1].working_groups %}Working groups: {{ member[1].working_groups | array_to_sentence_string }}
+{% endif %}{% if member[1].location %}Location: {{ member[1].location }}
+{% endif %}{% if member[1].projects %}Projects: {{ member[1].projects | array_to_sentence_string }}
+{% endif %}{% if member[1].languages %}Langauges: {{ member[1].languages | array_to_sentence_string }}
+{% endif %}{% if member[1]["pif-round"] %}PIF Round: {{ member[1]["pif-round"] }}
+{% endif %}{% endfor %}


### PR DESCRIPTION
This pull request adds a simple `humans.txt` file. You can read more about the how and why of adding a `humans.txt` file over at [humanstxt.org](http://humanstxt.org/). TL;DR:

> It's an initiative for knowing the people behind a website. It's a TXT file that contains information about the different people who have contributed to building the website.

As an added bonus, it looks like this would be [the 2nd .gov with a `humans.txt` file](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#qscrl=1&q=site:.gov+inurl:humans.txt) after broadbandmap.gov (shoutout @feomike).

The humans.txt file is generated from `_data/team.json` (although technically it should be contributors to the site, perhaps via the GitHub API, not merely team members).

It looks like this:

```
/* TEAM */

Name: Jamie Albrecht
Handle: jamie
Working groups: Documentation and Hiring

Name: Sarah Allen
Handle: sarah
Working groups: Agile and Training and Education
Projects: midas
PIF Round: 2

Name: Shawn Allen
Handle: shawn
Working groups: Government user interface guidelines and Testing
Location: SFO
Projects: discovery, hourglass, and doi-extractives-data
Langauges: JavaScript, Python, HTML, CSS, and SQL

Name: jane avriette
Handle: jane
Working groups: Testing
```

and even [parses](https://github.com/benbalter/humans.rb):

```ruby
{:team=>
  [{:name=>"Jamie Albrecht", :handle=>"jamie", :"working groups"=>"Documentation and Hiring"},
   {:name=>"Sarah Allen", :handle=>"sarah", :"working groups"=>"Agile and Training and Education", :projects=>"midas", :"pif round"=>"2"},
   {:name=>"Shawn Allen",
    :handle=>"shawn",
    :"working groups"=>"Government user interface guidelines and Testing",
    :location=>"SFO",
    :projects=>"discovery, hourglass, and doi-extractives-data",
    :langauges=>"JavaScript, Python, HTML, CSS, and SQL"},
   {:name=>"jane avriette", :handle=>"jane", :"working groups"=>"Testing"},
   {:name=>"Leah Bannon", :handle=>"leah"},
   {:name=>"Moncef Belyamani", :handle=>"moncef", :"working groups"=>"Testing", :location=>"DCA"},
   {:name=>"David Best", :handle=>"david", :"working groups"=>"Testing", :location=>"DAY"},
   {:name=>"Tom Black", :handle=>"blacktm", :"working groups"=>"Documentation", :"pif round"=>"2"},
   {:name=>"Mike Bland", :handle=>"mbland", :"working groups"=>"Documentation, Testing, and Working Group", :location=>"DCA", :langauges=>"C++ and Python"},
   {:name=>"Greg Boone", :handle=>"boone", :location=>"DCA", :langauges=>"Python, Ruby, PHP, and JavaScript"},
   {:name=>"Nick Brethauer",
    :handle=>"brethauer",
    :"working groups"=>"Documentation, Training and Education, User Research, and Working Group",
    :projects=>"discovery and hourglass"},
   {:name=>"Nick Bristow", :handle=>"nick", :"working groups"=>"Accessibility and Working Group", :projects=>"doi-extractives-data"},
   {:name=>"Gray Brooks", :handle=>"gray", :"working groups"=>"Analytics and Working Group", :location=>"DCA", :projects=>"developer-program and api-data-gov"},
   {:name=>"Chris Cairns", :handle=>"chrisc", :projects=>"myra", :"pif round"=>"2"},
   {:name=>"Jeremy Canfield", :handle=>"jeremy", :"working groups"=>"User Research"}
 ]
}
```

You can see other examples in action at http://ben.balter.com/humans.txt (auto generated from the GitHub API) and https://github.com/humans.txt.