### PR TITLE
Use new centrally hosted DAP code

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -20,8 +20,8 @@
 <![endif]-->
 
 <!--
- IE10 JS targeting: http://stackoverflow.com/a/17099988
- IE11 JS targeting: http://stackoverflow.com/a/17447695
+ IE10 JS targeting: https://stackoverflow.com/a/17099988
+ IE11 JS targeting: https://stackoverflow.com/a/17447695
 -->
 <script type="text/javascript">
   window._ie10 = ("onpropertychange" in document && !!window.matchMedia);
@@ -43,11 +43,11 @@
   // anonymize user IPs (chops off the last IP triplet)
   ga('set', 'anonymizeIp', true);
 
-  // forces SSL even if the page were somehow loaded over http://
+  // forces HTTPS even if the page were somehow loaded over http://
   ga('set', 'forceSSL', true);
 
   ga('send', 'pageview');
 </script>
 
 <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js?agency=GSA"></script>
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>


### PR DESCRIPTION
This changes our DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.