### PR TITLE
One Year In and Looking Forward

### DIFF
--- a/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
+++ b/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
@@ -1,6 +1,6 @@
 ---
 title: Does 18F Pass the Bechdel Test for Tech?
-date: '2015-03-17'
+date: 2015-03-17 14:00:00
 layout: post
 image: /assets/blog/bechdel/team.jpg
 tags: 

--- a/_posts/2015-03-17-for-public-comment-the-https-only-standard.md
+++ b/_posts/2015-03-17-for-public-comment-the-https-only-standard.md
@@ -1,6 +1,6 @@
 ---
 title: "For Public Comment: the HTTPS-Only Standard"
-date: '2015-03-17'
+date: 2015-03-17 10:00:00
 layout: post
 image: /assets/blog/https-standard/screen.png
 tags:

--- a/_posts/2015-03-19-18f-by-the-numbers.md
+++ b/_posts/2015-03-19-18f-by-the-numbers.md
@@ -2,6 +2,7 @@
 title: "18F by the Numbers"
 layout: post
 image: /assets/blog/agile-day/18fbythenumbers.png
+date: 2015-03-19 18:00:00
 tags:
 - 18F
 - how we work

--- a/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
+++ b/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
@@ -2,6 +2,7 @@
 title: "How we built analytics.usa.gov"
 layout: post
 image: /assets/blog/dap/screen.png
+date: 2015-03-19 10:00:00
 tags:
 - analytics
 - open government

