### PR TITLE
Tag bugs

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -3,8 +3,8 @@ layout: bare
 ---
 
 <section>
-
-  <h1>{{ page.posts | size }} post tagged {{ page.title }}</h1>
+  {% assign numberof = page.posts | size %}
+  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged {{ page.title }}</h1>
 
   <div class="container blog-entry {{tag}}" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
     {% for post in page.posts %}

--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -47,7 +47,7 @@ module Jekyll
         list = "<#{@heading}>#{first_name}'s blog posts:</#{@heading}>"
         list << "<ul>"
         for a in authored
-          list << "<li><a href='#{site_url}/#{a.url}'>#{a.title}</a></li>"
+          list << "<li><a href='#{site_url}#{a.url}'>#{a.title}</a></li>"
         end
         list << "</ul>"
       end


### PR DESCRIPTION
Fixes a couple small bugs on individual tag pages and individual bio pages.
Tags:
Even if the page had multiple posts, the copy read "_x_ post" now they say "_x_ posts" if _x_ is > 1.
Profiles:
URLs to blog posts written by an author were formatted with an extra `/` like `https://18f.gsa.gov//post-name` Now it's just the one slash like normal