### PR TITLE
Team template fix

### DIFF
--- a/deploy/fabfile.py
+++ b/deploy/fabfile.py
@@ -36,7 +36,11 @@ current = "%s/%s/current" % (home, environment)
 ruby = "/opt/install/rbenv/shims/ruby"
 
 # principal command to run upon update
-command = "cd %s && %s go server_build >> %s" % (current, ruby, log)
+if (environment == 'production') {
+  command = "cd %s && %s go production_build >> %s" % (current, ruby, log)
+} else {
+  command = "cd %s && %s go server_build >> %s" % (current, ruby, log)
+}
 
 ## can be run on their own
 

--- a/go
+++ b/go
@@ -92,6 +92,14 @@ def server_build
   exec_cmd('bundle exec jekyll b --config _config.yml')
 end
 
+def production_build
+  puts 'Pulling from git'
+  exec_cmd 'git pull'
+  update_gems
+  puts 'building iste'
+  exec_cmd('bundle exec jekyll b --config _config.yml, _config-production.yml')
+end
+
 def cf_deploy
   build
   exec_cmd('sh deploy/cf-deploy.sh')

--- a/go
+++ b/go
@@ -113,7 +113,8 @@ COMMANDS = {
   :build => 'Builds the site',
   :ci_build => 'Builds the site for a CI system',
   :server_build => 'Pulls from git and builds the site with `jekyll-get` enabled',
-  :cf_deploy => 'Deploys to cloudfoundry'
+  :cf_deploy => 'Deploys to cloudfoundry',
+  :production_deploy => 'Deploys to production using a second config file'
 }
 
 def usage(exitstatus: 0)

--- a/pages/team.html
+++ b/pages/team.html
@@ -16,12 +16,15 @@ title: People
 		<div class="team">
 			{% for person in site.team %}
 				{% if person.content.size > 0 %}
-					{% unless person.title %}
 					<div class='bio'>
-	        		<a href='/team/{{person.name}}' class="disabled">{{ person.name | team_photo }}
+              {% if site.collections.team.output %}
+	        		<a href='/team/{{person.name}}'>
+              {% else %}
+              <a class="disabled">
+              {% endif %}
+                  {{ person.name | team_photo }}
 							<h1>{{ person.name | team_full_name }}</h1></a>
 	    		</div>
-	    		{% endunless %}
 				{% endif %}
 	    {% endfor %}
     </div>


### PR DESCRIPTION
Closes #814 by creating a separate configuration file for production that disables generation of the bio pages and modifications to deployment scripts to match. Also leaves the `<a>` tags without an `href` and adds the `disabled` class on production. On staging people should be able to click through to their bios.

Also relocates the `team` page's template to a more reasonable place. See 0a11349 for more detail.