### PR TITLE
Final touch to resolve #917

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -30,7 +30,7 @@ layout: bare
                 Tagged /
                 <span class="blog-tags" itemprop="keywords">
                   {% for tag in post.tags %}
-                    <a href="/{{ site.tag_dir }}/{{ tag | uri_escape }}">{{ tag }}</a>
+                    <a href="/{{ site.tag_dir }}/{{ tag | slugify }}">{{ tag }}</a>
                     /
                   {% endfor %}
                 </span>


### PR DESCRIPTION
slugifies links on `/blog/` instead of URL encoding them.