### PR TITLE
Applies the new standard template to /consulting.

### DIFF
--- a/_includes/consulting-side.html
+++ b/_includes/consulting-side.html
@@ -1,0 +1,18 @@
+<aside>
+	<h2 id="recent-projects">Recent projects</h2>
+	<ul>
+		<li>Department of Labor / Wage and Hour Division / IT Modernization</li>
+		<li>Social Security Administration / Disability Case Processing System</li>
+		<li><a href="https://pages.18f.gov/consulting/projects/navy-reserve/">Navy Reserve / Ready to Serve (R2S)</a></li>
+		<li>Treasury / DATA Act Implementation</li>
+		<li>Department of Defense / Military OneSource Program</li>
+		<li>Transportation Security Administration / IT Modernization</li>
+	</ul>
+	<h2 id="recent-posts">Recent blog posts</h2>
+	<ul>
+		{% for post in site.tags["18f consulting"] limit:3 %}
+			<li><a href="{{post.url}}">{{post.title}}</a></li>
+		{% endfor %}
+	</ul>
+    <a href="/tags/consulting">More posts about 18F Consulting</a>
+</aside>

--- a/_includes/headline.html
+++ b/_includes/headline.html
@@ -20,4 +20,9 @@
 		<h1>Press</h1>
 		<h2>Working on a story about 18F?</h2>
 		{% endif %}
+
+		{% if page.layout == "page" %}
+			<h1>{{page.title}}{% if page.subtitle %}:{% endif %}</h1>
+			{% if page.subtitle %}<h2>{{page.subtitle}}</h2>{% endif %}
+		{% endif %}
 	</header>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -37,3 +37,7 @@ Add sidebars filtered by layout below
 	</ul>
 </aside>
 {% endif %}
+
+{% if page.title == "18F Consulting"%}
+	{% include consulting-side.html %}
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  {% include head.html %}
+</head>
+<body itemscope itemtype="http://schema.org/WebPage" id="{{page.title | slugify}}">
+
+{% include flag.html %}
+<section class="container bare profile">
+	{% include nav.html %}
+  {% include logo.html %}
+  {% include headline.html %}
+  <div class="content" role="main" itemscope itemprop="mainContentOfPage">
+    {{ content }}
+  </div>
+    {% include sidebar.html %}
+
+
+</section>
+
+  {% include footer.html %}
+  {% include scripts.html %}
+
+</body>
+</html>

--- a/pages/consulting.md
+++ b/pages/consulting.md
@@ -1,10 +1,9 @@
 ---
 title: 18F Consulting
+subtitle: Understand. Acquire. Deliver.
 permalink: /consulting/
-layout: bare
+layout: page
 ---
-
-<h1 style="padding-top: 64px;"> 18F Consulting: Understand. Acquire. Deliver.</h1>
 
 Building new digital services or improving old ones can be risky, complex, and expensive. Doing it well can solve real problems, improve lives, save taxpayer money, and improve the government.
 
@@ -12,15 +11,15 @@ Building new digital services or improving old ones can be risky, complex, and e
 
 ## What should you build, buy, or change?
 
-Too often, teams tasked with solving a problem don't know where to begin or get locked into an idea too soon. 18F Consulting helps you understand your audiences, and we counsel you on available options (e.g., product strategy, new technology, acquisition). 
+Too often, teams tasked with solving a problem don't know where to begin or get locked into an idea too soon. 18F Consulting helps you understand your audiences, and we counsel you on available options (e.g., product strategy, new technology, acquisition).
 
 ## How should you do it?
 
-We guide you through proven practices in human-centered design, lean startup, agile architecture, agile development, open data, and DevOps. These industry-standard techniques increase the likelihood your next initiative will thrive. 
+We guide you through proven practices in human-centered design, lean startup, agile architecture, agile development, open data, and DevOps. These industry-standard techniques increase the likelihood your next initiative will thrive.
 
 ## Who should do it?
 
-Procuring the right team through an outside vendor or recruiting talent in-house is key to producing high-quality digital services. We understand that federal acquisition and hiring processes have long been barriers to success. We use every tool in our kit to change that, to prioritize getting the right people, and to help you hold them accountable for their work. 
+Procuring the right team through an outside vendor or recruiting talent in-house is key to producing high-quality digital services. We understand that federal acquisition and hiring processes have long been barriers to success. We use every tool in our kit to change that, to prioritize getting the right people, and to help you hold them accountable for their work.
 
 Let us assist as you develop a strategy for soliciting and onboarding vendors and design or technology hires. Once you've built a team for your project or organization, we'll help you manage their performance.
 
@@ -59,15 +58,6 @@ Let us assist as you develop a strategy for soliciting and onboarding vendors an
 ## We’d love to hear from you
 
 Email <a id="email" href=""></a> with your need and we’ll be happy to talk further.
-
-## Recent projects
-
-- Department of Labor / Wage and Hour Division / IT Modernization
-- Social Security Administration / Disability Case Processing System
-- [Navy Reserve / Ready to Serve (R2S)](https://pages.18f.gov/consulting/projects/navy-reserve/)
-- Treasury / DATA Act Implementation
-- Department of Defense / Military OneSource Program
-- Transportation Security Administration / IT Modernization
 
 ## Learn more about the work we do
 


### PR DESCRIPTION
In theory this template is ready for all the pages but we'll want to proof them to look for design inconsistencies before going primetime.

Changes from the /press and /team page commits: you can now specify a "subtitle" on a page and it will show up in the second line of the "headline" for any document using the layout "page."

Outstanding changes remaining: create a style for posts to use the headline. This should be relatively straightforward at this point.

cc: @awfrancisco @jenniferthibault @elainekamlley 