### PR TITLE
Fix name wrapping on bigger screens

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -763,8 +763,8 @@ $tiniest: new-breakpoint(max-width 390px);
 		font-size: 1.2em;
 		text-align: center;
 		line-height: 1.2em;
+		min-height: 2.4em; // 2x line-height
 		@include media($smaller) {
-			min-height: 2.4em; // 2x line-height
 			margin-top: 0;
 		}
 		@include media($smallest) {


### PR DESCRIPTION
My fix from yesterday introduced a regression at bigger sizes. Widths between about 980 and 1100px exhibit this:

![image](https://cloud.githubusercontent.com/assets/113896/7145261/d0dfa8b6-e29f-11e4-9f9d-4715eacf27ed.png)

This tweak moves the `min-height` for the name elements out of the smaller breakpoint so that it's always applied.