### PR TITLE
Add recruiting address to webpage footer (?)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,8 @@
       <h1>Contact Us</h1>
       <a href="mailto:18f@gsa.gov" itemprop="email"><i class="fa fa-envelope"></i> 18F@gsa.gov</a>
       <br/>
+      <a href="mailto:join18f@gsa.gov" itemprop="email"><i class="fa fa-envelope"></i> Hiring: join18F@gsa.gov</a>
+      <br/>
       <a href="https://twitter.com/18F"><i class="fa fa-twitter"></i> @18F</a>
     </div>
     <div>


### PR DESCRIPTION
Adds a line for "join18F@gsa.gov" at bottom of webpage with "Hiring" in link. Not entirely sold this is needed, but if wanted or desired...here's the edit. I can buy the argument that its a bit confusing, and we do get messages to the general address regularly.

Test Edit for GitHub class: this should link to issue 815: https://github.com/18F/18f.gsa.gov/issues/815