### PR TITLE
Adds more files to be excluded from site generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,10 @@ exclude:
 - CONTRIBUTING.md
 - todo.txt
 - vendor
+- go
+- script
+- Gemfile
+- Gemfile.lock
 
 gems: [jekyll-sitemap]
 


### PR DESCRIPTION
Nothing dangerous about generating them, but there's also no reason to so we might as well not.