### PR TITLE
Improved line heights on bare template

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -981,6 +981,7 @@ $tiniest: new-breakpoint(max-width 390px);
 		font-family: $base-font-family;
 		font-weight: normal;
 		font-size: 1.4em;
+		line-height: 30px;
 		padding-top: 15px;
 		padding-bottom: 10px;
 		@include media($smallest) {
@@ -998,6 +999,12 @@ $tiniest: new-breakpoint(max-width 390px);
 	}
 	p {
 		margin-bottom: 1.1em;
+	}
+
+	ul, ol {
+		li {
+			margin: 5px 0;
+		}
 	}
 }
 .bare-logo {
@@ -1030,6 +1037,8 @@ $tiniest: new-breakpoint(max-width 390px);
 }
 
 .bare-content {
+	margin-top: 7px;
+
 	@include span-columns(9);
 	@include omega();
 	@include media($smallest) {


### PR DESCRIPTION
The compressed line heights on the [18F Consulting page](https://18f.gsa.gov/consulting/) were annoying me. Also, the new nav was butting up against the top of the content. This gives a few things on the page room to breathe.

Before:

![screenshot from 2015-05-11 15 30 07](https://cloud.githubusercontent.com/assets/4592/7573298/c02e1f08-f7f2-11e4-99d7-386fe7848760.png)

After:

![screenshot from 2015-05-11 15 29 59](https://cloud.githubusercontent.com/assets/4592/7573300/c0afa1ae-f7f2-11e4-8e2a-a5da6ca57a37.png)
