### PR TITLE
Reverts Gemfile to last working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'jekyll', '3.0.0.pre.beta2'
 
 group :jekyll_plugins do
   gem 'jekyll-sitemap'
-  gem 'jekyll_pages_api', '0.1.3'
+  gem 'jekyll_pages_api'
   gem 'jekyll-archives', :git => 'https://github.com/jekyll/jekyll-archives.git'
   gem 'jekyll-paginate'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.3.0)
+    redcarpet (3.2.3)
     rouge (1.9.0)
     safe_yaml (1.0.4)
     sass (3.4.14)
@@ -95,7 +95,7 @@ DEPENDENCIES
   jekyll-archives!
   jekyll-paginate
   jekyll-sitemap
-  jekyll_pages_api (= 0.1.3)
+  jekyll_pages_api
   jemoji
   pry
   redcarpet


### PR DESCRIPTION
Closes #905 and #904 to fix problems in staging.

Starting with #900 the Jekyll build was failing and causing a segmentation fault on the staging server. This was causing the site to not rebuild at all. Any occasionally it would cause the ruby job to hang indefinitely, only killable with `kill -9` :neutral_face: :neutral_face: :neutral_face: :neutral_face: :neutral_face: 

@konklone and I tried a few tactics for troubleshooting including rolling back version of `jekyll` and several plugins, and upgrading ruby itself. When none of those worked I started checking out commit by commit starting with the commit before the merge commit generated in #900 and working our way up until a commit broke the build again and reverted the project to the state it was in. In this case, the build broke after 1e87c58 and this PR reverts the changes made to Gemfile and Gemfile.lock in that commit.