### PR TITLE
Takes out the back link on /tags archives

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -4,7 +4,6 @@ layout: bare
 
 <section>
 
-  <nav class="back"><a href="/news"><i class="fa fa-chevron-left"></i><i class="fa fa-chevron-left"></i> back to all blog posts</a></nav>
   <h1>{{ page.posts | size }} post tagged {{ page.title }}</h1>
 
   <div class="container blog-entry {{tag}}" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">


### PR DESCRIPTION
We already have a link to /blog in the global nav menu. Will update this if I find more that we missed but this might be the last one.