### PR TITLE
Fix some duplicate bylines, make author adjustments

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -63,7 +63,7 @@ joe:
   first_name: Joe
   last_name: Polastre
 mattchessen:
-  full_name: Matt Chessen
+  full_name: "Matt Chessen, Department of State"
   first_name: Matt
   last_name: Chessen
 majma:

--- a/_posts/2014-04-11-open-source-terms-of-service-a-better-developer.html
+++ b/_posts/2014-04-11-open-source-terms-of-service-a-better-developer.html
@@ -17,8 +17,6 @@ tags:
 - open source
 
 ---
-<p class="authors">by {% author gray %}</p>
-
 <p>One of the important changes occurring across the Federal Government is the role of <a href="http://ben.balter.com/2014/01/27/open-collaboration/">open source for non-code projects</a> - using an open, iterative model of collaboration inherited from the coding community for all kinds of new purposes. Want to see a great example of this in action? In recent years, as <a href="https://www.data.gov/developers/apis">more and more agencies offer public APIs</a>, some have included a developer terms of service (TOS).</p>
 
 <!-- more -->

--- a/_posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.html
+++ b/_posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.html
@@ -18,8 +18,6 @@ tags:
 - code
 
 ---
-<p class="authors">by Memi Whitehead, GSA and {% author robert %}, 18F</p>
-
 <p>Easy access to detailed tracking of processes has become more and more popular. Whether using Amazon.com, UPS, Uber or United Airlines, people expect instant feedback. They want to immediately see the status of a process upon which they depend.</p>
 <p>Inspired both by customer questions and the transparency of ordering pizza online, GSA&#8217;s Memi Whitehead and Navin Vembar wanted to build a “Pizza Tracker” for the <a href="https://www.sam.gov/">System for Award Management (SAM)</a> to let users quickly see the status of their registration in that system.</p>
 

--- a/_posts/2014-05-09-a-few-notes-on-notalone-gov.html
+++ b/_posts/2014-05-09-a-few-notes-on-notalone-gov.html
@@ -23,10 +23,6 @@ tags:
 
 
 ---
-<p class="authors">
-  by {% author aaron %}, Mollie Ruskin, {% author sean %} and {% author noah %}
-</p>
-
 <p>At the end of April, Vice President Biden, while <a href="https://www.whitehouse.gov/photos-and-video/video/2014/04/29/vice-president-biden-speaks-preventing-campus-sexual-assault">rolling out the final report of the White House&#8217;s 90-day Task Force to Protect Students from Sexual Assault</a>, announced the launch of <a href="https://www.notalone.gov/">NotAlone.gov</a>, a website built by <a href="https://18f.gsa.gov/">18F</a> and the <a href="https://www.whitehouse.gov/innovationfellows">Presidential Innovation Fellows</a>.</p>
 
 <!-- more -->

--- a/_posts/2014-05-10-make-gov-apis-better-with-user-experience.html
+++ b/_posts/2014-05-10-make-gov-apis-better-with-user-experience.html
@@ -19,9 +19,6 @@ tags:
 - what we learned
 
 ---
-<p class="authors">
-  Cross-posted from <a href="https://www.digitalgov.gov/2014/05/09/make-gov-apis-better-with-user-experience/">DigitalGov.gov</a>. By Jonathan Rubin &amp; {% author gray %}.
-</p>
 
 <p><a href="https://www.digitalgov.gov/2013/04/30/apis-in-government/">APIs</a> and <a href="http://www.usability.gov/what-and-why/user-experience.html">User Experience</a> go together like gummi bears and ice cream.</p>
 
