### PR TITLE
Consulting format

### DIFF
--- a/pages/consulting.md
+++ b/pages/consulting.md
@@ -3,9 +3,11 @@ title: 18F Consulting
 permalink: /consulting/
 layout: bare
 ---
-## A new line of business within 18F, a digital services agency and technology incubator within the General Services Administration.
+# 18F Consulting
 
-18F Consulting is focused on providing hands-on consulting services to Federal program managers and other leaders who need assistance in designing and managing software acquisitions that use modern development techniques (e.g., agile, lean, open source). We offer a variety of services under the authority of the [Economy Act](http://www.acquisition.gov/far/html/Subpart%2017_5.html) from knowledgeable and experienced software engineers and acquisition specialists. Think of us as your in-house technical brains for your next software acquisition.
+### A new line of business within 18F, a digital services agency and technology incubator within the General Services Administration.
+
+18F Consulting is focused on providing hands-on consulting services to Federal program managers and other leaders who need assistance in designing and managing software acquisitions that use modern development techniques (e.g., agile, lean, open source). We offer a variety of services under the authority of the [Economy Act](https://www.acquisition.gov/?q=browse/far/17/5) from knowledgeable and experienced software engineers and acquisition specialists. Think of us as your in-house technical brains for your next software acquisition.
 
 ## Documents
 

--- a/pages/consulting.md
+++ b/pages/consulting.md
@@ -33,11 +33,11 @@ If you're a Federal Agency interested in our services, email us at <a id="email"
 
 ## Team
 
--Chris Cairns (Managing Director)
--Dave Zvenyach
--Jay Finch
--Jesse Taggert
--Tom Black
+- Chris Cairns (Managing Director)
+- Dave Zvenyach
+- Jay Finch
+- Jesse Taggert
+- Tom Black
 
 <!-- Obfuscate our email -->
 <div>

--- a/pages/consulting.md
+++ b/pages/consulting.md
@@ -33,11 +33,11 @@ If you're a Federal Agency interested in our services, email us at <a id="email"
 
 ## Team
 
-Chris Cairns (Managing Director)
-Dave Zvenyach
-Jay Finch
-Jesse Taggert
-Tom Black
+-Chris Cairns (Managing Director)
+-Dave Zvenyach
+-Jay Finch
+-Jesse Taggert
+-Tom Black
 
 <!-- Obfuscate our email -->
 <div>


### PR DESCRIPTION
Team member names were displaying in a single line. Updated so they will each appear on their own line. 

Should add links to bios when they are live. 