### PR TITLE
Skip links and happy meals

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,4 @@
-<a href="#top" class="skips">Skip to main content</a>
+<a href="#main" class="skips">Skip to main content</a>
 <nav class="global-nav {% if page.layout == 'default' %} homepage {% endif %}">
   <a href="#" class="toggle">Menu</a>
   <a href="#" class="toggle hidden">Close</a>

--- a/_layouts/bare.html
+++ b/_layouts/bare.html
@@ -11,7 +11,7 @@
 
   {% include logo.html %}
 
-  <div class="bare-content" role="main" itemscope itemprop="mainContentOfPage">
+  <div id="main" class="bare-content" role="main" itemscope itemprop="mainContentOfPage">
     {{ content }}
   </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 
 {% include flag.html %}
 {% include nav.html %}
-  <div role="main" itemscope itemprop="mainContentOfPage">
+  <div id="main" role="main" itemscope itemprop="mainContentOfPage">
     {{ content }}
   </div>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,7 @@
 	{% include nav.html %}
   {% include logo.html %}
   {% include headline.html %}
-  <div class="content" role="main" itemscope itemprop="mainContentOfPage">
+  <div id="main" class="content" role="main" itemscope itemprop="mainContentOfPage">
     {{ content }}
   </div>
     {% include sidebar.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@
 <section class="container bare">
 	{% include nav.html %}
 	{% include logo.html %}
-  <div class="bare-content" role="main" itemscope itemprop="mainContentOfPage">
+  <div id="main" class="bare-content" role="main" itemscope itemprop="mainContentOfPage">
 
     <section class="blog-posting" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
 

--- a/_layouts/press.html
+++ b/_layouts/press.html
@@ -9,7 +9,7 @@
 	{% include nav.html %}
   {% include logo.html %}
   {% include headline.html %}
-  <div class="content" role="main" id="top" itemscope itemprop="mainContentOfPage">
+  <div class="content" role="main" id="top main" itemscope itemprop="mainContentOfPage">
     <a href="#toc" class="skips">Table of contents</a>
     {{ content }}
     {% for item in site.press %}

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -10,7 +10,7 @@
 	{% include nav.html %}
   {% include logo.html %}
   {% include headline.html %}
-  <div class="content" role="main" itemscope itemprop="mainContentOfPage">
+  <div id="main" class="content" role="main" itemscope itemprop="mainContentOfPage">
     {% if content.size > 0 %}{{ content }}
 
     {% else %}We haven't gotten to filling in {{ page.first_name }}'s

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -6,11 +6,11 @@
 <body itemscope itemtype="http://schema.org/WebPage">
 
 {% include flag.html %}
-<section id ="team" class="container bare">
+<section id="team" class="container bare">
 	{% include nav.html %}
       {% include logo.html %}
 
-      <div class="team-content" role="main" itemscope itemprop="mainContentOfPage">
+      <div id="main" class="team-content" role="main" itemscope itemprop="mainContentOfPage">
         {{ content }}
       </div>
 

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -69,6 +69,9 @@ $tiniest: new-breakpoint(max-width 390px);
 	width:1px;
 	height:1px;
 	overflow:hidden;
+	&:focus {
+		border: 1px $blue;
+	}
 }
 
 // Splash

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -71,6 +71,10 @@ $tiniest: new-breakpoint(max-width 390px);
 	overflow:hidden;
 	&:focus {
 		border: 1px $blue;
+		left: 0;
+		height: auto;
+		width: auto;
+		background: white;
 	}
 }
 
@@ -308,7 +312,7 @@ $tiniest: new-breakpoint(max-width 390px);
 				color: $dark-gray;
 				text-decoration: none;
 				padding: 1em 2em;
-				&:hover {
+				&:hover, &:focus {
 					background-color: $medium-blue;
 					color: white;
 				}


### PR DESCRIPTION
I don't know what [this idiot](https://github.com/gboone) was thinking when he did the skip links [the first time 'round](https://github.com/18F/18f.gsa.gov/commit/6c79ff9833ce1997528144f154c4e2c74fc2e207#diff-70c103dc160c67e7a579206a58d26b94) but they're way better now.

This PR fixes the skip link target and makes it visible on `:focus`. It also adds a proper `:focus` state to the global nav links and properly anchors the main content section on all layouts. This should be a major improvement for users who navigate the page with a keyboard.