### PR TITLE
More CSS Refactoring 

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -43,8 +43,8 @@
 }
 
 .container-spaced {
-	padding-bottom: 40px;
-	padding-top: 40px;
+  padding-bottom: 40px;
+  padding-top: 40px;
 }
 
 .lead {

--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -20,7 +20,6 @@
 	}
 }
 
-
 // Extends
 //********************************************************
 %heading-text-style {
@@ -42,6 +41,12 @@
 .container {
 	@include outer-container;
 }
+
+.container-spaced {
+	padding-bottom: 40px;
+	padding-top: 40px;
+}
+
 .lead {
 	font-size: 1.4em;
 	line-height: 1.6em;

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -55,13 +55,14 @@ h6 {
 
 p {
   font-size: 1em;
-  padding: 0; 
-  margin: 0;
   line-height: 1.5;
-    + p {
-      margin-bottom: 0.4em;
-      margin-top: 0.5em;
-    }
+  margin: 0;
+  padding: 0;
+
+  + p {
+    margin-bottom: 0.4em;
+    margin-top: 0.5em;
+  } 
 }
 
 a {
@@ -78,24 +79,14 @@ a {
   }
 }
 
-// TODO audit codebase to determine if this works. Remove link-alt if it works.
-/*
-h1, h2, h3, h4, h5, h6 {
-  > a {
-    color: $red;
-    text-decoration: none;
-    &:hover, &:focus {
-        text-decoration: underline;
-    }
-  }
-}
-*/
 
 .link-alt {
   color: $red;
   text-decoration: none;
-  &:hover, &:focus {
-      text-decoration: underline;
+
+  &:hover, 
+  &:focus {
+    text-decoration: underline;
   }
 }
 

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -35,8 +35,18 @@ h3 {
   font-size: $base-font-size * 1.75; // 16 * 1.75 = 28px
 }
 
+.h3 {
+  font-size: $base-font-size * 1.75; // 16 * 1.75 = 28px
+}
+
 h4 {
   font-size: $base-font-size * 1.5; // 16 * 1.5 = 24px
+}
+
+// TODO change to match <h4>.
+.h4 {
+  font-size: 22px;
+  font-weight: 700;
 }
 
 h5 {
@@ -62,6 +72,27 @@ a {
   &:active, &:focus {
     color: $hover-link-color;
     outline: none;
+  }
+}
+
+// TODO audit codebase to determine if this works. Remove link-alt if it works.
+/*
+h1, h2, h3, h4, h5, h6 {
+  > a {
+    color: $red;
+    text-decoration: none;
+    &:hover, &:focus {
+        text-decoration: underline;
+    }
+  }
+}
+*/
+
+.link-alt {
+  color: $red;
+  text-decoration: none;
+  &:hover, &:focus {
+      text-decoration: underline;
   }
 }
 

--- a/assets/_sass/base/_typography.scss
+++ b/assets/_sass/base/_typography.scss
@@ -35,10 +35,6 @@ h3 {
   font-size: $base-font-size * 1.75; // 16 * 1.75 = 28px
 }
 
-.h3 {
-  font-size: $base-font-size * 1.75; // 16 * 1.75 = 28px
-}
-
 h4 {
   font-size: $base-font-size * 1.5; // 16 * 1.5 = 24px
 }
@@ -58,7 +54,14 @@ h6 {
 }
 
 p {
-  margin: 0 0 ($base-line-height * .5);
+  font-size: 1em;
+  padding: 0; 
+  margin: 0;
+  line-height: 1.5;
+    + p {
+      margin-bottom: 0.4em;
+      margin-top: 0.5em;
+    }
 }
 
 a {

--- a/assets/_sass/components/_blog.scss
+++ b/assets/_sass/components/_blog.scss
@@ -4,20 +4,10 @@
 	margin-top: 10px;
 }
 
-.blog-entry, .service-entry {
-	@extend %section-padding; //standard padding for all sections
-	padding-top: 25px; //compensates for padding in top row of news section
-
-	p {
-		font-size: 0.9em;
-		padding: 0; margin: 0;
-		line-height: 1.8;
-		+ p {
-			margin-bottom: 0.4em;
-			margin-top: 0.5em;
-		}
-	}
-}
+// .blog-entry, .service-entry {
+// 	@extend %section-padding; //standard padding for all sections
+// 	padding-top: 25px; //compensates for padding in top row of news section
+// }
 
 .blog-title, .service-title {
 	@include span-columns(12);

--- a/assets/_sass/components/_blog.scss
+++ b/assets/_sass/components/_blog.scss
@@ -7,17 +7,7 @@
 .blog-entry, .service-entry {
 	@extend %section-padding; //standard padding for all sections
 	padding-top: 25px; //compensates for padding in top row of news section
-	h1 {
-		font-size: 22px;
-	  	font-weight: 700;
-		> a {
-			color: $red;
-			text-decoration: none;
-			&:hover, &:focus {
-		  		text-decoration: underline;
-			}
-		}
-	}
+
 	p {
 		font-size: 0.9em;
 		padding: 0; margin: 0;

--- a/blog/index.html
+++ b/blog/index.html
@@ -11,7 +11,7 @@ layout: bare
     Subscribe to updates <a href="https://ifttt.com/recipes/214709-a-new-18f-blog-post-email-me-a-link-to-go-read-it-right-away">by email</a>, or through <a href="/feed/">our RSS feed</a>.
   </p>
 
-  <div class="container blog-entry {{tag}}" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
+  <div class="container container-spaced blog-entry  {{tag}}" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
 
     {% for post in paginator.posts %}
           <article class="tag-index">

--- a/blog/index.html
+++ b/blog/index.html
@@ -16,7 +16,11 @@ layout: bare
     {% for post in paginator.posts %}
           <article class="tag-index">
             <div class="blog-title">
-              <h1 itemprop="headline"><a href="{{ post.url }}">{{ post.title }}</a></h1>
+              <h1 itemprop="headline" class="h4">
+                <a class="link-alt" href="{{ post.url }}">
+                  {{ post.title }}
+                </a>
+              </h1>
             </div>
 
             <div class="blog-meta">

--- a/pages/index.html
+++ b/pages/index.html
@@ -72,8 +72,8 @@ permalink: /
 
     {% for post in site.posts limit:3 %}
       <div class="blog-title">
-        <h1 itemprop="headline">
-          <a href="{{ post.url }}" class="blog-title">{{ post.title }}</a>
+        <h1 class="h4" itemprop="headline">
+          <a class="link-alt" href="{{ post.url }}" class="blog-title">{{ post.title }}</a>
         </h1>
       </div>
       <div class="blog-meta">

--- a/pages/index.html
+++ b/pages/index.html
@@ -51,7 +51,9 @@ permalink: /
   <article class="container service-entry" itemprop="department">
     {% for service in site.data.services %}
       <div class="service-title">
-        <h1><a href="{{ service.link }}" class="service-title" itemprop="name">{{ service.display }}</a></h1>
+        <h1 class="h4">
+          <a href="{{ service.link }}" class="service-title link-alt" 
+              itemprop="name">{{ service.display }}</a></h1>
       </div>
       <div class="service-snippet">
         <p>{{ service.description }}</p>


### PR DESCRIPTION
Did a few things to clean up the CSS. Was poking around and noticed that some styles were using the same styling across the site so move them in to `_base.scss`. Here's a list of things: 

- moved `p` & `h1` to site wide styling
- created `class=“h4”` for smaller `h1` tag in blog posts vs styling the `h1` tag itself
- move container padding to its own class `container-spaced` and removed `blog entry` and `service-entry` tags 
- increased `p` font size from 12 to 14 to be consistent in base

@gboone the big one I would love your opinion on is increasing the font size. @msecret and I noticed that the site uses 14px except for the blog which is slightly smaller. What are your thoughts on making it consistent throughout the site? Here are the differences: 

12px on the live site: 
<img width="858" alt="screen shot 2015-10-30 at 9 47 10 am" src="https://cloud.githubusercontent.com/assets/7362915/10847296/c1a49e2c-7eeb-11e5-8b14-32a6e7d50cff.png">

14px on the branch: 
<img width="867" alt="screen shot 2015-10-30 at 9 46 50 am" src="https://cloud.githubusercontent.com/assets/7362915/10847302/cc72fda8-7eeb-11e5-8972-64324316cb17.png">