@@ -62,3 +59,5 @@ tags:
 <p>We’ve also assembled an <a href="https://18f.github.io/API-All-the-X/pages/agency_checklist.html">agency checklist</a> that API producers can use as they grow out and mature their efforts. It’s a living document, so feel free to suggest edits! We’re trying to schedule these sessions monthly, going forward. There is still very little out there on the subject of API usability, so we’re documenting everything and will share it with you all shortly.</p>
 
 <p>[Editor&#8217;s note: you can also view Gray Brooks&#8217;s <a href="https://speakerdeck.com/18f/api-usability-testing-18f-demo-day-9-may-2014">slides on API Usability Testing</a> from 18F Demo Day on May 9, 2014.]</p>
+
+<p><em>Cross-posted from <a href="https://www.digitalgov.gov/2014/05/09/make-gov-apis-better-with-user-experience/">DigitalGov.gov</a>.</em></p>

--- a/_posts/2014-05-11-18f-shows-what-is-possible-in-government-with-fbopen.html
+++ b/_posts/2014-05-11-18f-shows-what-is-possible-in-government-with-fbopen.html
@@ -15,11 +15,7 @@ tags:
 - opengov
 - api
 
-
 ---
-<p class="authors">
-  Cross-posted from <a href="https://apievangelist.com/2014/04/08/18f-shows-what-is-possible-in-government-with-fbopen-api/">API Evangelist</a>, by former Presidential Innovation Fellow Kin Lane.
-</p>
 
 <p>There has been some <a href="http://e-pluribusunum.com/2014/03/12/at-18f-in-gsa-u-s-seeks-to-tap-the-success-of-the-u-k-s-government-digital-services/">great coverage of the new group of tech specialists out of the GSA</a>, dubbed <a href="https://18f.gsa.gov/">18F</a>. According to their own home page, 18F:</p>
 
@@ -42,3 +38,5 @@ tags:
 <p><strong>Central Key Management With api.data.gov</strong><br/> Before you can make calls on the central FBOpen API instance, you must obtain an API key from <a href="https://api.data.gov">api.data.gov</a>. This should be standard business operations for ALL federal government APIs. Developers shouldn&#8217;t have to manage separate accounts with each agency, they should be able to request credentials in a single location, and use across all APIs they consume within in the federal government. api.data.gov uses <a href="https://github.com/NREL/api-umbrella">API Umbrella</a>, an open source API management solution developed by National Renewable Energy Laboratory (NREL), and is employed by the GSA in the common API infrastructure available to all agencies.</p>
 
 <p><strong>Read / Write APIs in Government (kindasorta)</strong><br/> I started to cry when I saw that there was not just a GET method for FBOpen, but here was a POST method, allowing for users to add or update opportunities via the API—then I saw it was disabled, and the tears dried up. The option is only available if you deploy your own instance of the API, which in my opinion actually represents the future of read / write APIs in government. I just don&#8217;t think government can move fast enough, and manage the responsibility of write APIs in all scenarios, and providing open source APIs like FBOpen, that anyone can download, install and allow for adding and updating data can bridge this canyon. If enough trusted instances of the FBOpen can be established outside the federal government firewall, agencies can make their own decision around which sources they want to trust and pull opportunities back into internal systems. With proper certification of API deployments by our government, APIs lie FBOpen can share the load of managing data with private sector, without the risk that comes with doing it all internally.</p>
+
+<p><em>Cross-posted from <a href="https://apievangelist.com/2014/04/08/18f-shows-what-is-possible-in-government-with-fbopen-api/">API Evangelist</a></em> by former Presidential Innovation Fellow Kin Lane.</p>

--- a/_posts/2014-05-14-hacking-bureaucracy-improving-hiring-and-software.html
+++ b/_posts/2014-05-14-hacking-bureaucracy-improving-hiring-and-software.html
@@ -5,7 +5,7 @@ tumblr_url: http://18fblog.tumblr.com/post/85724876053/hacking-bureaucracy-impro
 
 title: 'Hacking Bureaucracy: improving hiring and software deployment'
 
-description: When asked what it is we do, one quick answer is, “We’re hacking bureaucracy.” While it may sound provocative, it isn’t.
+description: When asked what it is we do, one quick answer is, "We’re hacking bureaucracy." While it may sound provocative, it isn’t.
 
 authors:
 - greg
@@ -18,19 +18,16 @@ tags:
 - hiring
 
 ---
-<p class="authors">
-  by {% author greg %} and {% author noah %}
-</p>
 
-<p>When asked what it is we do, one quick answer is, “We’re hacking bureaucracy.” While it may sound provocative, it isn’t.</p>
+<p>When asked what it is we do, one quick answer is, "We’re hacking bureaucracy." While it may sound provocative, it isn’t.</p>
 
-<p>In the movies, hackers are often dangerous criminals who break into large systems, but in the software development community, “hacker” describes the way someone thinks and works rather than a malicious activity — hackers are problem solvers. We consider ourselves hackers in that positive sense: productively disruptive and curious. (See <a href="https://www.schneier.com/blog/archives/2006/09/what_is_a_hacke.html">“What is a Hacker?”</a> by Bruce Schneier for a wonderful definition.)</p>
+<p>In the movies, hackers are often dangerous criminals who break into large systems, but in the software development community, "hacker" describes the way someone thinks and works rather than a malicious activity — hackers are problem solvers. We consider ourselves hackers in that positive sense: productively disruptive and curious. (See <a href="https://www.schneier.com/blog/archives/2006/09/what_is_a_hacke.html">"What is a Hacker?"</a> by Bruce Schneier for a wonderful definition.)</p>
 
 <!-- more -->
 
 <p>It’s not enough for us to just build software inside the Federal Government. Such an approach may bring short term gains, but it won’t drive long term positive change. At 18F we’re integrating our style of software development with the many departments and employees of the federal bureaucracy. This is the human platform on which we build our software platforms.</p>
 
-<p>When we launched 18F internally in December, we decided to start with two initial big and challenging projects: improving the efficiency and agility of (1) the hiring process and (2) the software deployment process. Building our “start-up” inside the federal bureaucracy meant first integrating with the federal bureaucracy.</p>
+<p>When we launched 18F internally in December, we decided to start with two initial big and challenging projects: improving the efficiency and agility of (1) the hiring process and (2) the software deployment process. Building our "start-up" inside the federal bureaucracy meant first integrating with the federal bureaucracy.</p>
 
 <p>Historically, hiring and software deployment practices inside the Federal Government have posed significant challenges for agile and user-centered software development practices. These processes need to take weeks, not months.</p>
 

--- a/_posts/2014-05-19-packaging-up-api-usability-testing-for-agency-re-use.html
+++ b/_posts/2014-05-19-packaging-up-api-usability-testing-for-agency-re-use.html
@@ -17,8 +17,6 @@ tags:
 - open source
 
 ---
-<p class="authors">by {% author gray %}</p>
-
 <p>Over the past year, a GSA collaboration has seen <a href="https://www.digitalgov.gov/2014/05/09/make-gov-apis-better-with-user-experience/">a project that offers API Usability Testing to federal agencies</a> go from the pilot stage to a regular, robust series. Already, 13 agencies and programs have participated, and several more participate with every monthly session that passes. The best examples from across the government have made clear that one of the most important tasks of API producers is to regularly engage their developer community and listen to what they have to say. But just encouraging agencies to do this only goes so far.</p>
 
 <!-- more -->

--- a/_posts/2014-05-29-announcing-the-developer-program-a-new-hub-for.html
+++ b/_posts/2014-05-29-announcing-the-developer-program-a-new-hub-for.html
@@ -15,9 +15,6 @@ tags:
 - /developer
 - api
 ---
-<p class="authors">
-  by {% author leah %} and {% author gray %}
-</p>
 
 <p>We recently launched our <a href="https://18f.github.io/API-All-the-X">/Developer Program</a> (pronounced &#8220;slash developer&#8221;) to help federal agencies develop useful, robust APIs. The Program is a collection of educational resources, opportunities to engage the community for help and feedback, and tools that can help you build APIs — essentially an ever-growing knowledge base curated by 18F.</p>
 

--- a/_posts/2014-06-25-intro-to-apis-working-with-urls-json-apis-and-open.html
+++ b/_posts/2014-06-25-intro-to-apis-working-with-urls-json-apis-and-open.html
@@ -17,9 +17,6 @@ tags:
 - how we work
 
 ---
-<p class="authors">
-  by {% author gray %} and {% author eric %}
-</p>
 
 <p><strong>June 27 @ 9:30am - 11:30am</strong><br/><a href="https://www.eventbrite.com/e/intro-to-apis-working-with-urls-json-apis-and-open-data-without-writing-any-code-in-person-registration-12028636977">Register Now</a></p>
 

--- a/_posts/2014-07-15-hot-off-the-press-18fs-api-standards.html
+++ b/_posts/2014-07-15-hot-off-the-press-18fs-api-standards.html
@@ -14,9 +14,6 @@ tags:
 - how we work
 
 ---
-<p class="authors">
-  By {% author alan %} and {% author eric %}
-</p>
 
 <p>We recently released the first version of our <a href="https://github.com/18F/api-standards">API Standards</a> — a set of recommendations and guidelines for API production. It is our intention that every 18F API meet these standards, to help us ensure a baseline quality and consistency across all APIs we offer now and in the future.</p><!-- more -->
 

--- a/_posts/2014-07-16-midas-a-marketplace-for-innovation-in-government.html
+++ b/_posts/2014-07-16-midas-a-marketplace-for-innovation-in-government.html
@@ -17,9 +17,6 @@ tags:
 - platform
 
 ---
-<p class="authors">
-  By {% author joe %}, 18F and Matt Chessen, Department of State
-</p>
 
 <p><a href="https://github.com/18f/midas">Midas</a> is an online platform that brings to life the vision of an &#8220;Innovation Toolkit&#8221; for government. It is a marketplace of skill building opportunities which matches people to projects that they&#8217;re passionate about. You can think of it as &#8220;<a href="https://www.kickstarter.com" title="kickstarter">kickstarter</a> for people&#8217;s time&#8221;.</p>
 

--- a/_posts/2014-07-23-take-a-gander-at-our-developer-page.html
+++ b/_posts/2014-07-23-take-a-gander-at-our-developer-page.html
@@ -15,9 +15,6 @@ tags:
 - /developer
 
 ---
-<p class="authors">
-  by {% author gray %}
-</p>
 
 <p>A growing trend both inside government and outside is to have a simple welcoming page for outside developers who may be interested in your team’s efforts. This material is <a href="https://18f.gsa.gov/2014/05/29/announcing-the-developer-program-a-new-hub-for/">often located</a> at <em>website.gov/developer</em> <a href="#footnote-1" id="back-1"><sup>1</sup></a> and points visitors to technical material that developers may be interested in, especially APIs.Collecting technical documentation in one place facilitates the developer experience, ensuring that they can find and begin using APIs with as little friction as possible.</p>
 

--- a/_posts/2014-07-29-18f-an-open-source-team.html
+++ b/_posts/2014-07-29-18f-an-open-source-team.html
@@ -18,8 +18,6 @@ tags:
 - policy
 
 ---
-<p class="authors">by {% author majma %} and {% author eric %}</p>
-
 <p>At 18F, we place a premium on developing digital tools and services in the open. This means contributing our source code back to the community, actively repurposing our code across projects, and contributing back to the open source tools we use. For a variety of reasons, we believe that doing so improves the final product we create. It is because of this that <a href="https://github.com/18F/open-source-policy/blob/master/policy.md">our policy</a> is to:</p>
 
 <!-- more -->

--- a/_posts/2014-07-31-working-in-public-from-day-1.html
+++ b/_posts/2014-07-31-working-in-public-from-day-1.html
@@ -15,9 +15,6 @@ tags:
 - how we work
 
 ---
-<p class="authors">
-  by {% author eric %}
-</p>
 
 <p>In the wide world of software, maybe you&#8217;ve heard someone say this, or maybe you&#8217;ve said it yourself: <em>"I&#8217;ll open source it after I clean up the code; it&#8217;s a mess right now."</em></p>
 

--- a/_posts/2014-08-12-the-contributors-guide-to-18f-code-for-the-common.html
+++ b/_posts/2014-08-12-the-contributors-guide-to-18f-code-for-the-common.html
@@ -15,9 +15,6 @@ tags:
 - public service
 
 ---
-<p class="authors">
-  by {% author robert %}
-</p>
 
 <h2>Introduction</h2>
 

--- a/_posts/2014-08-21-creating-an-open-fec.html
+++ b/_posts/2014-08-21-creating-an-open-fec.html
@@ -20,9 +20,6 @@ tags:
 - open data
 
 ---
-<p class="authors">
-  by {% author majma %}, {% author sean %}, {% author manger %}, {% author victor %}, and {% author amos %}
-</p>
 
 <p>Campaign finance information is not very approachable, even when made available as open data. The laws that regulate how money can be spent around elections are important to our democracy, but sometimes it&#8217;s difficult to understand how these laws apply. Between Senate, House, and Presidential campaigns, thousands of people run for office on a regular basis (every two years for the House of Representatives, every six years for the Senate, and every four years for the Presidency).</p>
 

--- a/_posts/2014-09-04-a-new-look-at-the-freedom-of-information-act.html
+++ b/_posts/2014-09-04-a-new-look-at-the-freedom-of-information-act.html
@@ -23,10 +23,6 @@ authors:
 
 ---
 
-<p class="authors">
-  by Jackie Kazil, Shashank Khandelwal, {% author majma %}, {% author eric %}, and {% author victor %}
-</p>
-
 <p>There are many ways the public can get information from the Federal Government. For example, you can check out data.gov to find scores of datasets and APIs, agency websites for information about their work, or other important information in online FOIA Libraries.</p>
 
 <!-- more -->

--- a/_posts/2014-09-08-the-encasement-strategy-on-legacy-systems-and-the.html
+++ b/_posts/2014-09-08-the-encasement-strategy-on-legacy-systems-and-the.html
@@ -15,9 +15,6 @@ tags:
 - api
 - how we work
 ---
-<p class="authors">
-  by {% author robert %} with illustrations by {% author mhz %}
-</p>
 
 <p>In 1986 a nuclear reactor known as <a href="https://en.wikipedia.org/wiki/Chernobyl_disaster">Chernobyl</a> released harmful radioactivity which spread over much of the western USSR and Europe. The core of this reactor remains a glowing, ineradicable mass of deadly radioactive lava in the middle of a large Exclusion Zone unfit for human habitation.</p>
 

--- a/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
+++ b/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
@@ -99,7 +99,7 @@ tags:
 ---
 ```
 
-Because we're running Jekyll on our own servers, we can also make our own custom plugins. (While Jekyll works on GitHub Pages, most Jekyll plugins sadly do not.) Since we have our authors [captured as data](https://github.com/18F/18f.gsa.gov/blob/staging/_data/authors.yml), we wrote a [simple plugin](https://github.com/18F/18f.gsa.gov/blob/staging/_plugins/author.rb) to add a `lookup` filter to our templates using that loops through a data file.
+Because we're running Jekyll on our own servers, we can also make our own custom plugins. (While Jekyll works on GitHub Pages, most Jekyll plugins sadly do not.) Since we have our authors [captured as data](https://github.com/18F/18f.gsa.gov/blob/staging/_data/authors.yml), we wrote a [simple plugin](https://github.com/18F/18f.gsa.gov/blob/staging/_plugins/author.rb) to add a `lookup` filter to our templates using that loops through a data file. (**Note**: We've since rewritten our plugin to [generate bylines automatically](https://github.com/18F/18f.gsa.gov/issues/633).)
 
 ```html
 <p class="authors">

--- a/_posts/2014-11-26-how-to-use-more-open-source.md
+++ b/_posts/2014-11-26-how-to-use-more-open-source.md
@@ -15,9 +15,6 @@ tags:
 description: The history of open source software is a record of steadily turning tremendously expensive custom-built solutions into freely available infrastructure that you can simply take for granted. What once were astoundingly sophisticated, expensive human endeavors have become open source tools you can drop into place in your project on a whim.
 
 ---
-<p class="authors">
-by {% author robert %}, and {% author eric %}
-</p>
 
 The history of open source software is a record of steadily turning tremendously expensive custom-built solutions into freely available infrastructure that you can simply take for granted. What once were astoundingly sophisticated, expensive human endeavors have become open source tools you can drop into place in your project on a whim.
 


### PR DESCRIPTION
There were a little over 20 remaining duplicate bylines, where `<p class="authors">` bylines had not been removed.

I adjusted the `_authors.yml` file for Matt Chessen, so as to keep his original byline description. In a couple of cases, I moved the "cross-posted from" language to the bottom of the post in a little italicized paragraph.

I also updated our webhooks post that talked about our authors plugin, to mention that we've since changed it and linked to the relevant issue.

Fixes #998.