### PR TITLE
Adds an edit link to prose on each post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,9 @@ rss_limit: 20
 
 future: false
 
+# edit on prose or github
+editurl: http://prose.io/#18F/18f.gsa.gov/edit/staging/
+
 # get data from the hub
 jekyll_get:
   - data: team

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -64,16 +64,18 @@
       <h1>Related Posts</h1>
       {% related_posts ul li %}
     </section>
-
+    <section class="blog-edit">
+     <a href="{{site.editurl}}{{page.path}}">Edit this post</a>
+    </section>
     <aside class="blog-follow-us">
       <h1>Follow the latest news from 18F</h1>
       <ul>
         <li><i class="fa fa-twitter"></i> <a href="https://twitter.com/18f">@18F</a></li>
         <li><i class="fa fa-rss"></i> <a href="/feed/">18F News Feed</a></li>
       </ul>
-      
+
       <!-- <i class="fa fa-github"></i> <a href="https://github.com/18f">GitHub / 18F</a> -->
-      
+
     </aside>
 
   </div>


### PR DESCRIPTION
Inspired by @andrewmaier’s pursuit to find the correct markdown file to
edit in order to fix a typo. I’m considering only showing this on
`staging` but don’t really see a problem putting it on the public site.