### PR TITLE
template page already puts a period after cta

### DIFF
--- a/_data/services.yaml
+++ b/_data/services.yaml
@@ -2,7 +2,7 @@
   display: Delivery
   link: /delivery
   description: "Delivery is at the heart of what we do. Our team of designers and developers work to transform government services by building world-class software products and raising standards of software development throughout the government. Learn more about our products by visiting our <a href='/dashboard'>dashboard</a> and you can find more information about <a href='https://pages.18f.gov/guides'>our standards and capabilities</a> through our guides."
-  cta: <a href='/dashboard'>what we're building and how we're doing it.</a>
+  cta: <a href='/dashboard'>what we're building and how we're doing it</a>
 -
   display: Consulting
   link: /consulting


### PR DESCRIPTION
https://18f.gsa.gov/ shows "doing it.." instead of "doing it."