### PR TITLE
adding a redirect for /developers

### DIFF
--- a/pages/developers.md
+++ b/pages/developers.md
@@ -1,0 +1,8 @@
+---
+layout: bare
+permalink: /developers/
+---
+
+<META http-equiv="refresh" content="0;URL=https://18f.gsa.gov/developer/">
+
+This page is redirecting to the [18F Developer Hub].  If the page doesn't not redirect you automatically, please <a href="https://18f.gsa.gov/developer/">click here</a>.  


### PR DESCRIPTION
It's a small but simple best practice that you want both `x.gov/developer` and `x.gov/developers` to arrive at the developer hub since it's easy for folks to misremember which it is and get a 404 if they are wrong.  

Since this was [discussed](https://github.com/18F/18f.gsa.gov/issues/115) a year ago, we've updated our practices and [this method of offering redirects is allowable](https://18f.slack.com/archives/g-accessibility/p1432221216000214).  

This pull request should result in `18f.gsa.gov/developers` redirecting to `18f.gsa.gov/developer` instead of 404ing.  

https://18f.gsa.gov/developer/