### PR TITLE
Link for CF contact form

### DIFF
--- a/_posts/2015-10-09-cloud-gov-launch.md
+++ b/_posts/2015-10-09-cloud-gov-launch.md
@@ -115,6 +115,6 @@ bottlenecks that pop up, and then hope to roll the service out more
 broadly.
 
 If you're interested in [cloud.gov](https://cloud.gov), be sure to
-drop your email address in the form located at https://cloud.gov, or
+drop your email address in the [form located at https://cloud.gov](https://cloud.gov/#contact), or
 drop by our [#devops-public Slack channel](https://chat.18f.gov/) to
 chat about it.


### PR DESCRIPTION
The link for the cloud.gov contact form was missing from the blog post. I'm adding it here, not quite sure what to do next so I'm pinging a few people :)

@awfrancisco @mogul 