### PR TITLE
Remove "independent agency" callouts

### DIFF
--- a/_posts/2014-12-18-a-complete-list-of-gov-domains.md
+++ b/_posts/2014-12-18-a-complete-list-of-gov-domains.md
@@ -28,7 +28,7 @@ We're happy to say that the `.gov` registry is now releasing the **entire set of
 
 <!-- more -->
 
-Some background: the `.gov` registry is a [centrally operated top-level domain](https://www.dotgov.gov) managed by the [Office of Government-wide Policy](http://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](http://www.gsa.gov/) (GSA), an independent federal agency.  The associated [DotGov.gov](http://www.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
+Some background: the `.gov` registry is a [centrally operated top-level domain](https://www.dotgov.gov) managed by the [Office of Government-wide Policy](http://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](http://www.gsa.gov/) (GSA).  The associated [DotGov.gov](http://www.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
 
 You can download the complete `.gov` domain list in CSV form here:
 

--- a/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
+++ b/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
@@ -23,7 +23,7 @@ The U.S. federal government now has a public dashboard and dataset for its web t
 
 <a href="https://analytics.usa.gov" target="_blank"><img src="/assets/blog/dap/screen.png" title="Screenshot of the new Digital Analytics Program public dashboard" style="border: 1px solid #ddd" /></a>
 
-This data comes from a unified [Google Analytics](https://www.google.com/analytics/) profile that is managed by the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/), which (like 18F) is a team inside of the [General Services Administration](https://en.wikipedia.org/wiki/General_Services_Administration), an independent federal agency.
+This data comes from a unified [Google Analytics](https://www.google.com/analytics/) profile that is managed by the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/), which (like 18F) is a team inside of the [General Services Administration](https://en.wikipedia.org/wiki/General_Services_Administration).
 
 18F worked with the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/), the [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service), and the White House to build and host the dashboard and its public dataset.
 


### PR DESCRIPTION
GSA is an "independent establishment", but not an independent agency in the sense as the FTC or FCC -- unlike the FTC or FCC Commissioners, the Administrator serves at the pleasure of the President. There's some confusion about this, in part because of [GAO's ambiguous mixing](http://www.gao.gov/browse/agency/Independent_Agencies) of "independent establishments" and "independent regulatory agencies" as "independent agencies". Better to just leave it out entirely.