### PR TITLE
Adds the `devops` tag to Diego's post about cloudfoundry

### DIFF
--- a/_posts/2015-05-07-layering-innovation.md
+++ b/_posts/2015-05-07-layering-innovation.md
@@ -8,6 +8,7 @@ tags:
 - developer
 - coding
 - how we work
+- devops
 excerpt: "At 18F, we're changing the way government thinks about software, all the way to provisioning and deployment. To do that, we implemented an open source platform as a service for our developers. Here’s a look at how we created it."
 description: "At 18F, we're changing the way government thinks about software, all the way to provisioning and deployment. To do that, we implemented an open source platform as a service for our developers. Here’s a look at how we created it."
 image: /assets/blog/layering-innovation/layer_cake.jpg


### PR DESCRIPTION
I tried to find this post about devops by going to 18f.gsa.gov/tags/devops and found nothing, so I added the devops tag. Plz merge.