### PR TITLE
Add CF deployment scripts and manifest

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,4 @@
+.git
+assets
+!_site/assets
+

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: _site

--- a/cf-deploy.sh
+++ b/cf-deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+DOMAIN="18f.gov"
+HOST=${HOST-site}
+if $(cf app site-a | grep -q started)
+then
+  OLD="site-a"
+  NEW="site-b"
+else
+  OLD="site-b"
+  NEW="site-a"
+fi
+
+echo "Pushing new app to $NEW and disabling $OLD"
+cf push $NEW
+if [[ $? -ne 0 ]]; then
+  echo "Error pushing"
+  cf stop $NEW
+  exit 1
+fi
+
+echo "Re-routing"
+cf map-route $NEW $DOMAIN -n $HOST
+cf unmap-route $OLD $DOMAIN -n $HOST
+cf stop $OLD
+
+echo "Done"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,10 @@
+---
+memory: 64M
+instances: 1
+applications:
+- name: site-a
+- name: site-b
+buildpack: https://github.com/cloudfoundry-incubator/staticfile-buildpack.git
+env:
+  FORCE_HTTPS: true
+domain: 18f.gov


### PR DESCRIPTION
These are some sample CF manifests and scripts that we can use to deploy the site.

I deployed it to `site.18f.gov` but you all can do what you see fit with this.

There is an org `18f` and a `site` space if you are not invited please ask me.