### PR TITLE
Spacing/styling fix for home page

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -15,7 +15,7 @@ $tiniest: new-breakpoint(max-width 390px);
 
 // Site-wide media queries
 //********************************************************
-.mantra, .blog-entry, .page-content, .team, .footer, .contact-box {
+.mantra, .blog-entry, .service-entry, .team, .footer, .contact-box {
 	@include media($small) {
     	padding-left: 5%;
     	padding-right: 5%;
@@ -415,7 +415,7 @@ $tiniest: new-breakpoint(max-width 390px);
 	}
 }
 
-.blog-entry, .page-content {
+.blog-entry, .service-entry {
 	@extend %section-padding; //standard padding for all sections
 	padding-top: 25px; //compensates for padding in top row of news section
 	h1 {
@@ -439,17 +439,7 @@ $tiniest: new-breakpoint(max-width 390px);
 	}
 }
 
-.page-content {
-	@extend %section-padding; //standard padding
-	padding-top: 12px;
-	padding-bottom: 0;
-	p {
-	  + p {
-	    margin: 1em 0;
-	  }
-	}
-}
-.blog-title {
+.blog-title, .service-title {
 	@include span-columns(12);
 	padding: 15px 0 5px 0;
 	@include media($tiniest) {

--- a/go
+++ b/go
@@ -69,7 +69,7 @@ def update_data
 end
 
 def serve
-  exec 'bundle exec jekyll serve --trace'
+  exec 'bundle exec jekyll serve --trace --no-watch'
 end
 
 def build

--- a/pages/index.html
+++ b/pages/index.html
@@ -42,28 +42,29 @@ permalink: /
   </div>
 </section>
 
-<section id="delivery" class="services">
+<section class="services" itemprop="makesOffer">
   <div class="header">
     <div class="container-fluid">
       <h1>our work</h1>
     </div>
   </div>
-  <article class="container page-content" itemprop="department" itemtype="">
-    <h1><a href="/delivery">Delivery</a></h1>
+  <article class="container service-entry" itemprop="department">
+    <div class="service-title">
+      <h1><a href="/delivery" class="service-title">Delivery</a></h1>
+    </div>
     <p>Delivery is at the heart of what we do. Our team of designers and developers work to transform government services by building world-class software products and raise standards of software development throughout the government. Learn more about our products by visiting our <a href="/dashboard">dashboard</a> and you can find more information about <a href="https://pages.18f.gov/guides">our standards and capabilities</a> through our guides.</p>
     <p>Learn more about <a href="/dashboard">what we're building and how we're doing it</a>.</p>
-  </article>
-  <article class="container page-content" itemprop="sectionConsulting" itemtype="">
-    <h1><a href="/consulting">Consulting</a></h1>
+    <div class="service-title">
+      <h1><a href="/consulting" class="service-title" itemprop="Name">Consulting</a></h1>
+    </div>
     <p>Our Consulting team helps federal agencies deliver successful digital services by using proven, modern approaches to your work such as human-centered design, lean startup, and agile development. As consultants, we're your partners: rolling-up our sleeves right alongside you to solve the biggest challenges facing your agency. From developing agile acquisition strategies to evaluating opportunities to improving your digital initiatives, our team sets you up for success.</p>
 
     <p>Learn more about the ways we can help you at <a href="/consulting">18F Consulting</a>.</p>
-  </article>
-  <article class="container page-content" itemprop="" itemtype="">
-    <h1><a href="https://pages.18f.gov/joining-18f/">Join us</a></h1>
+    <div class="service-title">
+      <h1><a href="https://pages.18f.gov/joining-18f/" class="service-title" itemprop="name">Join us</a></h1>
+    </div>
     <p>We are looking for candidates passionate about our mission, with top notch software development, design, content, and operations skills to match. The majority of our team is distributed across the country, in places like Chicago, New York, Raleigh, Tucson, Austin, Dayton, Philadelphia, San Diego, Seattle, and Portland.</p>
     <p>Learn more about <a href="https://pages.18f.gov/joining-18f">joining our team</a>.</p>
-  </article>
 </section>
 <section id="news" class="blog">
   <div class="header">


### PR DESCRIPTION
The spacing and styling was off for the "our work" section of the home page. This was due to a mis-reading and misapplication of classes and thus also css styles. This also adds new microformats that actually make sense.