### PR TITLE
Fix the RSS Feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem 'rouge'
 gem 'bourbon'
 gem 'redcarpet'
-gem 'jekyll', '3.0.0.pre.beta2'
+gem 'jekyll'
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,22 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    blankslate (2.1.2.4)
     bourbon (4.2.2)
       sass (~> 3.4)
       thor
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    classifier-reborn (2.0.3)
+      fast-stemmer (~> 1.0)
     coderay (1.1.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.9.1.1)
     colorator (0.1)
+    execjs (2.5.2)
+    fast-stemmer (1.0.2)
     ffi (1.9.8)
     gemoji (2.1.0)
     hash-joiner (0.0.7)
@@ -24,15 +33,24 @@ GEM
       nokogiri (~> 1.4)
     htmlentities (4.3.3)
     i18n (0.7.0)
-    jekyll (3.0.0.pre.beta2)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
       colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 3.0)
+      liquid (~> 2.6.1)
       mercenary (~> 0.3.3)
-      rouge (~> 1.7)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
       safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.2.1)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
@@ -42,13 +60,13 @@ GEM
     jekyll_pages_api (0.1.1)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jemoji (0.0.8)
-      gemoji
-      html-pipeline
-      jekyll
+    jemoji (0.4.0)
+      gemoji (~> 2.0)
+      html-pipeline (~> 1.9)
+      jekyll (~> 2.0)
     json (1.8.2)
-    kramdown (1.6.0)
-    liquid (3.0.1)
+    kramdown (1.7.0)
+    liquid (2.6.2)
     listen (2.10.0)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -56,13 +74,19 @@ GEM
     mercenary (0.3.5)
     method_source (0.8.2)
     mini_portile (0.6.2)
-    minitest (5.6.0)
+    minitest (5.6.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.11)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -75,8 +99,11 @@ GEM
     thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
+    toml (0.1.2)
+      parslet (~> 1.5.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
@@ -84,7 +111,7 @@ PLATFORMS
 DEPENDENCIES
   bourbon
   hash-joiner
-  jekyll (= 3.0.0.pre.beta2)
+  jekyll
   jekyll-paginate
   jekyll-sitemap
   jekyll_pages_api


### PR DESCRIPTION
This should fix 18f.gsa.gov/feed and close #756 by reverting Jekyll to the most stable version.