### PR TITLE
link to hiring site from job-related blog posts

### DIFF
--- a/_posts/2015-01-21-join-us.md
+++ b/_posts/2015-01-21-join-us.md
@@ -20,6 +20,8 @@ excerpt: The U.S. Digital Service is a collection of teams across the federal go
 
 <p class="authors">by 18F</p>
 
+**Update:** You can read more about our hiring process [here](https://pages.18f.gov/joining-18f/).
+
 Earlier today, our friend Mikey Dickerson from over at the U.S. Digital Service headquarters [posted on Medium](https://medium.com/@USDigitalService/an-improbable-public-interest-start-up-6f9a54712411) about the "Improbable Public Interest Start Up" he helped create inside the White House. The [U.S. Digital Service](https://wh.gov/usds) is a collection of teams across the federal government, working to bring skilled technologists into public service. We are thrilled to be part of this effort, and will continue to lead the charge for making easy things easy and hard things possible.
 
 Here at 18F, we've been growing quickly since we first got to work in early 2014. Ideas like open source, user-centered design, and "lean government" were completely new to some of our partner agencies and we were excited to be on the ground helping change the way they approached technical work. We have hired over one hundred public servants to work on projects like [streamlining Freedom of Information Act requests](https://github.com/18F/foia-hub), [opening up election finance data](https://18f.gsa.gov/2014/08/21/creating-an-open-fec/), and helping millions of Americans learn about a [new retirement option](https://myra.treasury.gov/).

--- a/_posts/2015-02-25-We-Are-Hiring.md
+++ b/_posts/2015-02-25-We-Are-Hiring.md
@@ -20,6 +20,8 @@ description: "You can find 18F in DC, San Francisco, Chicago, Dayton, and New Yo
   by {% author kaitlin %}, {% author shawn %}, and {% author hillary %}
 </p>
 
+**Update:** You can read more about our hiring process [here](https://pages.18f.gov/joining-18f/).
+
 Technology changes fast. People have grown to expect fast, personalized, and user-friendly information and services from the websites and apps they use on a daily basis. But with a shortage of in-house experts, budget limitations, and no quick way to purchase services, it can be hard for the Federal government to meet those same expectations. This is where we (and hopefully you) come in.
 
 Built in the spirit of America's top tech startups, 18F is a consultancy and product delivery team **for** the U.S. Government **inside** the U.S. Government. We work with federal agencies to rapidly deploy tools and online services that are reusable, cut costs, and are easier for people and businesses to use.


### PR DESCRIPTION
Occurred to me that these two posts are still coming up in search results, so we should direct people to the up-to-date information. Totally open to other ideas about how to word/format it.