### PR TITLE
Changes `projects` tag to `our projects`

### DIFF
--- a/_posts/2014-03-31-announcing-fbopen-government-opportunities-made-easier.html
+++ b/_posts/2014-03-31-announcing-fbopen-government-opportunities-made-easier.html
@@ -11,7 +11,7 @@ authors:
 - alison
 
 tags:
-- products
+- our products
 - fbopen
 - procurement
 - api


### PR DESCRIPTION
I think this is the only post using `products` and not `our projects`. I'd also be open to renaming "our projects" (or adding a new tag) to "our products" but the latter seems less inclusive somehow. Thoughts? @18F/blog 