### PR TITLE
Remove category from Peace Corps post

### DIFF
--- a/_posts/2015-04-09-flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform.md
+++ b/_posts/2015-04-09-flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform.md
@@ -6,8 +6,6 @@ image: /assets/blog/peacecorps/image04.png
 tags:
 - Peace Corps
 - how we work
-category:
-- Design and Code
 authors:
 - cm
 description: "We were proud to provide design and development work for the Peace Corps' new donation platform. We want to share a few reflections around drawing that delivery line for this new product, and explain where we think we made the right call and look at other decisions which still keep us up at night."


### PR DESCRIPTION
The Peace Corps post URL is prefixed with `/design%20and%20code/`:

> https://staging.18f.us/design%20and%20code/2015/04/09/flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform/

It should be: 

> https://staging.18f.us/2015/04/09/flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform/

It's because of the `category` field in the front matter, which this PR removes. I think we need to fix the URL generation before we can start using categories.