### PR TITLE
adds author metadata to News section

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -388,6 +388,9 @@ $tiniest: new-breakpoint(max-width 390px);
 		margin-bottom: 0.6em;
 		line-height: 1.2em;
 	}
+	.quiet {
+		color: $medium-gray;
+	}
 }
 .tag-index {
 	.blog-title h1 {

--- a/news/index.html
+++ b/news/index.html
@@ -35,6 +35,16 @@ layout: bare
                   {% endfor %}
                 </span>
               </p>
+              {% if post.authors != blank %}
+                <p class="quiet">
+                {% if post.authors.size > 1 %}
+                  Authors:
+                {% else %}
+                  Author:
+                {% endif %}
+                {{ post.authors | join: ', ' }}
+                </p>
+              {% endif %}
             </div>
 
             <div class="blog-snippet">


### PR DESCRIPTION
### What and Why
When I read the "News" section of 18F, I would love to quickly see who has written the post.

This PR looks for the author or authors, and lists them as secondary metadata as part of the blog post metadata block. If no author exists, no author block is printed.

### Screenshot
![screenshot 2015-05-04 17 34 34](https://cloud.githubusercontent.com/assets/3958678/7463023/09a88944-f284-11e4-8fb4-93dc92bd0c58.png)

### Discussion
I noticed that you all have stored Author data in frontmatter, which led to some inconsistencies in spellings, capitalization, first name only vs. first-and-last-names listed, etc. I'm sure there is a smarter way to solve this problem if the author info is stored elsewhere, and would love to see what you may come up with. I don't know Ruby so I did what I could :smiley: 