### PR TITLE
Restore /hub/deploy webhook

### DIFF
--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -97,6 +97,22 @@ server {
       proxy_read_timeout    30;
   }
 
+  location /hub/deploy {
+    proxy_pass http://localhost:4002/;
+    proxy_http_version 1.1;
+    proxy_redirect off;
+
+      proxy_set_header Host   $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_max_temp_file_size 0;
+
+      proxy_connect_timeout 10;
+      proxy_send_timeout    30;
+      proxy_read_timeout    30;
+  }
+
   # Redirect /code/<project> to the corresponding GitHub page
   location /code {
     rewrite ^/code/(.*)$ https://github.com/18F/$1 redirect;


### PR DESCRIPTION
Also, per 18F/hub#299, I updated `/etc/nginx/nginx.conf` to use `gzip_static on` after rebuilding Nginx at version 1.8.0 with `--with-http_gzip_static_module` enabled, in anticipation of using gzipped files produced by the impending [jekyll_pages_api_search gem](https://github.com/18F/jekyll_pages_api_search/).

BTW, I noticed that a `sudo service nginx restart` isn't enough to ensure the new build is loaded; the error logs show `unknown directive "gzip_static"` when issuing `sudo nginx -s reload` after a restart. You have to manually kill the master process, then run `sudo service nginx start`. After that, the `gzip_static` directive warnings go away.

Manually reissued the last webhook to `/hub/deploy` to ensure that things are working again as intended.

cc: @gboone @konklone