### PR TITLE
Excludes the comma from the final list item.

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -19,7 +19,7 @@ layout: feed
         <title>{{ post.title }}</title>
         <link>{{ site.url }}{{ post.url }}</link>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <dc:creator>{% for author in post.authors %}{{ author | lookup:"authors, full_name" }}, {% endfor %}</dc:creator>
+        <dc:creator>{% for author in post.authors %}{{ author | lookup:"authors, full_name" }}{% unless forloop.rindex == 1 %}, {% endunless %}{% endfor %}</dc:creator>
         {% for tag in post.tags %}<category>{{ tag | xml_escape }}</category>
         {% endfor %}{% for cat in post.categories %}<category>{{ cat | xml_escape }}</category>
         {% endfor %}<guid isPermaLink="false">{{ post.id }}</guid>


### PR DESCRIPTION
Stops the final comma in situations like "Author 1, Author 2, Author 3," cc: @konklone 