### PR TITLE
Tag movement for USEITI posts

### DIFF
--- a/_posts/2014-09-25-design-studio-onrr.md
+++ b/_posts/2014-09-25-design-studio-onrr.md
@@ -19,6 +19,7 @@ tags:
 - open data
 - how we work
 - workshop
+- useiti
 - eiti
 
 

--- a/_posts/2015-03-18-sunshine-week-extractive-industries-transparency-initiative-event.md
+++ b/_posts/2015-03-18-sunshine-week-extractive-industries-transparency-initiative-event.md
@@ -9,6 +9,7 @@ tags:
 - useiti
 - interior
 - sunshine week
+- eiti
 
 authors:
 - mhz

--- a/_posts/2015-11-02-useiti-what-we-learned-where-were-headed.md
+++ b/_posts/2015-11-02-useiti-what-we-learned-where-were-headed.md
@@ -7,6 +7,7 @@ tags:
 - our projects
 - eiti
 - open data
+- useiti
 description: During Sunshine Week, we wrote about our progress on the U.S. Extractive Industries Transparency Initiative (USEITI). Since then, the 18F team has worked with the USEITI team to process research on the current state of the project as well as the next steps for the U.S. as a candidate country for the global initiative.
 excerpt: During Sunshine Week, we wrote about our progress on the Extractive Industries Transparency Initiative, or EITI, an international coalition organized here by the U.S. Department of the Interior and a multi-stakeholder group that includes representatives from nonprofits, academia, industry and local governments. Since March, the 18F team has worked with the USEITI team to process research on the current state of the project as well as the next steps for the U.S. as a candidate country for the global initiative.
 image: /assets/blog/eiti/drill.jpg


### PR DESCRIPTION
We tagged two posts EITI, another USEITI. Since our work is about both the US initiative and part of the global, we should use both.