### PR TITLE
Fixes the user-research tag bug

### DIFF
--- a/pages/tags/user research.md
+++ b/pages/tags/user research.md
@@ -1,5 +1,5 @@
 ---
-permalink: /tags/user-research/
+permalink: /tags/user research/
 redirect_to:
   - /tags/user-research/
 ---


### PR DESCRIPTION
The page at /tags/user-research was redirecting to itself! Infinitely!
What is supposed to happen is the old /tags/user%20research/ redirects to /tags/user-research; that happens now.

cc: @carodew @awfrancisco @18F/blog 