--- a/_posts/2015-03-20-one-year-in-and-looking-forward.md
+++ b/_posts/2015-03-20-one-year-in-and-looking-forward.md
@@ -1,0 +1,191 @@
+---
+title: One Year In and Looking Forward
+date: '2015-03-20'
+layout: post
+image: "/assets/images/logo-18f.png"
+tags:
+- yearone
+- how we work
+- success stories
+- anniversary
+authors:
+- hillary
+- aaron
+description: "One year ago we said, 'Hello, World' and launched not only a new team, but also the promise of a new way of working with and for the Federal Government. Here's what we've accomplished so far."
+excerpt: "One year ago we said, 'Hello, World' and launched not only a new team, but also the promise of a new way of working with and for the Federal Government. Here's what we've accomplished so far."
+---
+<p class="authors">
+	by {% author hillary %} and {% author aaron %}
+</p>
+
+One year ago we said, ["Hello, World!"][1]
+and launched not only a new team, but also the promise of a new way of
+working with and for the Federal Government. The first 15 of us
+committed to making government services simpler and easier to use—a
+mission that continues to guide us. We set out to do this by drawing on
+principles of user-centered design, developing in the open, and
+incorporating agile and lean development practices.
+
+Our goal was (and is) to transform the way the U.S. government
+approaches problems. We proposed we could accomplish this by:
+
+- putting the needs of the American people first;
+
+- being design-centric, agile, open, and data-driven;
+
+- working in the open to make our products stronger; and
+
+- deploying our products early and often.
+
+Our goals and approach established, we rolled up our sleeves and got to
+work. With each new project we take on, we know the long tail of our
+impact will be the education and empowerment we share with our partner
+agencies. And, following in the footsteps of the UK’s Government Digital
+Service, we’ve been capturing, documenting, and blogging about our
+process as much as possible — not simply for the purpose of recording
+our history, but so we can share our process and progress with you.
+
+“Just Start” was our mantra in the early days of 18F, and we did.
+Sometimes we stumbled, but each time we practiced what we preach—build,
+measure, learn, and do it again.
+
+## It's Been an Incredible Year
+
+The initial idea was simple: Attract talented technologists to the civil
+service, enticing them with meaty problems and an opportunity for huge
+impact. The MVP (minimum viable product) was the [Presidential Innovation Fellowship][2], which proved you could get
+people to give up (or take a break from) their jobs in the private
+sector to come serve a tour of duty in the Federal Government. The next
+step? Convince people to serve longer than a six-to-12-month fellowship
+and join a product delivery team. The results speak for themselves:
+
+- 18F grew from a 15-person team to a 100-person team, including the
+Presidential Innovation Fellows. Fun fact: We’re still rapidly growing.
+We have more than 20 people joining us in the next few weeks alone!
+
+- We're working with 16 agencies on projects ranging from the creation
+of open data APIs, a service to collect donations, a purchasing approval
+tool that could save the government millions of dollars, and a platform
+to facilitate collaborative work amongst a distributed workforce.
+
+- We’ve used lean innovation to improve key internal processes such as
+hiring, acquisition, software deployment, and finance.
+
+- Our inboxes have fielded inquiries from more than forty agencies.
+
+- Demand for our services has been so high, we helped create a [brand
+new way for agile teams like us][3] to [get involved in the procurement
+process][4].
+
+- We have employees in 12 different locations, with offices in D.C., San
+Francisco, and Chicago.
+
+- Teammates left jobs at Apple, Google, Microsoft, Pivotal Labs, IDEO,
+IndieGogo, Groupon, NPR, the Sunlight Foundation, and more, excited
+about the prospect of serving their country in this unique way.
+
+- Our team [engaged with more than 125 end-users][5]
+while researching, prototyping, and developing projects.
+
+- More than 100 API teams received training and direct support via our
+[/Developer Program][6].
+
+- Our [open source policy][7] has been forked 14 times, and directly led to the GSA CIO articulating
+an ["open source first" policy][8]
+for the entire agency.
+
+- We have hosted two hackathons and two demo days, with more around the
+corner.
+
+- As a team, we've published 66 blog posts, tweeted 695 times, and have
+made so many updates to our code (called pushing a commit) that it took
+us two days to gather the info because we kept hitting Github's API
+request limit.
+
+- We've created 203 public repositories on Github. 64 of these have been
+active just in the last month. (Source:
+[Govcode.org][9])
+
+- Teammates are creating their own open source software like
+[urlsize][10] and
+[rdbms-subsetter][11].
+
+- We launched [Dashboard][12] to keep the
+public informed of our progress, project milestones, and reusable
+software.
+
+- We helped get the first .gov websites pre-loaded into major browsers
+as always-HTTPS.
+
+- Just yesterday we helped launch
+[analytics.usa.gov][13], giving the public a
+view of federal government website analytics for the first time.
+
+And We're Just Getting Started
+------------------------------
+
+During the next year, you'll see the expansion of several projects and
+lines of business:
+
+- 18F Consulting, to provide design thinking and technical acumen on a
+short-term, as-needed basis, helping agencies acquire better software.
+
+- 18F Talent, to help agencies identify and recruit cutting-edge
+technical talent.
+
+- FISMA Ready, a toolkit that provides Federal information security
+compliance for open-source software.
+
+- [Agile Delivery Services BPA][14],
+a micro-market blanket purchase agreement to help [agencies acquire
+better professional services][15].
+
+- A partnership with the U.S. Digital Service to help hire and start
+digital service teams like ours at many other agencies.
+
+Not to mention the fact that we plan to double in size and scale our
+services to make a larger impact. Check back here in one year and hold
+us to it.
+
+Thank You
+---------
+
+Finally, a personal thank you to the entire team. It is an honor to work
+with passionate people who are absolutely committed to both making our
+team better and our government better. And thank you to our partners.
+Sixteen agencies jumped in with both feet in our first year, taking a
+leap of faith that with great talent comes great possibility.
+
+As we set our sights on 2016, we'd love your feedback and ideas, and we
+also need your help!
+
+If you're a designer, developer, or technologist who has ...
+
+- a couple of hours? Check out our ["help wanted" tag][16]
+on Github.
+
+- a couple of days? Attend a [hackathon][17], or peruse our [Dashboard][12] for open
+source projects.
+
+- a couple of years? [Your country needs you!][18]
+
+Onward!
+
+[1]: https://18f.gsa.gov/18f/team/culture/2014/03/19/hello-world-we-are-18f/
+[2]: http://pif.gsa.gov
+[3]: https://18f.gsa.gov/2015/01/08/creating-a-federal-marketplace-for-agile-delivery-services/
+[4]: https://18f.gsa.gov/2015/02/12/highlights-from-the-agile-delivery-services-industry-day-events/
+[5]: https://speakerdeck.com/18f/user-centered-design-18f-demo-day-9-may-2014
+[6]: https://18f.github.io/API-All-the-X/
+[7]: https://github.com/18F/open-source-policy
+[8]: http://gsablogs.gsa.gov/innovation/2014/08/01/our-guiding-principles/
+[9]: https://www.govcode.org/repos
+[10]: https://github.com/18F/urlsize
+[11]: https://github.com/18F/rdbms-subsetter
+[12]: https://18f.gsa.gov/dashboard/
+[13]: http://analytics.usa.gov
+[14]: https://18f.gsa.gov/2015/01/08/creating-a-federal-marketplace-for-agile-delivery-services/
+[15]: https://18f.gsa.gov/2015/02/12/highlights-from-the-agile-delivery-services-industry-day-events/
+[16]: https://github.com/search?utf8=%E2%9C%93&q=user%3A18f+label%3A%22help+wanted%22
+[17]: http://www.eventbrite.com/e/gov-tech-hack-by-the-people-for-the-people-tickets-16135863803
+[18]: https://18f.gsa.gov/2015/02/25/We-Are-Hiring/


### PR DESCRIPTION
- Adds the one year in and looking forward post
- fixes chronology of posts other from this week
  - Bechdel Test, HTTPS standard, By the Numbers and analytics.usa.gov posts were slightly out of order because we didn't provide a date and time in the `date:` field (good to remember for future days with multiple posts).