### PR TITLE
Go edits

### DIFF
--- a/go
+++ b/go
@@ -88,6 +88,8 @@ end
 def server_build
   puts 'Pulling from git'
   exec_cmd 'git pull'
+  update_gems
+  exec_cmd('git reset HEAD Gemfile.lock'
   exec_cmd('bundle exec jekyll b --config _config.yml,_config-deploy.yml')
 end
 

--- a/go
+++ b/go
@@ -61,7 +61,6 @@ end
 
 def update_gems
   exec_cmd 'bundle update'
-  exec_cmd 'git add Gemfile.lock'
 end
 
 def update_data
@@ -89,8 +88,8 @@ def server_build
   puts 'Pulling from git'
   exec_cmd 'git pull'
   update_gems
-  exec_cmd('git reset HEAD Gemfile.lock'
-  exec_cmd('bundle exec jekyll b --config _config.yml,_config-deploy.yml')
+  puts 'building site'
+  exec_cmd('bundle exec jekyll b --config _config.yml')
 end
 
 


### PR DESCRIPTION
The past couple deployments have been failing because we added or updated gems (e.g., adding `jemoji`) and the build script doesn't currently attempt to install them for us. Thus, `./go build` will fail when jekyll tries to use gems that aren't installed. This fixes that problem by adding `./go update_gems` to `./go server_build`.