### PR TITLE
renamed news to blog

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       jekyll (>= 2.0)
     json (1.8.2)
     kramdown (1.7.0)
-    liquid (3.0.2)
+    liquid (3.0.3)
     listen (2.10.0)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)

--- a/_config.yml
+++ b/_config.yml
@@ -44,9 +44,9 @@ url: https://18f.gsa.gov
 title: 18F Digital Services Delivery
 description: "18F builds effective, user-centric digital services focused on the interaction between government and the people and businesses it serves."
 
-# blog archive at /news
+# blog archive at /blog
 paginate: 5
-paginate_path: "news/page/:num"
+paginate_path: "blog/page/:num"
 
 #emoji
 gems:

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,7 +9,7 @@
   </ul>
   <span class="sep">|</span>
   <ul class="hidden">
-    <li><a href="/news">Blog</a></li>
+    <li><a href="/blog">Blog</a></li>
     <li><a href="/#contact">Contact</a></li>
     <li><a href="/">Home</a></li>
   </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,8 +20,6 @@
 
     <section class="blog-posting" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
 
-      <nav class="back"><a href="/news"><i class="fa fa-chevron-left"></i><i class="fa fa-chevron-left"></i> back to all blog posts</a></nav>
-
       <h1><a href="{{ page.url }}">{{ page.title }}</a></h1>
 
       <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%B %-d, %Y" }} </time>

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -396,7 +396,7 @@ $tiniest: new-breakpoint(max-width 390px);
 }
 
 
-// News and blog pages
+// Blogblog-postin and blog pages
 //********************************************************
 .subscribe {
 	margin-top: 10px;
@@ -509,6 +509,7 @@ $tiniest: new-breakpoint(max-width 390px);
 
 .blog-posting {
 	h1 {
+		margin-top: 64px;
 	    font-weight: normal;
 	    margin-bottom: 20px;
 	    + p {

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -396,7 +396,7 @@ $tiniest: new-breakpoint(max-width 390px);
 }
 
 
-// Blogblog-postin and blog pages
+// Blog and blog pages
 //********************************************************
 .subscribe {
 	margin-top: 10px;

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,9 @@ layout: bare
 ---
 <section>
 
-  <h1># news</h1>
+  
+
+  <h1>Blog</h1>
 
   <p class="subscribe">
     Subscribe to updates <a href="https://ifttt.com/recipes/214709-a-new-18f-blog-post-email-me-a-link-to-go-read-it-right-away">by email</a>, or through <a href="/feed/">our RSS feed</a>.

--- a/deploy/test.sh
+++ b/deploy/test.sh
@@ -24,7 +24,7 @@ else
   CODE=1;
 fi
 # check that the blog was generated
-if [ -s "_site/news/index.html" ]
+if [ -s "_site/blog/index.html" ]
 then
   echo "Blog generated correctly";
 else
@@ -32,7 +32,7 @@ else
   CODE=1;
 fi
 # check that a blog pagination is generating and not empty
-if [ -s "_site/news/page/2/index.html" ]
+if [ -s "_site/blog/page/2/index.html" ]
 then
   echo "blog pagination generated correctly";
 else

--- a/news/index.html
+++ b/news/index.html
@@ -1,0 +1,5 @@
+---
+layout: feed
+---
+
+<META http-equiv="refresh" content="0;URL=/blog">


### PR DESCRIPTION
Changed the following areas from `/news` to `/blog`:

- _config.yml
- global nav button
- took out `back to all posts` button in blog post layout
- renamed news folder to blog folder

closes #356 