### PR TITLE
Redirect a bunch of old tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :jekyll_plugins do
   gem 'jekyll_pages_api'
   gem 'jekyll-archives', :git => 'https://github.com/jekyll/jekyll-archives.git'
   gem 'jekyll-paginate'
+  gem 'jekyll-redirect-from'
 end
 
 gem 'hash-joiner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.8.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
     jekyll-sitemap (0.8.1)
@@ -94,6 +96,7 @@ DEPENDENCIES
   jekyll (= 3.0.0.pre.beta2)
   jekyll-archives!
   jekyll-paginate
+  jekyll-redirect-from
   jekyll-sitemap
   jekyll_pages_api
   jemoji
@@ -101,3 +104,6 @@ DEPENDENCIES
   redcarpet
   rouge
   safe_yaml
+
+BUNDLED WITH
+   1.10.3

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ exclude:
 gems: 
   - jekyll-sitemap
   - jekyll-archives
+  - jekyll-redirect-from
 
 jekyll-archives:
   enabled:

--- a/pages/tags/18f consulting.md
+++ b/pages/tags/18f consulting.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/18f consulting/
+redirect_to:
+  - /tags/18f-consulting/
+---

--- a/pages/tags/18f events.md
+++ b/pages/tags/18f events.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/18f events/
+redirect_to:
+  - /tags/18f-events/
+---

--- a/pages/tags/API.md
+++ b/pages/tags/API.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/API/
+redirect_to:
+  - /tags/api/
+---

--- a/pages/tags/consulting services.md
+++ b/pages/tags/consulting services.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/18f consulting services/
+redirect_to:
+  - /tags/18f-consulting/
+---

--- a/pages/tags/day in the life.md
+++ b/pages/tags/day in the life.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/day in the life/
+redirect_to:
+  - /tags/day-in-the-life/
+---

--- a/pages/tags/demo day.md
+++ b/pages/tags/demo day.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/demo day/
+redirect_to:
+  - /tags/demo-day/
+---

--- a/pages/tags/department of labor.md
+++ b/pages/tags/department of labor.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/department of labor/
+redirect_to:
+  - /tags/department-of-labor/
+---

--- a/pages/tags/how we work.md
+++ b/pages/tags/how we work.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/how we work/
+redirect_to:
+  - /tags/how-we-work/
+---

--- a/pages/tags/market research.md
+++ b/pages/tags/market research.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/market research/
+redirect_to:
+  - /tags/market-research/
+---

--- a/pages/tags/open data.md
+++ b/pages/tags/open data.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/open data/
+redirect_to:
+  - /tags/open-data/
+---

--- a/pages/tags/open government.md
+++ b/pages/tags/open government.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/open government/
+redirect_to:
+  - /tags/open-government/
+---

--- a/pages/tags/our projects.md
+++ b/pages/tags/our projects.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/our projects/
+redirect_to:
+  - /tags/our-projects/
+---

--- a/pages/tags/peace corps.md
+++ b/pages/tags/peace corps.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/peace corps/
+redirect_to:
+  - /tags/peace-corps/
+---

--- a/pages/tags/presidential innovation fellows.md
+++ b/pages/tags/presidential innovation fellows.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/presidential innovation fellows/
+redirect_to:
+  - /tags/presidential-innovation-fellows/
+---

--- a/pages/tags/public service.md
+++ b/pages/tags/public service.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/public service/
+redirect_to:
+  - /tags/public-service/
+---

--- a/pages/tags/request for quote.md
+++ b/pages/tags/request for quote.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/request for quote/
+redirect_to:
+  - /tags/request-for-quote/
+---

--- a/pages/tags/speaker series.md
+++ b/pages/tags/speaker series.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/speaker series/
+redirect_to:
+  - /tags/speaker-series/
+---

--- a/pages/tags/success stories.md
+++ b/pages/tags/success stories.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/success stories/
+redirect_to:
+  - /tags/success-stories/
+---

--- a/pages/tags/sunshine week.md
+++ b/pages/tags/sunshine week.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/sunshine week/
+redirect_to:
+  - /tags/sunshine-week/
+---

--- a/pages/tags/the hub.md
+++ b/pages/tags/the hub.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/the hub/
+redirect_to:
+  - /tags/the-hub/
+---

--- a/pages/tags/usability testing.md
+++ b/pages/tags/usability testing.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/usability testing/
+redirect_to:
+  - /tags/usability-testing/
+---

--- a/pages/tags/user experience.md
+++ b/pages/tags/user experience.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/user experience/
+redirect_to:
+  - /tags/user-experience/
+---

--- a/pages/tags/user research.md
+++ b/pages/tags/user research.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/user-research/
+redirect_to:
+  - /tags/user-research/
+---

--- a/pages/tags/user-centered design.md
+++ b/pages/tags/user-centered design.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/user-centered design/
+redirect_to:
+  - /tags/user-centered-design/
+---

--- a/pages/tags/ux design.md
+++ b/pages/tags/ux design.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/ux-design/
+redirect_to:
+  - /tags/ux-design/
+---

--- a/pages/tags/what we learned.md
+++ b/pages/tags/what we learned.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/what we learned/
+redirect_to:
+  - /tags/what-we-learned/
+---

--- a/pages/tags/white house.md
+++ b/pages/tags/white house.md
@@ -1,0 +1,5 @@
+---
+permalink: /tags/white house/
+redirect_to:
+  - /tags/white-house/
+---


### PR DESCRIPTION
Closes #917 by installing the `jekyll-redirect-from` plugin and creating pages for the old "space separated" tag archives to establish the redirects.

This plugin is pretty cool and makes setting up redirects super simple.