### PR TITLE
Two author byline fix.

### DIFF
--- a/_includes/byline.html
+++ b/_includes/byline.html
@@ -1,9 +1,10 @@
 {% if include.context == 'page' and page.authors %}{% assign authors = page.authors %}{% endif %}{% if include.context == 'post' and post.authors %}{% assign authors = post.authors | to_yaml %}{% endif %}
-<p class="authors">
+<p class="authors">{% if authors.size == 2 %}
+  by <span class="author {{author[0]}}" style="color: #000">{{ authors[0] | team_link }}</span> and <span class="author {{author[1]}}" style="color:#000">{{ authors[1] | team_link }}</span>{% else %}
   by {% for author in authors %}
   <span class="author {{author}}" style="color: #000">
     {{ author | team_link }}{% unless forloop.last %}, {% endunless %}{% if forloop.rindex0 == 1 %} and {% endif %}
-  {% endfor %}</span>
+  {% endfor %}</span>{% endif %}
 </p>
 {% comment %}
 Take out the `{ if site.collections.team.output }` logic after


### PR DESCRIPTION
Modifies the byline include so that no comma separates names when only
two authors are on a post.

Fixes #1246, cc: @awfrancisco @18F/blog 