### PR TITLE
Fixes headlines and other stylings

### DIFF
--- a/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
+++ b/_posts/2015-01-08-an-open-source-tool-for-easier-database-testing.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "An Open Source Tool for Easier Database Testing"
+title: "An open source tool for easier database testing"
 date: 2015-01-13
 image: /assets/blog/db-testing-tool/cut_sweater.jpg
 description: "rdbms-subsetter, a new utility from 18F's work for generating test databases."
-excerpt: "18F is dedicated to spreading modern software techniques like rigorous automated testing throughout the Federal government; we want to showcase how solid testing enables rapid, high-quality development. When the product is based on a large relational database, this poses a dilemma: the full production dataset is too unwieldy to duplicate to the test and development environments."
+excerpt: "18F is dedicated to spreading modern software techniques like rigorous automated testing throughout the federal government; we want to showcase how solid testing enables rapid, high-quality development. When the product is based on a large relational database, this poses a dilemma: the full production dataset is too unwieldy to duplicate to the test and development environments."
 
 authors:
  - catherine
@@ -19,7 +19,7 @@ tags:
 
 ---
 18F is dedicated to spreading modern software techniques like
-rigorous automated testing throughout the Federal government;
+rigorous automated testing throughout the federal government;
 we want to showcase how solid testing enables rapid, high-quality
 development.
 
@@ -86,8 +86,8 @@ and code contributions.
 Since we're 18F, filing any bugs you find &#8212; and optionally writing tests for them, or even fixing them &#8212; is not just encouraged, it's downright patriotic.
 _(cue inspiring music)_
 
