### PR TITLE
Actually reference the new fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -81,7 +81,7 @@ http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-A
 
 <!-- CSS
 ================================================== -->
-<link href="https://fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:400,700" rel="stylesheet" type="text/css">
+<link href="/assets/css/google-fonts.css" rel="stylesheet">
 <link href="/assets/css/fonts.css" rel="stylesheet">
 <link href="/assets/css/font-awesome.min.css" rel="stylesheet">
 <link href="/assets/css/normalize.css" rel="stylesheet">


### PR DESCRIPTION
Ugh - I hadn't committed the change to the header file, so the `<link>` tag was still pointing to `fonts.googleapis.com`.

@gboone While my local testing was sound on Chrome and Firefox, this means that your tests on Safari and IE were not actually testing the inlined fonts. My apologies. Mind running that test again?