### PR TITLE
Fix FEC blog post JSON formatting

### DIFF
--- a/_posts/2015-07-15-openfec-api-update.md
+++ b/_posts/2015-07-15-openfec-api-update.md
@@ -162,23 +162,17 @@ when sorting by `contributor_receipt_date`, on the schedule\_a
 endpoint, you might receive a page of results with the following
 pagination information:
 
-```
-pagination: {
-
-    pages: 2152643,
-
-    per_page: 20,
-
-    count: 43052850,
-
-    last_indexes: {
-
-        last_index: 230880619,
-
-        last_contributor_receipt_date: "2014-01-01"
-
+```json
+{
+  "pagination": {
+    "pages": 2152643,
+    "per_page": 20,
+    "count": 43052850,
+    "last_indexes": {
+        "last_index": 230880619,
+        "last_contributor_receipt_date": "2014-01-01"
     }
-
+  }
 }
 ```
 


### PR DESCRIPTION
This PR turns this:

![screenshot from 2015-07-16 14 49 19](https://cloud.githubusercontent.com/assets/4592/8732182/dbbf9d04-2bc9-11e5-9723-461f598e5368.png)

Into this:

![screenshot from 2015-07-16 14 49 00](https://cloud.githubusercontent.com/assets/4592/8732171/d1bc5342-2bc9-11e5-8bf3-9733941e6078.png)