-For open-source enthusiasts, the potential to release work
-as open-source projects is exciting and motivating.  At 18F,
+For open source enthusiasts, the potential to release work
+as open source projects is exciting and motivating.  At 18F,
 our [Default to Open](https://github.com/18F/open-source-policy/)
 policy means that releasing our work isn't a favor to beg
 management for.  It's our everyday way of working &#8212; no questions asked and no hoops to jump through &#8212; and one

--- a/_posts/2015-01-08-creating-a-federal-marketplace-for-agile-delivery-services.md
+++ b/_posts/2015-01-08-creating-a-federal-marketplace-for-agile-delivery-services.md
@@ -48,6 +48,6 @@ To encourage healthy competition, we’re going to do two things: use simple and
 ##Small Business Friendly
 Small businesses are the drivers of economic growth in the U.S. Agile methodologies encourage work to be done in small, rapid, independent increments. When combined with modular approaches to contracting, this opens up a whole new world of contract opportunities for small businesses. For example, rather than compete work as one big, long contract (e.g., $50M over five years) that typically only large businesses can execute on, break it into many small, short-duration contracts (e.g., ten $5M contracts of three to six months in duration). This has the effect of leveling the competitive playing field for not just small companies, but businesses of all sizes. Federal buyers will be strongly encouraged to structure their acquisitions this way. For those who need help, the services of [18F Consulting](https://18f.gsa.gov/consulting/) will be made available to them.
 
-##Contact Us
+##Contact us
 
 If you have any questions about the upcoming Agile Delivery Services Multiple Award BPA and industry day event, please refer to the point of contact for this program in the [RFI](https://www.fbo.gov/notices/e0807fc8a69115f0e352f6f0c135697a).

--- a/_posts/2015-01-16-open-source-for-good-government.md
+++ b/_posts/2015-01-16-open-source-for-good-government.md
@@ -1,5 +1,5 @@
 ---
-title: Open Source for Good Government
+title: Open source for good government
 date: '2015-01-16'
 layout: post
 image: /assets/blog/join-us/18f_govuk.png

--- a/_posts/2015-01-21-join-us.md
+++ b/_posts/2015-01-21-join-us.md
@@ -1,5 +1,5 @@
 ---
-title: Join Us
+title: Join us
 date: '2015-01-21'
 layout: post
 
@@ -17,7 +17,7 @@ description: We've grown quickly since early 2014. Ideas like open source, user-
 
 excerpt: The U.S. Digital Service is a collection of teams across the federal government, working to bring skilled technologists into public service. We are thrilled to be part of this effort, and will continue to lead the charge for making easy things easy and hard things possible.
 ---
-**Update:** You can read more about our hiring process [here](https://pages.18f.gov/joining-18f/).
+**Update:** Read more about our hiring process [here](https://pages.18f.gov/joining-18f/).
 
 Earlier today, our friend Mikey Dickerson from over at the U.S. Digital Service headquarters [posted on Medium](https://medium.com/@USDigitalService/an-improbable-public-interest-start-up-6f9a54712411) about the "Improbable Public Interest Start Up" he helped create inside the White House. The [U.S. Digital Service](https://wh.gov/usds) is a collection of teams across the federal government, working to bring skilled technologists into public service. We are thrilled to be part of this effort, and will continue to lead the charge for making easy things easy and hard things possible.
 

--- a/_posts/2015-02-10-a-story-of-an-agile-workshop.md
+++ b/_posts/2015-02-10-a-story-of-an-agile-workshop.md
@@ -1,5 +1,5 @@
 ---
-title: A Story of an Agile Workshop
+title: A Story of an agile workshop
 date: '2015-02-11'
 layout: post
 image: /assets/blog/agile-workshop/workshop3.jpg
@@ -17,8 +17,7 @@ excerpt: "The clock was ticking as I stated the single solitary rule: We will ha
 ---
 by {% author robert %} and {% author blacktm %}
 
-The Agile Manifesto:
---------------------
+## The Agile Manifesto:
 
 "*…we have come to value:*
 
@@ -34,8 +33,7 @@ The Agile Manifesto:
 items on the left more.*" — [The Agile
 Manifesto](http://www.agilemanifesto.org/)[](http://www.agilemanifesto.org/)
 
-The Stage is Set
-----------------
+## The stage is set
 
 A week before Christmas, the Social Security Administration made an
 extraordinary effort to build better software to process disability
@@ -88,8 +86,7 @@ observers sat in the back of the room.
 
 ![The room: developers on left, the demo area, and product owners on right.](/assets/blog/agile-workshop/workshop3.JPG)
 
-The First Sprint Brought A Quick Win
-------------------------------------
+## The first sprint brought a quick win
 
 I was in a hurry to get the developers started — in fact, I cut people
 off abruptly and a little rudely in an effort to do so. The product team
@@ -121,8 +118,7 @@ bug and reject the story.” The product team voted to pass the story. The
 loud applause for the developers was a great example of Agile tenet \#1:
 **Value individuals and interactions** over processes and tools.
 
-The Second Sprint And Velocity
-------------------------------
+## The second sprint and velocity
 
 The new screen was good, but made it quite clear that the text was
 unpleasantly crowded. We needed to add some padding. This was
@@ -160,8 +156,7 @@ snacks I'd brought had been devoured by now. I learned something: Hummus
 is a terrible snack for this kind of thing. It’s messy, and you don’t
 want to bring a knife through security.
 
-The Third Sprint
-----------------
+## The third sprint
 
 In the final sprint, one story was well underway but wasn't quite done.
 I made a show of moving from the “In Test” column back to the “In
@@ -173,8 +168,7 @@ hardest three hours — and the most rewarding — that a software team will
 ever work. We sat in the odd glow of exhaustion and exhilaration as we
 began the retrospective.
 
-The Retrospective
------------------
+## The retrospective
 
 I was scribing on big flip-chart sheets as the big bosses walked in. The
 Chief Program Officer and her Deputy, Terri and John, had returned. We
@@ -199,8 +193,8 @@ really want as rapidly as possible by valuing individuals and
 interactions, working software, customer collaboration, and responding
 to change.
 
-Running Your Own Agile Workshop
--------------------------------
+## Running your own agile workshop
+
 We’ve previously published a guide to running your own [3-Sprint Agile
 Workshop](https://18f.gsa.gov/2014/10/21/how-to-run-your-own-3-sprint-agile-workshop/).
 

--- a/_posts/2015-02-12-highlights-from-the-agile-delivery-services-industry-day-events.md
+++ b/_posts/2015-02-12-highlights-from-the-agile-delivery-services-industry-day-events.md
@@ -1,5 +1,5 @@
 ---
-title: Highlights from the Agile Delivery Services Industry Day Events
+title: Highlights from the Agile Delivery Services Industry Day events
 date: '2015-02-12'
 layout: post
 image: /assets/blog/agile-day/agile-day.jpg
@@ -9,8 +9,8 @@ tags:
 - events
 authors:
 - chrisc
-description: 18F and GSA’s Office of Integrated Technology Services (ITS) held a pair of Industry Day events for our upcoming Agile Delivery Services blanket purchase agreement (BPA). Over 700 people registered for the events, showing just how much interest there is from the private sector in this new BPA.
-excerpt: 18F and GSA’s Office of Integrated Technology Services (ITS) held a pair of Industry Day events for our upcoming Agile Delivery Services blanket purchase agreement (BPA). Over 700 people registered for the events, showing just how much interest there is from the private sector in this new BPA.
+description: 18F and GSA’s Office of Integrated Technology Services (ITS) held a pair of events for our upcoming Agile Delivery Services blanket purchase agreement (BPA). Over 700 people registered for the events, showing just how much interest there is from the private sector in this new BPA.
+excerpt: 18F and GSA’s Office of Integrated Technology Services (ITS) held a pair of events for our upcoming Agile Delivery Services blanket purchase agreement (BPA). Over 700 people registered for the events, showing just how much interest there is from the private sector in this new BPA.
 ---
 
 By {% author chrisc %}
@@ -41,7 +41,7 @@ webinar, you can [*view a recording of
 it*](http://gsafas.adobeconnect.com/p9gcfd4n0rs/), and we should have
 video of the afternoon session shortly.
 
-It was great to see so many people in the GSA Auditorium to hear keynote
+It was great to see so many people in the GSA auditorium to hear keynote
 speakers Adam Neufeld (GSA Chief of Staff), Kay Ely (Director of GSA IT
 Schedule 70), Greg Godbout (Executive Director of 18F), and Ryan
 Panchadsaram (U.S. Deputy Chief Technology Officer) discuss the value of

--- a/_posts/2015-02-17-three-18f-products-that-will-help-your-workplace.md
+++ b/_posts/2015-02-17-three-18f-products-that-will-help-your-workplace.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 
-title: "Three 18F Products That Will Help Your Workplace"
+title: "Three 18F products that will help your workplace"
 
 image: /assets/blog/three-products/hub.png
 

--- a/_posts/2015-02-18-steve-portigal-pre-event-qa-post.md
+++ b/_posts/2015-02-18-steve-portigal-pre-event-qa-post.md
@@ -1,5 +1,5 @@
 ---
-title: Five Questions with Steve Portigal
+title: Five questions with steve portigal
 date: '2015-02-18'
 layout: post
 image: /assets/blog/speaker-series/portigal.jpg
@@ -15,16 +15,16 @@ authors:
 
 
 
-description: "Since October, 18F has been bringing in noted individuals from the software development world to discuss their work, and we’re excited to kick off a new, design-focused series this Friday, February 20 (10:30 AM ET) with Steve Portigal, author of Interviewing Users: How to Uncover Compelling Insights and host of the Dollars to Donuts podcast."
+description: "Since October, 18F has been bringing in noted individuals from the software development world to discuss their work, and we’re excited to kick off a new, design-focused series this Friday, February 20 (10:30 a.m. ET) with Steve Portigal, author of Interviewing Users: How to Uncover Compelling Insights and host of the Dollars to Donuts podcast."
 
-excerpt: "Since October, 18F has been bringing in noted individuals from the software development world to discuss their work, and we’re excited to kick off a new, design-focused series this Friday, February 20 (10:30 AM ET) with Steve Portigal, author of Interviewing Users: How to Uncover Compelling Insights and host of the Dollars to Donuts podcast."
+excerpt: "Since October, 18F has been bringing in noted individuals from the software development world to discuss their work, and we’re excited to kick off a new, design-focused series this Friday, February 20 (10:30 a.m. ET) with Steve Portigal, author of Interviewing Users: How to Uncover Compelling Insights and host of the Dollars to Donuts podcast."
 ---
 
 ![Steve Portigal, author of Interviewing Users: How to Uncover Compelling Insights](/assets/blog/speaker-series/portigal.jpg)
 
 Since October, 18F has been bringing in noted individuals from the
 software development world to discuss their work, and we’re excited to
-kick off a new, design-focused series this Friday, February 20 (10:30 AM
+kick off a new, design-focused series this Friday, February 20 (10:30 a.m.
 ET). We’re inviting a number of influential designers to share their
 unique perspective with the 18F team, and with you.
 

--- a/_posts/2015-02-24-how-to-use-github-and-the-terminal-a-guide.md
+++ b/_posts/2015-02-24-how-to-use-github-and-the-terminal-a-guide.md
@@ -1,5 +1,5 @@
 ---
-title: "How To Use GitHub and the Terminal: A Guide"
+title: "How to use GitHub and the terminal: a guide"
 layout: post
 date: 2015-03-03
 authors:
@@ -17,7 +17,7 @@ description: "At 18F we hire people from many different backgrounds and each new
 image: /assets/blog/github-tutorial/image21.png
 ---
 
-We’ve written before how everything we do is open [from day 1](https://18f.gsa.gov/2014/07/31/working-in-public-from-day-1/). One of the ways we do that is by building all of our products&mdash;from [our blog](https://github.com/18F/18f.gsa.gov/) and [our dashboard](https://github.com/18F/dashboard) to a [new website](https://github.com/18F/letgirlslearn) for the Peace Corps’ Let Girls Learn Initiative&mdash;using GitHub. We do this so that the public can see the code we’re working on, offer feedback, and copy or fork that code for their own projects. If you’ve never used GitHub before, it can be a little intimidating, so we’d like to share the tutorial our own new employees use when they start with 18F.
+We’ve written before how everything we do is open [from day one](https://18f.gsa.gov/2014/07/31/working-in-public-from-day-1/). One of the ways we do that is by building all of our products&mdash;from [our blog](https://github.com/18F/18f.gsa.gov/) and [our dashboard](https://github.com/18F/dashboard) to a [new website](https://github.com/18F/letgirlslearn) for the Peace Corps’ Let Girls Learn Initiative&mdash;using GitHub. We do this so that the public can see the code we’re working on, offer feedback, and copy or fork that code for their own projects. If you’ve never used GitHub before, it can be a little intimidating, so we’d like to share the tutorial our own new employees use when they start with 18F.
 
 We hire people from many different backgrounds and each new employee brings a different level of comfort with the specific tools we use on our various projects. The team that runs the 18F website recently started writing down the tools and processes that we use to update the blog and the code that runs the site.
 
@@ -40,7 +40,7 @@ If you have an alternative way of doing any of these steps — or have ways to m
 
 **What you need to get started:** [a GitHub account](https://github.com/join) and Mac OS X. These instructions are primarily for Macs, but most of the instructions will work the same on a Linux computer. If you are working on Windows, we suggest checking out [this comment](https://github.com/18F/18f.gsa.gov/issues/542#issuecomment-75145417) that was posted to GitHub that details how to make these instructions work for Windows machines.
 
-## Turn Your Mac Into a Web Development Machine
+## Turn your Mac into a web development machine
 
 > Using Linux? You can skip this section.
 
@@ -58,11 +58,11 @@ And you should have a window like this when you open it:
 
 ![Screen shot of blank terminal window](/assets/blog/github-tutorial/terminal-window.png)
 
-* Go to the terminal and paste the following `curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/mac` and press enter.
+* Go to Terminal and paste the following `curl --remote-name https://raw.githubusercontent.com/18F/laptop/master/mac` and press enter.
 
 * Then paste `bash mac 2>&1 | tee ~/laptop.log && source ~/.rvm/scripts/rvm` and press enter. This sets up all of the software you need in order to manage the languages we use at 18F. (For a full list of programs, click [here](https://github.com/18F/laptop)).
 
-## Getting Started With GitHub and the Terminal
+## Getting started With GitHub and the Terminal
 
 > Terminal is a program that lets you send commands to your computer, and the text you pasted above is an example of how those commands work. In this guide, whenever you see text that looks like `this`, you're reading a command. Type the commands exactly as you see them here (or copy and paste them into your Terminal) and always press return at the end.
 
@@ -88,7 +88,7 @@ I like to put all my GitHub projects in the same directory. So **the first thing
 
 ![Screenshot: typing in mkdir code](/assets/blog/github-tutorial/mkdir-code.gif)
 
-## Clone a Repo on Your Computer
+## Clone a repo on your computer
 
 * First, you want to log into GitHub. Go to [https://github.com/login](https://github.com/login) and sign in with your username and password.
 
@@ -116,7 +116,7 @@ In this step we are going to _clone_ the 18f.gsa.gov project to your computer.
 
 > If you run into an error here and you haven't used the Laptop script mentioned above, you need to create what's called an SSH key. You can follow the instructions that are located [here](https://help.github.com/articles/generating-ssh-keys/). (Pro Tip: You type in everything _except_ the `$`.) You only have to do this once. An SSH key is a small file that sits on your computer and tells GitHub who you are. It's kind of like a password your computer types in for you automatically. Every time you use this computer to clone a project or pull/push a project, this SSH key will get used. You will have to do this on every computer you have. So, if you plan to work on these projects on a separate computer, you will need to do this process again.
 
-### Branching and Pull Requests
+### Branching and pull requests
 
 Let's go back to the [18f.gsa.gov](https://github.com/18F/18f.gsa.gov) repo from your web browser.
 
@@ -136,7 +136,7 @@ In the next step we're going to create a branch, and later on, when you make a p
 
 > On the right side, you can also see a list of the existing pull requests and issues. All of the pull requests go to the staging branch. When we merge the pull request to the staging branch, GitHub automatically brings those changes into the project, but does not make them live on https://18f.gsa.gov yet.
 
-In your terminal, enter the following commands:
+In Terminal, enter the following commands:
 
 * `cd 18f.gsa.gov` to change directories to `18f.gsa.gov`.
 * `ls -1F` to see all of the files and folders in the GitHub repo, just as you saw them on GitHub
@@ -150,7 +150,7 @@ This last command will show you a little bit of information about what you're wo
 
 ![Screenshot: how to use git status](/assets/blog/github-tutorial/screenshot5.gif)
 
-## Build the 18F Site
+## Build the 18F site
 
 Let's go ahead and get you ready to build the site.
 
@@ -166,7 +166,7 @@ Let's go ahead and get you ready to build the site.
 
 >**Congratulations! A lot of the steps that you've just done are one time steps. You only have to run the `laptop` script once. You only have to clone the repo once. And you only need to run `./go init` once. Just wanted to keep your morale high. Onward!**
 
-### Create a Branch
+### Create a branch
 
 Okay. Now you're ready to start editing.
 
@@ -190,7 +190,7 @@ Okay. Now you're ready to start editing.
 
 ![Screenshot: git checkout and status](/assets/blog/github-tutorial/screenshot11.gif)
 
-### Edit and Commit a Blog Post
+### Edit and commit a blog post
 
 We're now going to walk you through creating a new blog post for 18f.gsa.gov.
 
@@ -202,13 +202,13 @@ We're now going to walk you through creating a new blog post for 18f.gsa.gov.
 
 ![Screen shot: Saving post in _posts directory](/assets/blog/github-tutorial/image14.png)
 
-### Adding Front Matter
+### Adding front matter
 
 The next step is to add what's called front matter. This is metadata for the blog post: extra information Jekyll uses to build parts of the website. It includes things like the title, authors, description, and date. You add front matter by pasting in the following fields starting on line 1 of your text editor:
 
 ```yaml
 ---
-title: "How the 18F Website Team Uses GitHub: A Tutorial"
+title: "How the 18F website team uses GitHub: a tutorial"
 layout: post
 author:
 - melody
@@ -230,11 +230,11 @@ A [complete explanation for the front-matter](https://github.com/18F/18f.gsa.gov
 
 * When you are done writing, save the post by pressing Command + S.
 
-* And then return back to the Terminal.
+* And then return back to Terminal.
 
 > (Don't worry. You are almost done.)
 
-### Learn How to Make a Pull Request
+### Learn how to make a pull request
 
 * Type `git status` again.
 

--- a/_posts/2015-02-25-We-Are-Hiring.md
+++ b/_posts/2015-02-25-We-Are-Hiring.md
@@ -1,5 +1,5 @@
 ---
-title: We Are Hiring
+title: We are hiring
 layout: post
 image: /assets/blog/were-hiring/18fdc-pif.jpg
 tags:
@@ -12,19 +12,19 @@ authors:
 - shawn
 - hillary
 
-excerpt: "You can find 18F in DC, San Francisco, Chicago, Dayton, and New York. Our rapidly growing team is home to a variety of roles, including these: Software Makers, Experience Designers & Researchers, DevOps, Visual and Interaction Designers, Writers & Content Strategists, Product Managers and whatever other skills you can bring to the team."
+excerpt: "You can find 18F in D.C., San Francisco, Chicago, Dayton, and New York. Our rapidly growing team is home to a variety of roles, including these: Software Makers, Experience Designers & Researchers, DevOps, Visual and Interaction Designers, Writers & Content Strategists, Product Managers and whatever other skills you can bring to the team."
 description: "You can find 18F in DC, San Francisco, Chicago, Dayton, and New York. Our rapidly growing team is home to a variety of roles, including these: Software Makers, Experience Designers & Researchers, DevOps, Visual and Interaction Designers, Writers & Content Strategists, Product Managers and whatever other skills you can bring to the team."
 ---
 **Update:** You can read more about our hiring process [here](https://pages.18f.gov/joining-18f/).
 
-Technology changes fast. People have grown to expect fast, personalized, and user-friendly information and services from the websites and apps they use on a daily basis. But with a shortage of in-house experts, budget limitations, and no quick way to purchase services, it can be hard for the Federal government to meet those same expectations. This is where we (and hopefully you) come in.
+Technology changes fast. People have grown to expect fast, personalized, and user-friendly information and services from the websites and apps they use on a daily basis. But with a shortage of in-house experts, budget limitations, and no quick way to purchase services, it can be hard for the federal government to meet those same expectations. This is where we (and hopefully you) come in.
 
-Built in the spirit of America's top tech startups, 18F is a consultancy and product delivery team **for** the U.S. Government **inside** the U.S. Government. We work with federal agencies to rapidly deploy tools and online services that are reusable, cut costs, and are easier for people and businesses to use.
+Built in the spirit of America's top tech startups, 18F is a consultancy and product delivery team **for** the U.S. government **inside** the U.S. government. We work with federal agencies to rapidly deploy tools and online services that are reusable, cut costs, and are easier for people and businesses to use.
 
-![The 18F Team in DC plus 2014 Presidential Innovation
+![The 18F Team in D.C. plus 2014 Presidential Innovation
 Fellows](/assets/blog/were-hiring/18fdc-pif.jpg)
 
-We’re on a mission to transform the way government builds and buys digital services. We're currently working with more than a dozen different teams across the Federal Government to help them deliver on their missions in a user-centered way. We will accomplish this by:
+We’re on a mission to transform the way government builds and buys digital services. We're currently working with more than a dozen different teams across the federal government to help them deliver on their missions in a user-centered way. We will accomplish this by:
 
 * putting the needs of the American people first;
 * being design-centric, agile, open, and data-driven; and
@@ -38,27 +38,27 @@ Whether you’re near an 18F office in Washington DC, San Francisco, Chicago, or
 
 Our rapidly growing team is home to a variety of roles, including these:
 
-## Software Development
+## Software development
 
-Using modern, open-source web frameworks and tools, our front and back end developers work in small, cross-functional teams, close to user research and product prioritization, to produce functional, scalable web services.
+Using modern, open source web frameworks and tools, our front and back end developers work in small, cross-functional teams, close to user research and product prioritization, to produce functional, scalable web services.
 
-## Infrastructure & Tools
+## Infrastructure and tools
 
 Engineers work to provide developers at 18F (and across the government) with modern infrastructure services and fantastic tooling. Our engineers solve the most difficult problems between development and operations, whether that's debugging an application or architecting an environment. We work on automating everything, removing technical blockers, and constantly increasing everyone's capacity to deliver.
 
-## Experience Design & Research
+## Experience design and research
 
 Our designers research user needs and communicate them to developers, product leads, and agency partners. They create research-based personas, understand information architecture, visualize scenarios, and design workflows based on user feedback.
 
-## Visual & Interaction Design
+## Visual and interaction design
 
 Our designers create wireframes, HTML prototypes, high-fidelity mockups, and more, based on a firm understanding of user needs. They do what it takes to communicate (and sometimes implement) these solutions.
 
-## Writing & Content Strategy
+## Writing and content strategy
 
 Sometimes called content designers, they assess current content needs, work closely with design researchers, and strategize with agency partners to write application copy, marketing collateral, editorial copy, and more.
 
-## Product Management
+## Product management
 
 Product Leads work closely with agency partners to define and prioritize product value in agile cycles. They remove blocks for the team, create and groom backlogs, champion user testing and ensure we are always shipping valuable code.
 
@@ -70,6 +70,6 @@ Not everyone fits into a predefined box. Cross-disciplinary innovators who are p
 
 We’re building a team that looks like the United States, and we don't discriminate based on race, color, religion, sex (including pregnancy and gender identity), national origin, political affiliation, sexual orientation, marital status, disability, genetic information, age, membership in an employee organization, retaliation, parental status, military service, or other non-merit factor. If you have the skills we need, that’s all that matters.
 
-## To Learn More ...
+## Learn more
 
 Visit our [website] (https://18f.gsa.gov/), follow us on [Twitter] (https://twitter.com/18f), or drop us a line at [Join18F@gsa.gov] (mailto:Join18F@gsa.gov)!

--- a/_posts/2015-02-26-Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One.md
+++ b/_posts/2015-02-26-Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One.md
@@ -1,5 +1,5 @@
 ---
-title: "Five Ways to Turn a Bad Idea into a Great One: Steve Portigal Event Recap"
+title: "Five ways to turn a bad idea into a great one: Steve Portigal event recap"
 layout: post
 image: /assets/blog/portigal-event-image/portigalevent.jpg
 tags:

--- a/_posts/2015-02-27-making-procurement-easier-some-questions-for-developer-kaitlin-devine.md
+++ b/_posts/2015-02-27-making-procurement-easier-some-questions-for-developer-kaitlin-devine.md
@@ -1,5 +1,5 @@
 ---
-title: "Making Procurement Easier: Some Questions For Developer Kaitlin Devine"
+title: "Making procurement easier: questions for developer Kaitlin Devine"
 layout: post
 image: /assets/blog/discovery-launch/discovery-dashboard.png
 date: 2015-03-05
@@ -14,12 +14,12 @@ authors:
 - elaine
 - melody
 
-excerpt: "We recently sat down with developer Kaitlin Devine and asked her a few questions about Discovery, a new product designed to make government procurement more efficient."
+excerpt: "We recently sat down with Developer Kaitlin Devine and asked her a few questions about Discovery, a new product designed to make government procurement more efficient."
 description: "We recently sat down with developer Kaitlin Devine and asked her a few questions about Discovery, a new product designed to make government procurement more efficient."
 ---
 
 
-We recently sat down with developer Kaitlin Devine and asked her a few
+We recently sat down with Developer Kaitlin Devine and asked her a few
 questions about 18F and government procurement. Not familiar with the term
 procurement? It basically means buying stuff. A self-described
 “procurement nerd,” Kaitlin has been working on a project to make the
@@ -27,7 +27,7 @@ procurement process a lot more efficient within GSA. It’s called [Discovery](h
 
 **What do you do at 18F and why did you want to work here?**
 
-My name is Kaitlin Devine and I’m the Director of Engineering. I’m also
+My name is Kaitlin Devine and I’m the director of engineering. I’m also
 a Python developer working on a few projects here. What I love most
 about working at 18F is that it’s very new and exciting and there’s a
 lot of opportunity to craft it in your own image if you can or are
@@ -159,7 +159,7 @@ an understanding of the space and of user needs, we were able to say
 **What has the feedback been from the client? What have you heard since
 this has been released?**
 
-We actually did a Demo Day for 18F and this was one of the projects we
+We actually did a demo day for 18F and this was one of the projects we
 demoed and people were really, really enthusiastic about it. One of
 GSA’s main business lines is procurement - we procure things for other
 agencies - so people were really excited about it, because even in it’s

--- a/_posts/2015-03-02-cos-post.md
+++ b/_posts/2015-03-02-cos-post.md
@@ -1,5 +1,5 @@
 ---
-title: New Resources at CareerOneStop
+title: New resources at CareerOneStop
 layout: post
 image: /assets/images/cos.png
 authors:

--- a/_posts/2015-03-04-annoucing-oasis-discovery-making-market-research-easier.md
+++ b/_posts/2015-03-04-annoucing-oasis-discovery-making-market-research-easier.md
@@ -1,5 +1,5 @@
 ---
-title: "Announcing OASIS Discovery: Making Market Research Easier"
+title: "Announcing OASIS Discovery: making market research easier"
 layout: post
 image: /assets/blog/discovery-launch/discovery-dashboard.png
 tags:

--- a/_posts/2015-03-05-Labor-Category-Descriptions-for-Agile-Procurements.md
+++ b/_posts/2015-03-05-Labor-Category-Descriptions-for-Agile-Procurements.md
@@ -1,5 +1,5 @@
 ---
-title: "Labor Category Descriptions for Agile Procurements"
+title: "Labor category descriptions for agile procurements"
 layout: post
 image: ""
 date: 2015-03-10

--- a/_posts/2015-03-06-ux-lessons-learned-from-a-procurement-project.md
+++ b/_posts/2015-03-06-ux-lessons-learned-from-a-procurement-project.md
@@ -1,5 +1,5 @@
 ---
-title: "UX Lessons Learned From A Procurement Project"
+title: "UX lessons learned from a procurement project"
 layout: post
 image: /assets/blog/discovery-launch/discovery-dashboard.png 
 date: 2015-03-06
@@ -93,15 +93,15 @@ more specific line of questions every time we heard something that would
 make us think ‘Oh, we need to follow up on how they manage their
 documents’ or something like that.
 
-**So they would say something like ‘I have trouble managing my
-documents’ and then you would say…**
+**So they would say something like "I have trouble managing my
+documents" and then you would say…**
 
 They wouldn’t always be that explicit about it. A lot of times, you have
 to read into things and probe a little bit and ask specific questions
 and ask users to show you, rather than tell you, because you can’t
 always rely on what people are saying.
 
-If they say ‘This is my problem,’ it may be the case that what they’re
+If they say "This is my problem,"" it may be the case that what they’re
 saying isn’t their problem: it may be a combination of things, or
 something else that they’re not consciously aware of. My job is a
 combination of asking questions, of trying to learn the context of how
@@ -118,7 +118,7 @@ procurement officer’s job is to say that they buy things on behalf of
 the government and, at the end of the day, they are responsible for
 buying that thing at a fair and reasonable price.
 
-**How does Discovery make a contracting officer’s life easier?**
+**How does Ddiscovery make a contracting officer’s life easier?**
 
 Depending on what is being bought, the procurement process can be months
 and maybe even years long. Contracting officers have to write the
@@ -160,7 +160,7 @@ learned that everyone had their own way of completing [task ordering]
 and it wasn’t actually a problem.
 
 **So your client initially thought it was a problem but the people who
-worked with your client said ‘Nope, not a problem?’**
+worked with your client said, "Nope, not a problem?"**
 
 The contracting officers themselves had ways of making task orders.
 Through those conversations, we started to gather evidence that an
@@ -169,8 +169,8 @@ way to conduct market research -- specifically, identifying potential
 vendors and understanding their contract histories and things like that.
 
 So we basically gathered up this evidence and then came back to our
-client and said ‘This is what we discovered and learned and we would
-recommend going in this other direction’ and the client was actually,
+client and said "This is what we discovered and learned and we would
+recommend going in this other direction" and the client was actually,
 really on board with that pivot and going away from his own idea.
 
 **How did user research inform that process?**
@@ -185,8 +185,8 @@ Maybe we would have changed direction eventually, but maybe not.
 Probably not. Because once you’re invested in going in a certain
 direction, you have the snowball effect of everyone’s time and resources
 also being put into the problem. Even in the best of circumstances and
-the best of lean/agile world, it’s hard to go back and say ‘No, this is
-not the right thing to be solving.’
+the best of lean/agile world, it’s hard to go back and say "No, this is
+not the right thing to be solving."
 
 Throughout building the tool, we also used lean UX methodologies. We
 built a working prototype every two weeks and then tested it at the end
@@ -224,7 +224,7 @@ it, so we’re going to collect data and continue building up a user
 community of people we can talk to or interact with about it.
 
 **What would you consider to be a metric of success? What says to you
-‘Boom, we were successful in this project?’**
+"Boom, we were successful in this project?"**
 
 We define this in our project. We want to see reduced overall time spent
 in doing the market research and creating the market research report. We

--- a/_posts/2015-03-11-onet-today-and-beyond.md
+++ b/_posts/2015-03-11-onet-today-and-beyond.md
@@ -1,5 +1,5 @@
 ---
-title: "O*NET Today and Beyond"
+title: "O*NET today and beyond"
 date: '2015-03-11'
 layout: post
 
@@ -37,7 +37,7 @@ The de facto source of skills information, both inside and outside the
 federal government, is [*O\*NET*](http://www.onetonline.org/) - the
 Occupational Information Network.
 
-## What Is O\*NET?
+## What is O\*NET?
 
 O\*NET is a data collection program that populates and maintains a
 current database of the detailed characteristics of workers,
@@ -56,7 +56,7 @@ lawyer, to name a few.
 
 ![The O*Net Content model takes many sources to identify detailed occupations.](/assets/blog/onet/image01.jpg)
 
-*Fig. 1: O\*NET Content Model*
+*Fig. 1: O\*NET content model*
 
 O\*NET supersedes the U.S. Department of Labor’s (DOL’s) *Dictionary of
 Occupational Titles* (DOT) and provides additional occupational
@@ -68,7 +68,7 @@ the 2010 version of the Standard Occupational Classification (SOC)
 mandated by Office of Management and Budget (OMB) for use by all federal
 agencies collecting occupational and labor market information (LMI).
 
-## What Is O\*NET Good At?
+## What Is O\*NET good at?
 
 O\*NET is the bedrock of occupational data — some users think of it as a
 one-stop shop for data on occupations that have existed (and will exist)
@@ -76,20 +76,20 @@ for some time. In a phrase, it is the *gold standard* of data on
 occupational skills – data upon which laws are created and an economic
 ecosystem can be built.
 
-## How Often Does O\*NET Data Get Updated?
+## How often does O\*NET data get updated?
 
 The O\*NET data set gets updated once a year. Currently, this is the
 fastest that comprehensive, consistent, representative, user-centered
 data, which complies with OMB’s Information Quality Guidelines and data
 collection requirements, can be gathered and processed.
 
-## How Does O\*NET Collect Its Data, Anyway?
+## How does O\*NET collect its data, anyway?
 
 Data collection operations are conducted by RTI International at its
 Operations Center in Raleigh, North Carolina, and at its Survey Support
 Department, also located in Raleigh.
 
-O\*NET uses a 2-stage sample — first businesses in industries that
+O\*NET uses a two-stage sample — first businesses in industries that
 employ the type of worker are sampled and contacted — then when it is
 confirmed that they employ those workers and will participate — a random
 sample of their workers in the occupation receive the O\*NET survey form
@@ -110,7 +110,7 @@ At the current funding level \$6.2 million for PY 14 the O\*NET grantee
 updates slightly more than 100 occupations per year with new survey
 data.
 
-## Why Use Sampling And Surveys?
+## Why use sampling and surveys?
 
 O\*NET currently uses sampling and surveys to gather its massive amounts
 of data because these are the best techniques that also comply with the
@@ -127,7 +127,7 @@ O\*NET was designed specifically to address OMB IQG, including OMB
 information collection request standards, and to correct some fairly
 serious limitations in the Dictionary of Occupational Titles.
 
-## What Are Other Foundational Principles of O\*NET?
+## What are other foundational principles of O\*NET?
 
 In addition to serving as a comprehensive database of occupational data
 and promoting the integrity of said data, O\*NET upholds several other
@@ -138,7 +138,7 @@ principles. These include the following:
 3.  **Broadly representative** — O\*NET’s data is sampled from across the labor market, the nation, and employing industries.
 4.  **User-centered** — Incumbent workers or occupational experts are the primary respondents to O\*NET’s surveys.
 
-## Why Does O\*NET Only Contain Survey-based Data?
+## Why does O\*NET only contain survey-based data?
 
 Using survey-based data enables O\*NET to have comprehensive coverage,
 be very representative, enable the data to be validated and cleaned
@@ -147,7 +147,7 @@ variance or error, and to meet the OMB data collection requirements.
 Even though this type of data tends to be higher cost than other data
 types, survey-based data results in average or mean values (by design).
 
-## What About Other Types of Data?
+## What about other types of data?
 
 There are two other primary types of data that could be included in the
 O\*NET data set — transactional data and crowdsourced data.
@@ -169,7 +169,7 @@ investments in curation and management for them to satisfy the OMB
 Information Quality Guidelines and the O\*NET Foundational Principles,
 which are intended to fix the problems with the DOT.
 
-## What Is The Biggest Misconception About O\*NET?
+## What is the biggest misconception about O\*NET?
 
 “*Why isn’t Python an O\*NET Skill?*”, “*Why is Active Listening an
 O\*NET Skill?*”, “*Why are O\*NET Skills so broad and generic?*”
@@ -190,7 +190,7 @@ Activity, Abilities, Tasks, Skills and Knowledge sections of an O\*NET
 occupational profile. In short, Skills are just the tip of the
 occupational iceberg.
 
-## What Are The Issues That You Hear Voiced Most About O\*NET?
+## What are the issues that you hear voiced most about O\*NET?
 
 The current set of concerns with the O\*NET program include:
 
@@ -218,7 +218,7 @@ immediately included in the O\*NET database. Only occupations that have
 stood the test of time should be included in an authoritative source;
 upon which regulatory decisions are made.
 
-## How Do We Solve These Issues?
+## How do we solve these issues?
 
 A public-private partnership that produces a Skills Market Platform
 (SMP) (Fig. 2), which is an open, dynamic, growing, standards-based,
@@ -226,7 +226,7 @@ public-facing platform for skills data.
 
 ![Reference architecture for a skills market platform](/assets/blog/onet/image00.png)
 
-*Fig. 2: Reference Architecture for a Skills Market Platform (SMP)*
+*Fig. 2: reference architecture for a Skills Market Platform (SMP)*
 
 The SMP should be run by a nonprofit that will handle the data curation,
 quality control, analytics and the public application programming
@@ -264,7 +264,7 @@ The ultimate goal is for the Federal government to facilitate the
 creation of the innovation platform for skills; enabling any American to
 freely and openly leverage a common language and knowledge base.
 
-**What Needs To Be Done**
+**What needs to be done**
 
 The Skills Market Platform relies on an existing:
 
@@ -280,7 +280,7 @@ The Skills Market Platform relies on an existing:
 3.  Skills Innovation Layer (SIL) that allows experimentation with the
     SDS and SNP and enables innovations on top of it.
 
-## Call To Action
+## Call to action
 
 Ever wondered what skills a particular certification course gives you?
 Ever debated the true skills details of a job description? Are you

--- a/_posts/2015-03-12-day-in-the-life-of-an-18F-content-designer.md
+++ b/_posts/2015-03-12-day-in-the-life-of-an-18F-content-designer.md
@@ -1,5 +1,5 @@
 ---
-title: "A Day in the Life of an 18F Content Designer"
+title: "A day in the life of an 18F content designer"
 layout: post
 image: /assets/blog/day-in-life-content/kate.JPG
 tags:
@@ -23,21 +23,21 @@ Up first is Kate Garklavs, 18F’s first content designer. Kate was drawn to 18F
 
 On that note, let’s get a glimpse at what a day on the 18F content team is like. Kate, take it away. 
 
-**7:00 AM:** Rise and shine! When my alarm sounds, I hit snooze twice before checking Slack to see what’s happening with my East Coast colleagues. After responding to any urgent messages, I go about the rest of my morning routine — shower, coffee, breakfast, coffee. Because I like my coworkers and want to shield them from the extent of my hanger, I never skip breakfast. And, if you’re curious about the true breakfast of champions, be advised that it’s this: a whole-wheat English muffin (toasted until medium-brown) spread with half of an avocado (mashed), sprinkled with Maldon and dotted with Tapatio. 
+**7:00 a.m.:** Rise and shine! When my alarm sounds, I hit snooze twice before checking Slack to see what’s happening with my East Coast colleagues. After responding to any urgent messages, I go about the rest of my morning routine — shower, coffee, breakfast, coffee. Because I like my coworkers and want to shield them from the extent of my hanger, I never skip breakfast. And, if you’re curious about the true breakfast of champions, be advised that it’s this: a whole-wheat English muffin (toasted until medium-brown) spread with half of an avocado (mashed), sprinkled with Maldon and dotted with Tapatio. 
 
-**9:00 AM:** Most mornings, I get to the office around 9:00. Per the advice of productiveness gurus everywhere, I try not to check my email until a little later in the morning, but some mornings I check right away — I’m only human, after all. My preference, though, is to dive right into a project.
+**9:00 a.m.:** Most mornings, I get to the office around 9:00. Per the advice of productiveness gurus everywhere, I try not to check my email until a little later in the morning, but some mornings I check right away — I’m only human, after all. My preference, though, is to dive right into a project.
 
-**9:30 AM:** At 9:30, I join my colleagues for the weekly all hands meeting. We’re part of a distributed workforce, and so when the entire group convenes, we do so via digital means (VTC). Every Tuesday, the group meets to discuss major events, project successes, and other news. This weekly meeting is a great way to learn more about what different projects are up to and to touch base with colleagues, wherever they hang their metaphorical hats.
+**9:30 a.m.:** At 9:30, I join my colleagues for the weekly all hands meeting. We’re part of a distributed workforce, and so when the entire group convenes, we do so via digital means (VTC). Every Tuesday, the group meets to discuss major events, project successes, and other news. This weekly meeting is a great way to learn more about what different projects are up to and to touch base with colleagues, wherever they hang their metaphorical hats.
 
 <img alt="all hands meeting" src="/assets/blog/day-in-life-content/allhands.JPG" class="align-center" />
 
-**10:00 AM:** Right after the all hands, I meet up with the MyUSA team for our weekly sprint planning meeting. What’s a sprint? I’m glad you asked! In agile parlance, a sprint is a short period of time (usually a week or two) during which a project team aims to complete a fixed number of tasks. It’s an organizational tool that helps teams break down larger projects into smaller, more achievable tasks.
+**10:00 a.m.:** Right after the all hands, I meet up with the MyUSA team for our weekly sprint planning meeting. What’s a sprint? I’m glad you asked! In agile parlance, a sprint is a short period of time (usually a week or two) during which a project team aims to complete a fixed number of tasks. It’s an organizational tool that helps teams break down larger projects into smaller, more achievable tasks.
 
 And what’s [MyUSA] (https://my.usa.gov/)? Also glad you asked! MyUSA is a service that will allow citizens to access services from multiple government agencies ([Benefits.gov] (http://www.benefits.gov/), [BusinessUSA] (http://business.usa.gov/), and [USA.gov] (http://www.usa.gov/) among them) through a single account. Citizens will access this account with a single sign on (no need to remember unwieldy passwords), and they’ll be able to track their progress on different tasks — completing and submitting forms, for example. You can think of MyUSA as a one-stop shop for government.
 
 During sprint planning, each team member reviews what they did during the previous sprint and discusses what they’d like to accomplish in the coming one. Recently, I’ve been rewriting the front page copy based on data from user interviews. Many of our interviewees had difficulty making meaning of our value statement, so I’ve focused my efforts on crafting a statement (20 words or fewer) that describes what MyUSA does. Writing 20 words might not seem like much, but conveying the essence of a multifaceted service in a single sentence is much harder than it looks. 
 
-**11:00 AM:** After wrapping up sprint planning, I meet with Greg and other members of the blog team for the **blog huddle**. Modeled a bit after writing workshops and drawing on techniques used at university writing centers, the huddle is a drop-in workshop during which anyone can get advice on blogging and feedback on their drafts. It’s only been around for a month or so, but it’s already proving to be popular.
+**11:00 a.m.:** After wrapping up sprint planning, I meet with Greg and other members of the blog team for the **blog huddle**. Modeled a bit after writing workshops and drawing on techniques used at university writing centers, the huddle is a drop-in workshop during which anyone can get advice on blogging and feedback on their drafts. It’s only been around for a month or so, but it’s already proving to be popular.
 
 During today’s huddle, a coworker asks for advice on how to write about part of a project that didn’t pan out, but in a way that doesn’t upset the client. I recommend leading in by discussing parts of the project that did work out, as well as reframing the mishap: that is, describing how it allowed the project to pivot (and move in a more successful direction). I also remind my colleague to send the client his draft before sending the draft for additional approval; getting your subject’s thumbs-up before publication is vital to maintaining successful relationships. 
 
@@ -50,17 +50,17 @@ At 18F, the spirit of innovation prevails, even in our approach to lunch.
 <div class="align-center" ><img alt="making tortillas" src="/assets/blog/day-in-life-content/tacos1.JPG" class="align-left" />
 <img alt="delicious homemade taco" src="/assets/blog/day-in-life-content/tacos2.JPG" class="align-right" /></div>
 
-**1:00 PM:** With lunch over, it’s time to get back to work. After a quick check of the inbox, I start some revisions of site copy for openFOIA, which helps folks make [FOIA] (http://www.foia.gov/) (Freedom of Information Act) requests more easily and efficiently. 
+**1:00 p.m.:** With lunch over, it’s time to get back to work. After a quick check of the inbox, I start some revisions of site copy for openFOIA, which helps folks make [FOIA] (http://www.foia.gov/) (Freedom of Information Act) requests more easily and efficiently. 
 
 As I review each chunk of copy, I keep a few factors in mind: what phrasings and definitions we’re legally required to use, which phrasings we aren’t, and how I can describe the central concepts in a way that appeals to the viewer. Whenever possible, I replace long words with shorter ones, acronyms with agency names, and legal jargon with plain language. 
 
-**3:00 PM:** Later in the afternoon, I meet with my colleague Nick to discuss the next event in the 18F Presents series. Roughly once a month, 18F brings in a noted speaker from the field of visual design, UX, or content. (Our first speaker was Steve Portigal — read more about the event [here] (https://18f.gsa.gov/2015/02/26/Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One/).)
+**3:00 p.m.:** Later in the afternoon, I meet with my colleague Nick to discuss the next event in the 18F Presents series. Roughly once a month, 18F brings in a noted speaker from the field of visual design, UX, or content. (Our first speaker was Steve Portigal — read more about the event [here] (https://18f.gsa.gov/2015/02/26/Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One/).)
 
 Nick and I are helping to organize the series, and today we’re creating a survey to collect people’s thoughts on who we should invite. I also work on drafting email templates to send to speakers at different points before the event; creating these templates now saves time in the long run. 
 
-**4:00 PM:** As we head into late afternoon, I make some mint tea and comment on a few blog post drafts. One of my favorite parts of working at 18F is collaborating with my coworkers. Ours is a crew practiced in offering thoughtful, well-worded insights — and offering them quickly. Though some posts take longer to write and publish, many of our posts (500 to 1,000 words) have a two- or three-day turnaround time — nothing to sneeze at, when you factor in government-specific review and regulatory processes.
+**4:00 p.m.:** As we head into late afternoon, I make some mint tea and comment on a few blog post drafts. One of my favorite parts of working at 18F is collaborating with my coworkers. Ours is a crew practiced in offering thoughtful, well-worded insights — and offering them quickly. Though some posts take longer to write and publish, many of our posts (500 to 1,000 words) have a two- or three-day turnaround time — nothing to sneeze at, when you factor in government-specific review and regulatory processes.
 
-**5:30 PM:** At half past five, the whistle blows; in the case of the SF office, this translates to the overhead lights starting to dim. Energy-saving measure or hint to head homeward? I interpret it as the latter. 
+**5:30 p.m.:** At half past five, the whistle blows; in the case of the SF office, this translates to the overhead lights starting to dim. Energy-saving measure or hint to head homeward? I interpret it as the latter. 
 
 Discarding my spent to-do list before I go, I bid farewell to 50 UN Plaza and start my walk home through the friscalating dusklight of SOMA. Most nights I listen to a podcast as I walk; lately, I’m digging [Invisibilia] (http://www.npr.org/programs/invisibilia/) and [The Allusionist] (http://www.theallusionist.org/) (and am always open to suggestions, so please send yours!). Some nights, though, I’m content to just walk, listening to the clatter of the F as it edges away from downtown, the conversations — muted and shouted — of my fellow passersby.
 

--- a/_posts/2015-03-13-how-to-protosketch.md
+++ b/_posts/2015-03-13-how-to-protosketch.md
@@ -1,5 +1,5 @@
 ---
-title: How to Protosketch
+title: How to protosketch
 date: '2015-03-13'
 layout: post
 image: /assets/images/2014/12/protosketch.jpg
@@ -32,8 +32,7 @@ Although not difficult, protosketching demands a definite "bag of
 tricks" that one should understand to rapidly create web-enabled spike
 solutions. Let's dive a little deeper in.
 
-Publicize Your Work with GitHub Pages
--------------------------------------
+## Publicize your work with GitHub Pages
 
 Your basic goal is to demonstrate possibilities rapidly. You can do this
 on your personal computer and have people crowd around it---but it is
@@ -56,8 +55,7 @@ Open Source
 Policy*](https://github.com/18F/open-source-policy/blob/master/policy.md),
 "from the first line."
 
-Leverage Design For Free Using a Framework
-------------------------------------------
+## Leverage design for free using a framework
 
 HTML is the basis of most web-enabled protosktetching. You probably need
 to understand HTML and CSS to protosketch rapidly. However, frameworks,
@@ -69,8 +67,7 @@ devices of different sizes and aspect ratios.
 Although you may someday want to build a native mobile app, you will
 generally want to start with a mobile-friendly website instead.
 
-jQuery API for mocking APIs quickly but dependably
--------------------------------------------------
+## jQuery API for mocking APIs quickly but dependably
 
 One common thread in the projects being considered for 18F Consulting is
 a desire to integrate disparate data sources into a single application
@@ -93,8 +90,7 @@ worthwhile to optimize JavaScript code to nicely render arbitrary JSON.
 In other words, the less your JavaScript knows about your data, the more
 flexibly you can sketch in sample data.
 
-Making Data Malleable
----------------------
+## Making data malleable
 
 The protosketcher should feel comfortable enough modifying sample data
 so that it feels "malleable". Paul Graham, in an essay titled[
@@ -116,8 +112,7 @@ about what should be built, but being an instrument for the program
 manager's or end-user's vision. JavaScript and mock APIs give us this
 freedom.
 
-Render Rapidly by Using Public or Fake Data
--------------------------------------------
+## Render rapidly by using public or fake data
 
 It is convenient to work publicly in open-source to avoid security
 issues, which means that we must use public or fake data, instead of
@@ -128,8 +123,7 @@ An example of fake text is the famous Lorem Ipsum text. Wikimedia
 Commons is a great source of photographs and visual designs that have
 clearly expressed, open licenses (or lack of licenses).
 
-Running a Server
-----------------
+Running a server
 
 Given the power of JavaScript, you can quickly build impressive demos
 with "fake" data using the JSON and jQuery API trick mentioned above.
@@ -150,8 +144,7 @@ Flask before, for example, this might take 20 minutes.
 Heroku and similar application hosting platforms provides a more
 permanent and robust solution.
 
-Theatrical Devices
-------------------
+## Theatrical devices
 
 Protosketching is a form of coding athleticism--a performance art as a
 well as a compositional art. Don't be ashamed to use a little
@@ -180,7 +173,7 @@ Here are some of the techniques we have used:
     open-source project, which itself was forked from a Code for
     America's Honolulu project. And it worked.
 
-**Motivation: Remember, You're Protosketching For the Success of Your Project**
+**Motivation: Remember, you're protosketching for the success of your project**
 ===============================================================================
 
 Remember, the reason you are using a bag-of-tricks and theater is not to
@@ -191,7 +184,7 @@ duty in any Agile, User-centered Design process to use any tool in our
 kit to accomplish this. Protosketching is a valuable kind of spike
 solution that lets you quickly get feedback from the user.
 
-**Appendix: A Technical Example**
+**Appendix: A technical example**
 =================================
 
 We exemplify some of the basic techniques mentioned in this article with

--- a/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
+++ b/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
@@ -1,5 +1,5 @@
 ---
-title: Does 18F Pass the Bechdel Test for Tech?
+title: Does 18F pass the Bechdel test for tech?
 date: 2015-03-17 14:00:00
 layout: post
 image: /assets/blog/bechdel/team.jpg
@@ -13,8 +13,8 @@ tags:
 authors:
 - elaine
 - melody
-description: "How does the Bechdel Test, originally designed for evaluating works for fiction, apply to technology projects? To pass, a function written by a woman dev must call a function written by another woman dev."
-excerpt: "How does the Bechdel Test, originally designed for evaluating works for fiction, apply to technology projects? To pass, a function written by a woman dev must call a function written by another woman dev."
+description: "How does the Bechdel test, originally designed for evaluating works for fiction, apply to technology projects? To pass, a function written by a woman dev must call a function written by another woman dev."
+excerpt: "How does the Bechdel test, originally designed for evaluating works for fiction, apply to technology projects? To pass, a function written by a woman dev must call a function written by another woman dev."
 ---
 Kaitlin Devine, 18F’s Director of Engineering recently noticed this
 tweet:
@@ -66,7 +66,7 @@ projects become Bechdel compliant, we plan to note the change.
 
 The Results:
 
-## BECHDEL WINNERS
+## Bechdel winners
 
 [*Discovery*](https://github.com/18F/discovery) - Market research tool
 for the OASIS procurement vehicle, which serves contracting specialists
@@ -93,7 +93,7 @@ for a contract, based on historical pricing information.
 [*FBOpen*](https://github.com/18F/fbopen)- FBOpen helps small
 businesses search for opportunities to work with the U.S. government.
 
-## ALMOST-BECHDELS
+## Almost Bechdels
 
 [*Data
 Act*](https://github.com/fedspendingtransparency/fedspendingtransparency.github.io) -
@@ -103,7 +103,7 @@ mentions, “There isn't actually any code associated with this right now,
 only static content. We will have some in a few weeks which will pass
 the test.”
 
-## NOT YET
+## Not yet
 **(Help us change that! You can fork any of the projects below
 and help us out!)**
 

--- a/_posts/2015-03-17-for-public-comment-the-https-only-standard.md
+++ b/_posts/2015-03-17-for-public-comment-the-https-only-standard.md
@@ -1,5 +1,5 @@
 ---
-title: "For Public Comment: the HTTPS-Only Standard"
+title: "For public comment: the HTTPS-only standard"
 date: 2015-03-17 10:00:00
 layout: post
 image: /assets/blog/https-standard/screen.png
@@ -33,7 +33,7 @@ From [the proposal](https://https.cio.gov):
 
 > Private and secure connections are becoming the Internet’s baseline, as expressed by the policies of the Internet’s [standards](https://w3ctag.github.io/web-https/) [bodies](http://www.internetsociety.org/news/internet-society-commends-internet-architecture-board-recommendation-encryption-default), popular web browsers, and the Internet community of practice.
 >
-> The Federal government must adapt to this changing landscape, and benefits by beginning the conversion now. Proactive investment at the Federal level will support faster internet-wide adoption and promote better privacy standards for the entire browsing public.
+> The federal government must adapt to this changing landscape, and benefits by beginning the conversion now. Proactive investment at the federal level will support faster internet-wide adoption and promote better privacy standards for the entire browsing public.
 
 At the core of this proposal is the idea that **all browsing activity should be considered private and sensitive**.
 

--- a/_posts/2015-03-18-sunshine-week-extractive-industries-transparency-initiative-event.md
+++ b/_posts/2015-03-18-sunshine-week-extractive-industries-transparency-initiative-event.md
@@ -1,5 +1,5 @@
 ---
-title: 'Sunshine Week: Extractive Industries Transparency Initiative Event'
+title: 'Sunshine week: extractive industries transparency initiative event'
 date: '2015-03-18'
 layout: post
 image: /assets/blog/useiti-sunshine/useiti.png
@@ -65,7 +65,7 @@ You can [learn more about the benefits of the broader initiative on the
 EITI
 website](https://eiti.org/eiti/benefits)[.](https://eiti.org/eiti/benefits)
 
-## USEITI On the Web
+## USEITI on the web
 
 The website [18F helped Interior build](https://useiti.doi.gov),
 currently in [live beta](https://18f.gsa.gov/dashboard/stages/),

--- a/_posts/2015-03-19-18f-by-the-numbers.md
+++ b/_posts/2015-03-19-18f-by-the-numbers.md
@@ -1,5 +1,5 @@
 ---
-title: "18F by the Numbers"
+title: "18F by the numbers"
 layout: post
 image: /assets/blog/agile-day/18fbythenumbers.png
 date: 2015-03-19 18:00:00
@@ -22,7 +22,7 @@ Today, we’re celebrating our first anniversary. We wanted to take a look at so
 ![Infographic showing 18F's first-year progress by the numbers](/assets/blog/agile-day/18fbythenumbers.png)
 
 
-##By The Projects
+##By the projects
 
 15: Current [Delivery Services Projects] (https://18f.gsa.gov/dashboard/)
 
@@ -37,7 +37,7 @@ Today, we’re celebrating our first anniversary. We wanted to take a look at so
 4: Hackathons and Demo Days hosted ([and we’ve got more] (http://accessibilitytoday.eventbrite.com) [around the corner!] (http://www.eventbrite.com/e/gov-tech-hack-by-the-people-for-the-people-tickets-16135863803))
 
 
-##By The People
+##By the people
 
 15: People on the [18F team] (https://18f.gsa.gov/) one year ago
 
@@ -54,7 +54,7 @@ Today, we’re celebrating our first anniversary. We wanted to take a look at so
 684: Number of Tweets on [@18F] (https://twitter.com/18f) (as of 3/19/15)
 
 
-##By The Code
+##By the code
 
 
 203: Public repositories on GitHub (source: [GovCode] (https://www.govcode.org/repos))

--- a/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
+++ b/_posts/2015-03-19-how-we-built-analytics-usa-gov.md
@@ -158,7 +158,7 @@ All static files are stored in Amazon S3 and served by Amazon CloudFront, so we 
 
 From a maintenance standpoint, this is a dream. And we can always replace this later with a dynamic server if it becomes necessary, by which time we'll have a clearer understanding of what kind of traffic the site can expect and what features people want.
 
-## Usability Testing
+## Usability testing
 
 We went to a local civic hacking meetup and conducted a quick usability testing workshop. In line with PRA guidelines, we interviewed 9 members of the public and a handful of federal government employees. Any government project can do this, and the feedback was very helpful.
 

--- a/_posts/2015-03-20-one-year-in-and-looking-forward.md
+++ b/_posts/2015-03-20-one-year-in-and-looking-forward.md
@@ -1,5 +1,5 @@
 ---
-title: One Year In and Looking Forward
+title: One year in and looking forward
 date: '2015-03-20'
 layout: post
 image: "/assets/images/logo-18f.png"
@@ -43,7 +43,7 @@ our history, but so we can share our process and progress with you.
 Sometimes we stumbled, but each time we practiced what we preach—build,
 measure, learn, and do it again.
 
-## It's Been an Incredible Year
+## It's been an incredible year
 
 The initial idea was simple: Attract talented technologists to the civil
 service, enticing them with meaty problems and an opportunity for huge
@@ -99,8 +99,7 @@ as always-HTTPS.
 [analytics.usa.gov][13], giving the public a
 view of federal government website analytics for the first time.
 
-And We're Just Getting Started
-------------------------------
+## And we're just getting started
 
 During the next year, you'll see the expansion of several projects and
 lines of business:
@@ -110,7 +109,7 @@ short-term, as-needed basis, helping agencies acquire better software.
 - 18F Talent, to help agencies identify and recruit cutting-edge
 technical talent.
 - FISMA Ready, a toolkit that provides Federal information security
-compliance for open-source software.
+compliance for open source software.
 - [Agile Delivery Services BPA][14],
 a micro-market blanket purchase agreement to help [agencies acquire
 better professional services][15].
@@ -121,8 +120,7 @@ Not to mention the fact that we plan to double in size and scale our
 services to make a larger impact. Check back here in one year and hold
 us to it.
 
-Thank You
----------
+## Thank you
 
 Finally, a personal thank you to the entire team. It is an honor to work
 with passionate people who are absolutely committed to both making our
@@ -135,11 +133,11 @@ also need your help!
 
 If you're a designer, developer, or technologist who has ...
 
-- a couple of hours? Check out our ["help wanted" tag][16]
+- A couple of hours: Check out our ["help wanted" tag][16]
 on Github.
-- a couple of days? Attend a [hackathon][17], or peruse our [Dashboard][12] for open
+- A couple of days: Attend a [hackathon][17], or peruse our [Dashboard][12] for open
 source projects.
-- a couple of years? [Your country needs you!][18]
+- A couple of years: [Your country needs you!][18]
 
 Onward!
 

--- a/_posts/2015-03-24-making-twitter-images-more-accessible.md
+++ b/_posts/2015-03-24-making-twitter-images-more-accessible.md
@@ -1,5 +1,5 @@
 ---
-title: "Making Twitter Images Accessible"
+title: "Making twitter images accessible"
 layout: post
 image: /assets/blog/twitter/twitter.png
 date: 2015-03-24

--- a/_posts/2015-03-30-new-rfp-ghostwriting-service-to-improve-contract-success.md
+++ b/_posts/2015-03-30-new-rfp-ghostwriting-service-to-improve-contract-success.md
@@ -1,5 +1,5 @@
 ---
-title: New RFP Ghostwriting service to improve contract success
+title: New RFP ghostwriting service to improve contract success
 date: '2015-03-30'
 layout: post
 image: "/assets/blog/rfp-as-a-service/18f-consulting-masthead.gif"
@@ -45,11 +45,11 @@ These are the types of questions we ask as we’re reviewing RFPs:
 
 1.  Based on the need you’re trying to address, are you making
     appropriate uses of the various software development methods
-    (e.g., agile, waterfall)?
+    (for example, agile, waterfall)?
 2.  How can you most effectively include considerations for user-centered
     design and development?
 3.  Where are there opportunities to incorporate proven, commodity IT
-    solutions (e.g., Commercial Off-The-Shelf (COTS) over expensive
+    solutions (for example, Commercial Off-The-Shelf (COTS) over expensive
     custom-built solutions)?
 4.  Are you making appropriate use of [open
     source](https://18f.gsa.gov/2014/11/26/how-to-use-more-open-source/)

--- a/_posts/2015-03-31-focus-on-accessibility.md
+++ b/_posts/2015-03-31-focus-on-accessibility.md
@@ -1,5 +1,5 @@
 ---
-title: "Focus on Accessibility"
+title: "Focus on accessibility"
 layout: post
 image: /assets/blog/accessibility/pictureintweet.png
 tags:

--- a/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
+++ b/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
@@ -1,5 +1,5 @@
 ---
-title: 'GovTechHack: Hacking for Civic Improvement'
+title: 'GovTechHack: hacking for civic improvement'
 date: '2015-04-02'
 layout: post
 image: /assets/blog/govtechhack/IMG_4015.JPG
@@ -35,22 +35,21 @@ More than 75 individuals came prepared to share their time and skills in
 the name of civic improvement, and their achievements were nothing short
 of remarkable.
 
-18F supported the event by identifying the open-source projects to be
+18F supported the event by identifying the open source projects to be
 hacked. These projects’ contributors were on-hand during the hackathon
 to answer questions, and also made themselves available before and after
 the event to answer questions and accept pull requests. We at 18F would
 be delighted to collaborate with any group looking for a way to
-contribute — you can find us and other active open-source teams on
+contribute — you can find us and other active open source teams on
 [government open source email
 list](mailto:government-open-source@googlegroups.com).
 
-How it Worked
--------------
+## How it worked
 
 <img alt="The crowd listens to opening day presentations" src="/assets/blog/govtechhack/IMG_3998.JPG" class="align-left" />
 
-**Day 1:** The two-day event kicked off on a sunny Friday evening.
-Participants arrived promptly at 6:00 PM, which gave them plenty of time
+**Day one:** The two-day event kicked off on a sunny Friday evening.
+Participants arrived promptly at 6:00 p.m., which gave them plenty of time
 to get settled and introduce themselves to their fellow hackers.
 
 Around 6:30, the evening’s kickoff presentation began. Former
@@ -79,20 +78,20 @@ following day. These projects included:
     for purchase card holders authorized to buy office supplies for
     the government
 
--   [**GovCode**](https://github.com/dlapiduz/govcode.org) — A service consolidating open-source government
+-   [**GovCode**](https://github.com/dlapiduz/govcode.org) — A service consolidating open source government
     projects, making participation easier than ever
 
 -   [**Solar Data Sets**](http://energy.gov/eere/sunshot/sunshot-initiative) — The Department of Energy’s SunShot Initiative
     seeks to inspire more people to create software solutions to the
     challenge of increasing our use of solar energy.
 
-**Day 2**: Bright and early Saturday morning, participants reconvened at
+**Day two**: Bright and early Saturday morning, participants reconvened at
 the cafe, eager to work. The previous evening, each group had outlined
 its priorities. While most of San Francisco slept, these groups tackled
 design, development, and marketing issues within the five aforementioned
 projects.
 
-The groups worked from 9:00 AM until 4:00 PM, taking a quick lunch break
+The groups worked from 9:00 a.m. until 4:00 p.m., taking a quick lunch break
 and also stopping for snacks. As afternoon slid into evening, the groups
 presented their work to a panel of judges, highlighting the bugs they’d
 fixed and recommendations they’d made.
@@ -137,8 +136,7 @@ govtechhack slack instance which was created especially for the event.
 There were even remote participants who were able to join teams and help
 out even though they could not be there in person
 
-Want to help?
--------------
+## Want to help?
 
 The success of
 [GovTechHack](https://twitter.com/search?f=realtime&q=%23GovTechHack&src=typd)

--- a/_posts/2015-04-03-18f-discussion-should-project-teams-code-first-or-design-first.md
+++ b/_posts/2015-04-03-18f-discussion-should-project-teams-code-first-or-design-first.md
@@ -1,5 +1,5 @@
 ---
-title: "18F Discussion: Should Project Teams Code First Or Design First?"
+title: "18F discussion: Should project teams code first or design first?"
 layout: post
 image: "/assets/blog/code-design/decisions-blue.png"
 tags:

--- a/_posts/2015-04-03-how-to-welcome-new-coders-to-a-civic-hackathon.md
+++ b/_posts/2015-04-03-how-to-welcome-new-coders-to-a-civic-hackathon.md
@@ -1,5 +1,5 @@
 ---
-title: 'How To Welcome New Coders To A Civic Hackathon'
+title: 'How to welcome new coders to a civic hackathon'
 date: '2015-04-03'
 layout: post
 image: /assets/blog/govtechhack/IMG_3998.JPG
@@ -46,8 +46,7 @@ The National Day of Civic Hacking is a great time to attend — or host
 first-time hackathon hosts. These tips will help participants feel
 welcome, and help them maximize their contributions.
 
-Explicitly welcome newcomers with a new contributor guide.
-==========================================================
+## Explicitly welcome newcomers with a new contributor guide
 
 Usability testers, accessibility experts, researchers, data cleaners,
 writers, translators, subject-matter experts, and content designers are
@@ -72,8 +71,7 @@ with their best skills. For example, Wikimedia hackathons have [an
 explicit buddy-pairing
 system](http://www.mediawiki.org/wiki/Hackathons#Pairing_buddies).
 
-Clearly define projects and enumerate ways newcomers can get involved with each.
-================================================================================
+## Clearly define projects and enumerate ways newcomers can get involved with each
 
 Last month, we co-hosted
 [GovTechHack](https://18f.gsa.gov/2015/04/02/govtechhack-hacking-for-civic-improvement/), a San-Francisco-based hackathon where civic-minded coders, builders,
@@ -98,8 +96,7 @@ next time around. We wish we’d also:
 -   Included a checklist for users (like [this one](https://github.com/girldevelopit/gdi-new-site/issues/245))
 -   Added a section on how non-coders could have helped each project. It’s worth thinking about and then articulating — in writing — how people with other areas of expertise or knowledge can help during a hackday. If you don’t have time to write these issues out, you can open an issue that asks for someone to interview you about them. Voila! Problem solved.
 
-Make really good nametags for people
-====================================
+## Make really good nametags for people
 
 Sarah Allen, a developer at 18F, passes along nametags, pictured below,
 which were used at the GovTechHack. The nametags used color-coded
@@ -111,8 +108,7 @@ first time.
 
 ![Image: nametag from recent hackathon showing color-coded stickers for devs, designers, and content strategists](/assets/blog/new-to-hackathon/nametag.jpg)
 
-Clearly label issues on GitHub with ways people can help.
-=========================================================
+## Clearly label issues on GitHub with ways people can help
 
 It is always a good idea to label GitHub issues that could use outside
 hands — we use the “Help Wanted” label. Government open source projects
@@ -131,8 +127,7 @@ projects. (18F’s Aidan Feldman has created [a list of
 labels](https://github.com/osscommunity/starters/issues/5) you can use
 for new projects.)
 
-Make your team available for people who hack remotely.
-======================================================
+## Make your team available for people who hack remotely
 
 Not everyone can get to a nearby city to hack on the National Civic Day
 of Hacking, but this doesn’t mean they should be excluded from
@@ -156,8 +151,7 @@ team to more easily converse in real-time. This also gives participants
 a space to connect with each other beyond the event, if they choose to
 do so.
 
-Personally invite contributions.
-================================
+## Personally invite contributions
 
 A personal invitation might be all it takes to turn a project user into
 a project contributor. If someone opens an issue that’s easily solved,
@@ -168,8 +162,7 @@ Civic Hacking are opportunities to show people that their contributions
 are being received by real people who are delighted to have them
 contribute.
 
-Develop a toolkit for participants
-==================================
+## Develop a toolkit for participants
 
 Our colleagues at GSA have created [a
 toolkit](http://gsa.github.io/Open-Data-Collaboration-Sandbox/github_tips_and_tricks/)

--- a/_posts/2015-04-06-day-in-the-life-of-talent-manager.md
+++ b/_posts/2015-04-06-day-in-the-life-of-talent-manager.md
@@ -1,5 +1,5 @@
 ---
-title: 'A Day in the Life of an 18F Talent Manager'
+title: 'A day in the life of an 18F talent manager'
 date: '2015-04-08'
 layout: post
 image: /assets/blog/talent-manager/Jamie.jpg
@@ -22,44 +22,44 @@ I spent my first few months at 18F on the Operations Team — the heart and soul
 
 Somewhere along the way, I became the go-to gal for all things “hiring.” Thankfully, in recent months, we’ve hired a bunch of fantastic new people and now there’s a whole team — **Team Talent** — dedicated to recruiting and workforce planning. With most of TT holding down the fort in DC, I figured it was time to give SF some love (both professionally and personally).
 
-Today, I am a Talent Manager in our San Francisco office, and this is a day in my life.
+Today, I am a talent manager in our San Francisco office, and this is a day in my life.
 
-**5:30 AM**: Forget those West Coast stereotypes! Ever since my Peace Corps days of waking up with the animals, I haven’t been able to sleep in much. This bodes well for never feeling behind my East Coast counterparts. Heck, I sometimes beat some of them to the office.
+**5:30 a.m.**: Forget those West Coast stereotypes! Ever since my Peace Corps days of waking up with the animals, I haven’t been able to sleep in much. This bodes well for never feeling behind my East Coast counterparts. Heck, I sometimes beat some of them to the office.
 
-My morning routine is easy, quick, and simple. The only things I take too seriously at this hour are tea, fruit, and yogurt. I’m out the door and walking to work by 6:00 AM.
+My morning routine is easy, quick, and simple. The only things I take too seriously at this hour are tea, fruit, and yogurt. I’m out the door and walking to work by 6:00 a.m.
 
 <img alt="My morning walk to work" src="/assets/blog/talent-manager/morningwalk.JPG" class="align-left" />
 
-**7:00 AM**: Wednesday is farmer’s market day at 50 UN Plaza, which means breakfast (part two) is too many free samples of chocolate almond brittle. At this hour, no one else is around, so I crank up our Bose speakers and unleash DJ JME. I make all my co-workers listen to [this song] (https://www.youtube.com/watch?v=sZ-D4jmkUiQ) at least once. You should listen, too. It helps me work through my priority inbox and prepare my notes for my morning meetings.
+**7:00 a.m.**: Wednesday is farmers' market day at 50 UN Plaza, which means breakfast (part two) is too many free samples of chocolate almond brittle. At this hour, no one else is around, so I crank up our Bose speakers and unleash DJ JME. I make all my co-workers listen to [this song] (https://www.youtube.com/watch?v=sZ-D4jmkUiQ) at least once. You should listen, too. It helps me work through my priority inbox and prepare my notes for my morning meetings.
 
-At **8:00 AM**, I join Jen and Shawnique for the Team Talent stand up. We use this time together to walk through our candidate tracker. The hiring process here is longer than most, so we have to stay on top of each person’s route to Day 1. We also use this time to plan our next interview day (every other Friday), and discuss any other current challenges.
+At **8:00 a.m.**, I join Jen and Shawnique for the Team Talent stand up. We use this time together to walk through our candidate tracker. The hiring process here is longer than most, so we have to stay on top of each person’s route to Day 1. We also use this time to plan our next interview day (every other Friday), and discuss any other current challenges.
 
-At **9:00 AM**, I start to assemble folders of the necessary documents from the candidates we’ve most recently asked to join 18F. Each candidate’s folder includes: a comprehensive resume (usually multiple pages), salary documentation for the previous two years, background-check-related forms, and additional memos related to location (if you are not in DC or San Francisco) and salary (if you’re coming in above the first salary level). Those memos I mentioned require two signatures, so I send those off for approval before submitting the complete folders to GSA Human Resources (HR).
+At **9:00 a.m.**, I start to assemble folders of the necessary documents from the candidates we’ve most recently asked to join 18F. Each candidate’s folder includes: a comprehensive resume (usually multiple pages), salary documentation for the previous two years, background-check-related forms, and additional memos related to location (if you are not in DC or San Francisco) and salary (if you’re coming in above the first salary level). Those memos I mentioned require two signatures, so I send those off for approval before submitting the complete folders to GSA Human Resources (HR).
 
-At **10:00 AM** I check in with our main GSA HR point of contact. We talk daily. Once the 18F team selects someone for hire, their folder must go through GSA HR proper to be found officially qualified for the position (including GS and Step level confirmation), then through security for the background check, and then back to HR to set up start dates and orientation. This is a long process — it takes between four and six weeks — and one that requires a lot of attention from all sides (Team Talent, GSA support offices, and the candidate).
+At **10:00 a.m.** I check in with our main GSA HR point of contact. We talk daily. Once the 18F team selects someone for hire, their folder must go through GSA HR proper to be found officially qualified for the position (including GS and Step level confirmation), then through security for the background check, and then back to HR to set up start dates and orientation. This is a long process — it takes between four and six weeks — and one that requires a lot of attention from all sides (Team Talent, GSA support offices, and the candidate).
 
-**11:00 AM:** I hop on a list of calls with these individuals. As you may have inferred from above, the hiring process has a lot of steps. I do my best to outline them via email, but sometimes you’ve gotta go the old fashioned route and actually talk to people. Call me crazy, but I kind of like it. It helps me get to know everyone before their first day. For this reason, many of my colleagues refer to me as the “face” of 18F. I do my best to put on a good face, but I hope more than anything that future 18F-ers see me as their buddy, a resource they can count on as they navigate the world of federal employment here.
+**11:00 a.m.:** I hop on a list of calls with these individuals. As you may have inferred from above, the hiring process has a lot of steps. I do my best to outline them via email, but sometimes you’ve gotta go the old fashioned route and actually talk to people. Call me crazy, but I kind of like it. It helps me get to know everyone before their first day. For this reason, many of my colleagues refer to me as the “face” of 18F. I do my best to put on a good face, but I hope more than anything that future 18F team members see me as their buddy, a resource they can count on as they navigate the world of federal employment here.
 
 By **noon**, I am ready for a break. My SF officemates know that my lunch habits are typically atrocious, and they often chastise me. Today, I wander the farmer’s market eating pretzel M&Ms, gathering samples of apples and oranges, buying dates (the fruit, not the social event), and of course stopping for another round of almond brittle.
 
 <img alt="SF on a sunny day" src="/assets/blog/talent-manager/sfview.JPG" class="align-right" />
 
-**1:00 PM**: I make my way back inside and settle in to review resumes. This task is fairly simple: input names and other pertinent information into our candidate tracker, separate applicants into the appropriate [buckets] (https://18f.gsa.gov/2015/03/10/Labor-Category-Descriptions-for-Agile-Procurements/), and then send the resumes out  for evaluation. Each resume is reviewed by at least two Subject Matter Experts (SMEs) on our team.
+**1:00 p.m.**: I make my way back inside and settle in to review resumes. This task is fairly simple: input names and other pertinent information into our candidate tracker, separate applicants into the appropriate [buckets] (https://18f.gsa.gov/2015/03/10/Labor-Category-Descriptions-for-Agile-Procurements/), and then send the resumes out  for evaluation. Each resume is reviewed by at least two subject matter experts (SMEs) on our team.
 
-**2:00 PM**: I step away from the computer to hop on the phone again. I’ve scheduled a few 30-minute phone screens (in terms of the hiring process, this happens post resume review) with potential Operations Specialists and Talent Coordinators.  Most of these positions are filled via a special hiring authority granted to Returned Peace Corps/Americorps/Vista Volunteers. I am biased, but Peace Corps Volunteers are incredible humans. We’ve got a lot of them here at 18F and we’d love many, many more. If you know someone that fits that bill, tell them to [apply] (http://www.peacecorps.gov/resources/returned/careercen/careerlink/jobs/7702/)!
+**2:00 p.m.**: I step away from the computer to hop on the phone again. I’ve scheduled a few 30-minute phone screens (in terms of the hiring process, this happens post resume review) with potential operations specialists and talent coordinators.  Most of these positions are filled via a special hiring authority granted to Returned Peace Corps/Americorps/Vista Volunteers. I am biased, but Peace Corps Volunteers are incredible humans. We’ve got a lot of them here at 18F and we’d love many, many more. If you know someone that fits that bill, tell them to [apply] (http://www.peacecorps.gov/resources/returned/careercen/careerlink/jobs/7702/)!
 
-**3:30 PM**: After three phone calls, I am ready for my mid-afternoon break. I like to hula-hoop around the office. I’ve made it my mission to teach the rest of the office. Luckily, this is a receptive bunch – they are always down for some learnin’.
+**3:30 p.m.**: After three phone calls, I am ready for my mid-afternoon break. I like to hula-hoop around the office. I’ve made it my mission to teach the rest of the office. Luckily, this is a receptive bunch – they are always down for some learnin’.
 
 <img alt="Hula hooping" src="/assets/blog/talent-manager/hulahoop.JPG" class="align-left" />
 
-**4:00 PM**: I take a good portion of the rest of the day to sit down and tackle my inbox and other small tasks; since I used to be one of the only Operations Specialists, I am still somehow involved in all of the things. It is quiet(er) in DC at this point, so I can focus on these items with fewer disruptions. If you must know, I have an inbox zero policy, and finagling my inbox to zero takes longer than I like to admit out loud.
+**4:00 p.m.**: I take a good portion of the rest of the day to sit down and tackle my inbox and other small tasks; since I used to be one of the only Operations Specialists, I am still somehow involved in all of the things. It is quiet(er) in DC at this point, so I can focus on these items with fewer disruptions. If you must know, I have an inbox zero policy, and finagling my inbox to zero takes longer than I like to admit out loud.
 
-**6:00 PM**: I start my walk home listening to my wonderfully (well, depends on who you ask) crafted playlist of the day. I try and take new walking paths as much as possible – this city is still new to me, after all.
+**6:00 p.m.**: I start my walk home listening to my wonderfully (well, depends on who you ask) crafted playlist of the day. I try and take new walking paths as much as possible – this city is still new to me, after all.
 
 That’s what makes me happy here at 18F, too – something and someone new to learn from and about each day. I joined 18F because of that small group of 10 people here in the beginning and I stay here for the 100+ that have joined since then.
 
 **Update:**
 
-A [tweet](https://twitter.com/Shahryar/status/585884382621229056) from @Shahryar said, "Wow, nice read but am I reading this correctly - are you doing an 11.5 hour work day every day?"
+A [tweet](https://twitter.com/Shahryar/status/585884382621229056) from @Shahryar said, "Wow, nice read, but am I reading this correctly - are you doing an 11.5 hour work day every day?"
 
 The answer is nope! This post is an exaggerated look at my work day — it was the only way to capture all of the hula hooping I do every hour! ([This was my response](https://twitter.com/jmealbrecht/status/585887525643821056) on Twitter.)

--- a/_posts/2015-04-07-icymi-a11yhack-accessibility-awareness-hackathon.md
+++ b/_posts/2015-04-07-icymi-a11yhack-accessibility-awareness-hackathon.md
@@ -1,5 +1,5 @@
 ---
-title: 'In Case You Missed It: #a11yhack, an Accessibility Hackathon'
+title: 'In case you missed it: #a11yhack, an accessibility hackathon'
 date: '2015-04-07'
 layout: post
 image: /assets/blog/a11yhack/a11yhack.jpg
@@ -108,7 +108,7 @@ and discussing accessibility needs and concerns in the community. We’ll
 be doing more events like this in the future, so if you didn’t make it
 to this one, we hope to see you at the next.
 
-### Key Links
+### Key links
 
 [Resources](https://18f.github.io/hackathons/a11yhack/resources):
 Accessibility Resources.
@@ -123,7 +123,7 @@ Accessibility Tools.
 [Hackpad](https://hackpad.com/Accessibility-Hackathon-a11yhack-FSW5lFX53LP):
 Shared notes from hackathon.
 
-### Hackathon Projects:
+### Hackathon projects:
 
 Join or post your projects in the [snapshot of the Accessibility
 Hackathon

--- a/_posts/2015-04-09-flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform.md
+++ b/_posts/2015-04-09-flexibility-when-releasing-a-new-product-peace-corps-new-donation-platform.md
@@ -1,5 +1,5 @@
 ---
-title: "Flexibility When Releasing A New Product: Peace Corps' New Donations Platform"
+title: "Flexibility when releasing a new product: Peace Corps' new donations platform"
 date: '2015-04-09'
 layout: post
 image: /assets/blog/peacecorps/image04.png
@@ -34,8 +34,7 @@ call and look at other decisions which still keep us up at night. By
 highlighting some of the bigger (and more contentious) decision points,
 we hope we can help inform your next project(s), as well as our own.
 
-Progressive Enhancement
------------------------
+## Progressive enhancement
 
 Our effort to refresh the Peace Corps' donations platform stemmed from
 many goals, such as highlighting volunteer stories (to humanize the
@@ -68,7 +67,7 @@ re-prioritizing allowed us to make the product better on the whole.
 In another situation, starting with a simple solution ultimately led us
 down a worse path. Our most complex user interaction offers multiple
 filters and categorization mechanisms for selecting how a user's
-donation will be used by the Peace Corps Volunteers. A reasonable
+donation will be used by the Peace Corps volunteers. A reasonable
 technical architecture for this sort of page would involve asynchronous
 requests, where data is transmitted in chunks instead of in one large
 block, so that the browser only loads what is needed. We chose to start
@@ -83,8 +82,7 @@ later added additional patches to minimize redundant markup. We're still
 not where we should be with regards to site load time because our
 initial approach was too simplistic.
 
-Zero Downtime and Caching Overkill
--------------
+## Zero downtime and caching overkill
 
 During our early planning phases, we were informed there might be a
 couple concurrent announcements by the Peace Corps which could drive
@@ -117,8 +115,7 @@ the beefy implementation was overkill. If we had instead started with a
 simpler vision, we would have simpler configuration, leaving less room
 for confusion and waste.
 
-Cutting Features
-----------------
+## Cutting features
 
 Replacing legacy (existing, outdated) systems is always a challenge. Not
 only do we need to find all of the technical boundaries, we are also
@@ -151,8 +148,7 @@ search feature in the backlog (a holding area for features not actively
 planned). When it came time to release, the feature was still not
 present. Time will tell whether this tradeoff was worthwhile.
 
-The Road Ahead
---------------
+## The road ahead
 
 We will no doubt see more dividends and costs associated with our
 technical choices in the coming months, but we have pulled out the above

--- a/_posts/2015-04-20-act-iac-event-on-devops-in-the-government.md
+++ b/_posts/2015-04-20-act-iac-event-on-devops-in-the-government.md
@@ -1,5 +1,5 @@
 ---
-title: "ACT-IAC Event on DevOps in the Government"
+title: "ACT-IAC event on DevOps in the government"
 authors:
 - jhunter
 - noah
@@ -15,11 +15,11 @@ date: '2015-04-20'
 
 excerpt: "Themed 'Achieve Agile Nirvana Through DevOps,' the education and
 training event will be held from 8:00 a.m. to 11:00 a.m. on Friday, May 1 at the
-General Services Administration, 1800 F Street NW, in Washington, DC."
+General Services Administration, 1800 F Street NW, in Washington, D.C."
 
 description: "Themed 'Achieve Agile Nirvana Through DevOps,' the education and
 training event will be held from 8:00 a.m. to 11:00 a.m. on Friday, May 1 at the
-General Services Administration, 1800 F Street NW, in Washington, DC."
+General Services Administration, 1800 F Street NW, in Washington, D.C."
 ---
 Improving collaboration and communication between an organization’s
 development resources and its operational resources is the focus of an
@@ -29,7 +29,7 @@ Themed [*“Achieve Agile Nirvana Through DevOps,”*](https://actiac.org/groups
 training event will be held from 8:00 a.m. to 11:00 a.m. on Friday, May 1 at the
 [*General Services
 Administration*](http://gsa.gov/portal/category/100000), 1800 F Street
-NW, in Washington, DC.
+NW, in Washington, D.C.
 
 "DevOps is an IT solution development and implementation approach that promotes better collaboration and communication between an organization’s development resources and its operational resources," according to the [*ACT-IAC website*](https://actiac.org/groups/event/achieve-agile-nirvana-through-devops-512015). "This approach aims to provide increased quality and efficiency of the solution by focusing on the delivery of the entire 'service' targeted by the solution and not just one single software 'product.'”
 
@@ -43,10 +43,10 @@ to rapidly deploy IT solutions.
 
 Featured speakers and panelists will include:
 * Mark Schwartz, CIO at United States Citizen and Immigration Services
-* Lisa Gelobter, Chief Digital Service Officer at the Department of Education
-* Greg Godbout, CTO at EPA and former Executive Director of 18F
-* Kaitlin Devine, Director of Engineering at 18F
-* Noah Kunin, Head of Delivery Architecture at 18F
+* Lisa Gelobter, chief digital service officer at the Department of Education
+* Greg Godbout, CTO at EPA and former executive director of 18F
+* Kaitlin Devine, director of engineering at 18F
+* Noah Kunin, head of delivery architecture at 18F
 
 **Emerging Technology SIG Agile Committee Special Program Event Logistics**
 
@@ -59,8 +59,8 @@ Featured speakers and panelists will include:
 **Location**: General Services Administration (GSA), Conference Center, 1800 F Street NW, Washington DC 20405
 (metro stops Farragut North and Farragut West serve this location and are a few blocks away)
 
-**Fee**: No cost for Federal employees; $25 for non-Federal ACT-IAC members and $35 for non-Federal attendees to cover logistics.
+**Fee**: No cost for federal employees; $25 for non-federal ACT-IAC members and $35 for non-federal attendees to cover logistics.
 
-**Member Registration**: www.actiac.org/register
+**Member registration**: www.actiac.org/register
 
-**Non-Member Registration**: rwright@actiac.org
+**Non-member registration**: rwright@actiac.org

--- a/_posts/2015-04-21-hackathons-not-just-for-folks-who-code.md
+++ b/_posts/2015-04-21-hackathons-not-just-for-folks-who-code.md
@@ -1,5 +1,5 @@
 ---
-title: "Hackathons: Not Just For Folks Who Code"
+title: "Hackathons: not just for folks who code"
 layout: post
 authors:
 - kate
@@ -30,7 +30,7 @@ volunteers and their larger communities. When people with diverse
 talents contribute to a unified cause, the outcome is more complex — and
 more likely to succeed.
 
-Getting Started
+Getting started
 ---------------
 
 My first night at the two-day event, I demoed
@@ -65,8 +65,7 @@ our team.”
 Like that, I’d found a way I could participate in the way I do best — by
 creating content.
 
-Increasing Involvement
------------------------
+## Increase involvement
 
 The next morning, coffee in hand, I wandered over to the Communicart
 station. Raphy paired me up with Brad, a sales rep for a major CRM
@@ -92,8 +91,8 @@ together and channeling the positive, competitive energy of the group,
 we’d made a meaningful contribution to Communicart — and, by extension,
 the government.
 
-Replicating the Good Vibes
---------------------------
+## Replicate the good vibes
+
 
 Perhaps my favorite part of this anecdote is that Brad’s and my
 experience is far from unique: Everywhere you go, you’ll find talented
@@ -123,8 +122,7 @@ a product lead at 18F, for generating this list of strategies.
 The following are our tips on including non-coders to your next
 hackathon.
 
-Tips for Hackathon Organizers
------------------------------
+## Tips for hackathon organizers
 
 ### Advertise to non-developers first
 

--- a/_posts/2015-04-23-coming-soon-the-agile-delivery-services-soliciatation.md
+++ b/_posts/2015-04-23-coming-soon-the-agile-delivery-services-soliciatation.md
@@ -1,5 +1,5 @@
 ---
-title: "Coming Soon: The Agile Delivery Services Solicitation"
+title: "Coming soon: the agile delivery services solicitation"
 layout: post
 authors:
 - chrisc
@@ -9,11 +9,11 @@ tags:
 - 18f consulting
 - agile
 - request for quote
-excerpt: "Calling all Agile vendors...get ready! By the end of this month, GSA will be releasing a Request for Quote (RFQ) for the alpha version of the Agile Delivery Services Blanket Purchase Agreement"
-description: "Calling all Agile vendors...get ready! By the end of this month, GSA will be releasing a Request for Quote (RFQ) for the alpha version of the Agile Delivery Services Blanket Purchase Agreement"
+excerpt: "Calling all agile vendors...get ready! By the end of this month, GSA will be releasing a Request for Quote (RFQ) for the alpha version of the Agile Delivery Services Blanket Purchase Agreement"
+description: "Calling all agile vendors...get ready! By the end of this month, GSA will be releasing a Request for Quote (RFQ) for the alpha version of the Agile Delivery Services Blanket Purchase Agreement"
 ---
 
-Calling all Agile vendors...get ready!
+Calling all agile vendors...get ready!
 
 By the end of this month, GSA will be releasing a Request for Quote
 (RFQ) for the [alpha version of the Agile Delivery Services Blanket
@@ -32,4 +32,4 @@ Now it's time to solicit the services of those vendors who want to be a part of 
 For those vendors with prior Federal bidding experience, you’ll find this RFQ unique in many ways. First, we’re going to evaluate you based on a submission of a working prototype. Second, you’ll need to write more code than narrative. Third, you’ll submit pricing for [labor
 categories](https://18f.gsa.gov/2015/03/10/Labor-Category-Descriptions-for-Agile-Procurements/) specifically written for the types of agile staff that 18F needs. And, last, you’ll have to be quick &#8212; the required turnaround time to submit an RFQ response is (very) short.
 
-We couldn’t be more excited about the weeks to come. The creation of this marketplace of Agile vendors will drive government technology forward in new and exciting ways. We welcome and look forward to your responses.
+We couldn’t be more excited about the weeks to come. The creation of this marketplace of agile vendors will drive government technology forward in new and exciting ways. We welcome and look forward to your responses.

--- a/_posts/2015-04-23-the-dat-team-talks-data-streams.md
+++ b/_posts/2015-04-23-the-dat-team-talks-data-streams.md
@@ -1,5 +1,5 @@
 ---
-title: "The Dat Team Talks Data Streams"
+title: "The dat team talks data Streams"
 layout: post
 authors:
 - eric

--- a/_posts/2015-04-24-agile-developments-secret-weapon-transparency.md
+++ b/_posts/2015-04-24-agile-developments-secret-weapon-transparency.md
@@ -1,5 +1,5 @@
 ---
-title: "Agile Development’s Secret Weapon: Transparency"
+title: "Agile development’s secret weapon: transparency"
 layout: post
 authors:
 - vdavez
@@ -8,14 +8,14 @@ tags:
 - agile
 - how we work
 - transparency
-excerpt: "18F Consulting recommends Agile development for several reasons, including Agile’s emphasis on user needs, continuous integration, and rapid adaptation to changed circumstances. But there is another important reason we recommend Agile: its focus on transparency."
-description: "18F Consulting recommends Agile development for several reasons, including Agile’s emphasis on user needs, continuous integration, and rapid adaptation to changed circumstances. But there is another important reason we recommend Agile: its focus on transparency."
+excerpt: "18F Consulting recommends agile development for several reasons, including agile’s emphasis on user needs, continuous integration, and rapid adaptation to changed circumstances. But there is another important reason we recommend agile: its focus on transparency."
+description: "18F Consulting recommends agile development for several reasons, including agile’s emphasis on user needs, continuous integration, and rapid adaptation to changed circumstances. But there is another important reason we recommend agile: its focus on transparency."
 image: /assets/blog/how-to-github/image.jpg
 ---
-[18F Consulting](https://18f.gsa.gov/consulting) recommends Agile
-development for several reasons, including Agile’s emphasis on user
+[18F Consulting](https://18f.gsa.gov/consulting) recommends agile
+development for several reasons, including agile’s emphasis on user
 needs, continuous integration, and rapid adaptation to changed
-circumstances. But there is another important reason we recommend Agile:
+circumstances. But there is another important reason we recommend agile:
 its focus on **transparency**.
 
 Two of the 12 principles of the [Agile
@@ -26,15 +26,15 @@ software is the primary measure of progress*.”
 
 Embedded in these principles is primacy of working software as a
 **measure of performance**, which is **highly visible**. After each
-iteration or sprint (usually every two weeks), an Agile team’s success
+iteration or sprint (usually every two weeks), an agile team’s success
 can be measured by whether the software works, or whether it doesn’t.
 This frequency of inspection creates a powerful transparency tool for
-product owners (agencies) who want to ensure that their Agile teams
+product owners (agencies) who want to ensure that their agile teams
 (often vendors) deliver a high-quality service, and to hold them
 accountable when they don’t.
 
 How do you distinguish working from non-working software at the end of
-every iteration? This is where the concept of “done done” in Agile comes
+every iteration? This is where the concept of “done done” in agile comes
 into play. When a unit of work, which is normally expressed as a [user
 story](http://guide.agilealliance.org/guide/user-stories.html), can
 potentially be released into a production environment at the end of the
@@ -47,9 +47,9 @@ done](https://www.scrumalliance.org/community/articles/2008/september/what-is-de
 
 Your definition of done should include everything required to make the
 user story **completely done**. Creating (and maintaining) a checklist
-of user-story-completion criteria is a great way to ensure your Agile
+of user-story-completion criteria is a great way to ensure your agile
 team understands what “done done” means. Here’s a sample checklist that
-we’ve modified from the book [*The Art of Agile
+we’ve modified from the book [*The Art of agile
 Development*](http://www.jamesshore.com/Agile-Book/) by James Shore:
 
 1.  **Tested:** all unit, integration, and customer tests are finished
@@ -65,14 +65,14 @@ Development*](http://www.jamesshore.com/Agile-Book/) by James Shore:
 11. **Documented:** when appropriate, documentation such as a training guide is created or updated
 
 Unless you know when user stories are truly done, you’ll have little —
-if any — insight into the performance of your Agile team. As you assess
+if any — insight into the performance of your agile team. As you assess
 your team’s performance, use both *user acceptance criteria* and the
 *definition of done* to inform your assessment. Doing so explicitly
-ensures that you can measure your Agile Team’s performance in a highly
+ensures that you can measure your agile team’s performance in a highly
 visible way, and focus on what counts: working software.
 
-If you’re interested in learning more about how Agile can provide
+If you’re interested in learning more about how agile can provide
 greater transparency in your new or existing projects, [email us at 18F
 Consulting](mailto:Inquiries18F@gsa.gov). We’d also love to hear your
-perspectives and learn from your experiences; if you have used Agile in
+perspectives and learn from your experiences; if you have used agile in
 government to help promote transparency, drop us a line.

--- a/_posts/2015-04-28-intersection-of-art-and-technology.md
+++ b/_posts/2015-04-28-intersection-of-art-and-technology.md
@@ -1,5 +1,5 @@
 ---
-title: "The Intersection of Art and Technology"
+title: "The intersection of art and technology"
 layout: post
 authors:
 - julia

--- a/_posts/2015-04-29-18f-how-we-write.md
+++ b/_posts/2015-04-29-18f-how-we-write.md
@@ -1,5 +1,5 @@
 ---
-title: "18F: A Great Place to Write"
+title: "18F: a great place to write"
 layout: post
 authors:
 - melody

--- a/_posts/2015-05-07-layering-innovation.md
+++ b/_posts/2015-05-07-layering-innovation.md
@@ -26,9 +26,9 @@ the way to provisioning and deployment.** To do that, we implemented
 an open source platform as a service for our developers. Here’s a look
 at how we created it.
 
-## The Problem
+## The problem
 
-The adoption of Agile, lean, and user-centric design methodologies means
+The adoption of agile, lean, and user-centric design methodologies means
 projects now take weeks to build rather than years. But when it’s time
 to deploy them, projects can get waylaid by months of bureaucracy and
 legacy systems that don’t have the flexibility of modern infrastructure.
@@ -48,7 +48,7 @@ process that includes security and administrative reviews. This process
 is so burdensome that it can take up to 14 months of back and forth
 between the different parties before the public ever sees the product.
 
-## Our First Approach
+## Our first approach
 
 Our first approach was to focus on the review process to launch
 applications. If we could figure out how to minimize this process, it
@@ -81,7 +81,7 @@ configuration management was often more a burden than a blessing. In the
 spirit of lean development, we took our findings and feedback from the
 developers and went back to the drawing board.
 
-## Focusing on Our Users
+## Focusing on users
 
 After extensive research, we realized that our users, the developers,
 just wanted to focus on writing applications, not managing configuration
@@ -98,7 +98,7 @@ benefit of being able to reuse approved components, and provide an
 environment where running the application is the last piece of the
 puzzle.
 
-## Building and Deploying a Platform
+## Building and deploying a platform
 
 The idea of providing a platform to a team of developers is hardly
 novel. There are many solutions available and many opinions on which is

--- a/_posts/2015-06-22-avoiding-cloudfall.md
+++ b/_posts/2015-06-22-avoiding-cloudfall.md
@@ -100,7 +100,7 @@ using an iterative approach to cloud migration, both offices can develop
 a greater understanding of each others’ needs and continuously improve
 as migration proceeds.
 
-### Staged Prioritization
+### Staged prioritization
 
 In parallel with our [general
 product-stage](https://18f.gsa.gov/dashboard/stages/) approach, cloud

--- a/_posts/2015-06-24-thomas-vander-wal-event.md
+++ b/_posts/2015-06-24-thomas-vander-wal-event.md
@@ -14,7 +14,7 @@ image: /assets/blog/vander-wal/email.jpg
 ---
 
 William Shakespeare invented more than 1,700 English words. For
-example, *swagger.* Also, *bedazzled.*
+example, *swagger*. Also, *bedazzled*.
 
 *Folksonomy* and *infocloud* — language innovations of Thomas Vander
 Wal — haven’t yet reached Shakespearean fame, but they’re shaping up to

--- a/_posts/2015-09-01-govconnect-launch.md
+++ b/_posts/2015-09-01-govconnect-launch.md
@@ -95,7 +95,7 @@ and helps develop critical skills and build professional networks across
 the government to where and when they’re needed. GovConnect is a network
 of existing and new programs that seek to achieve this goal.
 
-## GovConnect phase 1
+## GovConnect phase one
 
 In April 2014, OPM's [call for
 participation](https://www.chcoc.gov/content/govconnect-expo-follow-identifying-volunteer-pilot-agencies)

--- a/_posts/2015-09-03-every-kid-in-a-park.md
+++ b/_posts/2015-09-03-every-kid-in-a-park.md
@@ -24,7 +24,7 @@ not seem to go hand in hand.
 
 But the launch of Every Kid in a Park highlights how user research can
 bring beautiful, useful design to federal websites — including those
-aimed at kids.
+aimed at children.
 
 Every Kid in a Park gives U.S. fourth graders free access to all federal
 lands and water — including national parks, forests, wildlife refuges,
@@ -40,7 +40,7 @@ Department of Interior."
 
 [everykidinapark.gov](https://everykidinapark.gov)
 is the landing page for that program. It includes a comprehensive list
-of where kids can go, and explains how the program works, and how to
+of where kids can go, explains how the program works, and shows how to
 print a pass. Best of all, it was designed, developed, and written for
 10-year-olds.
 
@@ -49,7 +49,7 @@ U.S. Department of Interior and other federal land management agencies.
 
 “I'm so proud to be part of this initiative that gets children out from
 in front of their screens indoors to great, wild, and exciting
-outdoors,” 18F developer Shashank Khandelwal said. Khandelwal served as
+outdoors,” 18F Developer Shashank Khandelwal said. Khandelwal served as
 the website’s product manager.
 
 This sentiment was echoed across team members. Christine Cheung, the


### PR DESCRIPTION
- Addresses headline capitalization for all of 2015 heads and subheads
- Fixes instances of "Agile" "AM" "PM" "open-source" "Federal" and "Government," per 18F Content Guide