### PR TITLE
Move CORS rules include to fix HSTS header

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -25,6 +25,7 @@ server {
   ssl_certificate_key  /etc/nginx/ssl/keys/18f.gsa.gov.key;
   include ssl/ssl.rules;
   include ssl/hsts.rules;
+  include cors.rules;
 
   add_header X-Government-Innovation Disrupted;
 
@@ -34,20 +35,17 @@ server {
   location / {
       root   /home/site/production/current/_site;
       default_type text/html;
-      include cors.rules;
   }
 
   location /dashboard {
       root /home/site/production/dashboard/_site;
       default_type text/html;
-      include cors.rules;
   }
 
   location /hub {
       root /home/site/production/hub/_site_public;
       index index.html api.json;
       default_type text/html;
-      include cors.rules;
   }
 
   # proxy to hydra, cover up for their lack of HTTPS
@@ -122,6 +120,7 @@ server {
   ssl_certificate_key  /etc/nginx/ssl/keys/star.18f.us.key;
   include ssl/ssl.rules;
   include ssl/hsts.rules;
+  include cors.rules;
 
   error_page 404 /404/index.html;
   error_page 500 /500/index.html;
@@ -129,13 +128,10 @@ server {
   location / {
       root   /home/site/staging/current/_site;
       default_type text/html;
-
-      include cors.rules;
   }
+
   location /dashboard {
     root /home/site/staging/dashboard/_site;
-
-    include cors.rules;
   }
 
   # production hook runs on port 3000


### PR DESCRIPTION
Little known fact about nginx vhost configs - you have to keep `add_header` directives at the same level. By adding `cors.rules` into specific paths, it prevented the HSTS header from appearing. This is dumb, but this fixes it. The tradeoff is that now the entire site is available over CORS, for `GET`, `OPTIONS`, and `HEAD` requests. Since that seems fine to me, this seems like the simplest fix.