### PR TITLE
Reverts the logo on the homepage.

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -4,7 +4,7 @@ permalink: /
 ---
 
 <section class="splash" style="" role="banner" itemscope itemtype="http://schema.org/WPHeader">
-  <img src="/assets/images/logo-18f-rainbow.png" alt="18F logo" class="logo fadeIn" />
+  <img src="/assets/images/logo-18f.png" alt="18F logo" class="logo fadeIn" />
   <h1>Building the 21st century digital government.</h1>
   <ul role="presentation" class="rslides">
     <li>


### PR DESCRIPTION
We'll keep the rainbow logo around in case we need it again.

Not proposing we do this now. But we can merge whenever we're ready to bring the old standard back.