### PR TITLE
Move staging site to staging.18f.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains 18F's website, https://18f.gsa.gov.
 
 ### Deployment and workflow
 
-* The `staging` branch is **automatically deployed** to our [staging site](https://staging.18f.us).
+* The `staging` branch is **automatically deployed** to our [staging site](https://staging.18f.gov).
 * The `production` branch is **automatically deployed** to our [production site](https://18f.gsa.gov).
 
 **All development and pull requests should be done against the `staging` branch.**

--- a/deploy/18f-site.conf
+++ b/deploy/18f-site.conf
@@ -1,4 +1,4 @@
-# nginx configuration for 18f.gsa.gov, and its staging site, staging.18f.us.
+# nginx configuration for 18f.gsa.gov, and its staging site, staging.18f.gov.
 #
 # Also handles forwarding /deploy webhooks for GitHub, so that pushes to
 # the `staging` and `production` branches deploy to the staging and
@@ -7,7 +7,7 @@
 # For our TLS configuration (ssl.rules), please see
 # https://github.com/18F/tls-standards/blob/master/configuration/nginx/ssl.rules
 #
-# HSTS is handled slightly differently for the root 18f.us redirect (it does not
+# HSTS is handled slightly differently for the root 18f.gov redirect (it does not
 # include subdomains, as we use that domain for all kinds of testing), so each
 # domain has to either include hsts.rules or hsts-no-subdomains.rules.
 #
@@ -49,22 +49,6 @@ server {
       root /home/site/production/hub/_site_public;
       index index.html api.json;
       default_type text/html;
-  }
-
-  # proxy to hydra, cover up for their lack of HTTPS
-  location /listserv {
-    proxy_pass http://hydra.gsa.gov/cgi-bin/listserv.pl;
-    proxy_http_version 1.1;
-    proxy_redirect off;
-
-    # *don't* forward hostname or protocol
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_max_temp_file_size 0;
-
-    proxy_connect_timeout 10;
-    proxy_send_timeout    30;
-    proxy_read_timeout    30;
   }
 
   # production hook runs on port 4000
@@ -143,16 +127,16 @@ server {
 }
 
 
-# staging site, https://staging.18f.us
+# staging site, https://staging.18f.gov
 # staging site comes first so that it intercepts other domain names too
 server {
   listen 443 ssl spdy;
   server_name default_server;
-  server_name  staging.18f.us;
+  server_name  staging.18f.gov;
 
   # wildcard cert
-  ssl_certificate      /etc/nginx/ssl/keys/star.18f.us-chain.crt;
-  ssl_certificate_key  /etc/nginx/ssl/keys/star.18f.us.key;
+  ssl_certificate      /etc/nginx/ssl/keys/staging.18f.gov.chained.crt;
+  ssl_certificate_key  /etc/nginx/ssl/keys/staging.18f.gov.key;
   include ssl/ssl.rules;
   include ssl/hsts.rules;
   include cors.rules;
@@ -203,23 +187,6 @@ server {
       proxy_read_timeout    30;
   }
 
-  # proxy to hydra, cover up for their lack of HTTPS
-  location /listserv {
-    proxy_pass http://hydra.gsa.gov/cgi-bin/listserv.pl;
-    proxy_http_version 1.1;
-    proxy_redirect off;
-
-    # *don't* forward hostname or protocol
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_max_temp_file_size 0;
-
-    proxy_connect_timeout 10;
-    proxy_send_timeout    30;
-    proxy_read_timeout    30;
-  }
-
-
   access_log  /home/site/staging/nginx_access.log main;
   error_log  /home/site/staging/nginx_error.log;
 }
@@ -236,34 +203,15 @@ server {
 
 server {
     listen 80;
-    server_name staging.18f.us;
-    return 301 https://staging.18f.us$request_uri;
+    server_name staging.18f.gov;
+    return 301 https://staging.18f.gov$request_uri;
 }
 
-# redirect 18f.us and 18f.gov to our homepage
+# redirect 18f.gov to our homepage
 server {
   listen 80;
-  server_name 18f.us;
-  server_name www.18f.us;
   server_name 18f.gov;
   server_name www.18f.gov;
-
-  add_header Cache-Control no-cache;
-
-  return 301 https://18f.gsa.gov$request_uri;
-}
-
-# also redirect https://18f.us to our homepage
-server {
-  listen 443 ssl spdy;
-  server_name 18f.us;
-  server_name www.18f.us;
-
-  ssl_certificate      /etc/nginx/ssl/keys/star.18f.us-chain.crt;
-  ssl_certificate_key  /etc/nginx/ssl/keys/star.18f.us.key;
-  include ssl/ssl.rules;
-  include ssl/hsts-no-subdomains.rules;
-  include headers.rules;
 
   add_header Cache-Control no-cache;
 


### PR DESCRIPTION
I moved the staging site to staging.18f.gov, and removed all references to staging.18f.us from nginx, from the README, and updated this repo's webhook URL.

staging.18f.us is no longer guaranteed to work at all (and doesn't serve an 18f.us cert anymore, expired or not).

I verified that the staging.18f.gov webhook was operating as expected with a couple of trivial HTML comment hotfixes to `staging`.