### PR TITLE
Adds to the byline include links out to the author's team page

### DIFF
--- a/_includes/byline.html
+++ b/_includes/byline.html
@@ -1,4 +1,10 @@
 {% if include.context == 'page' and page.authors %}{% assign authors = page.authors %}{% endif %}{% if include.context == 'post' and post.authors %}{% assign authors = post.authors | to_yaml %}{% endif %}
 <p class="authors">
-  by {% for author in authors %}<span class="author {{author}}" style="color: #000">{{author | lookup:"authors, full_name"}}</span>{% unless forloop.last %}, {% endunless %}{% if forloop.rindex0 == 1 %} and {% endif %}{% endfor %}
+  by {% for author in authors %}
+  <span class="author {{author}}" style="color: #000">{% if site.collections.team.output %}<a href='/team/{{person}}'>{{author | lookup:"authors, full_name"}}</a>{% else %}{{ author | lookup:"authors, full_name"}}{% endif %}</span>{% unless forloop.last %}, {% endunless %}{% if forloop.rindex0 == 1 %} and {% endif %}
+  {% endfor %}
 </p>
+{% comment %}
+Take out the `{ if site.collections.team.output }` logic after
+individual bio pages are deployed to production
+{% endcomment %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,9 +11,6 @@ Add sidebars filtered by layout below
 			{% if page.github %}
 			<li><a href="https://github.com/{{ page.github }}">GitHub</a></li>
 			{% endif %}
-			{% if page.twitter %}
-			<li><a href="https://twitter.com/{{ page.twitter }}">Twitter</a></li>
-			{% endif %}
 			{% if page.email %}
 			<li><a mailto="{{page.email}}">Email</a></li>
 			{% endif %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,18 +4,13 @@ Add sidebars filtered by layout below
 
 {% if page.layout == "profile" %}
 <aside>
-	{% if page.github or page.twitter or page.email %}
-		{% unless site.config.display_personal %}
-		<h3>Where to find {{ page.first_name }}:</h3>
+	{% if page.project %}
+	<h3>{{ page.first_name }}'s projects:</h3>
 		<ul>
-			{% if page.github %}
-			<li><a href="https://github.com/{{ page.github }}">GitHub</a></li>
-			{% endif %}
-			{% if page.email %}
-			<li><a mailto="{{page.email}}">Email</a></li>
-			{% endif %}
+			{% for project in page.project %}
+				<li>{{ project }}</li>
+			{% endfor %}
 		</ul>
-		{% endunless %}
 	{% endif %}
 	{% authored_posts heading=h3 %}
 </aside>

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -13,14 +13,7 @@
   {% include headline.html %}
   <div class="content" role="main" itemscope itemprop="mainContentOfPage">
     {% if content.size > 0 %}{{ content }}
-    {% if page.project %}
-    <h3>{{ page.first_name }}'s projects:</h3>
-    	<ul>
-	    	{% for project in page.project %}
-					<li>{{ project }}</li>
-				{% endfor %}
-    	</ul>
-    	{% endif %}
+    
     {% else %}We haven't gotten to filling in {{ page.first_name }}'s
 information yet. Check back soon, and thanks for your patience!
     {% endif %}


### PR DESCRIPTION
This will only work in places where the team page is enabled – currently not in production. This template logic looks pretty bonkers ATM and we'll want to un-complicate it once we enable the profiles everywhere.