### PR TITLE
fixes the blog title of tag pages

### DIFF
--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -10,7 +10,7 @@ layout: bare
     {% for post in page.posts %}
         <article class="tag-index">
           <div class="blog-title">
-            <h1 itemprop="headline"><a href="{{ post.url }}">{{ post.title }}</a></h1>
+            <h1 itemprop="headline" class="h4"><a class="link-alt" href="{{ post.url }}">{{ post.title }}</a></h1>
           </div>
 
           <div class="blog-meta">


### PR DESCRIPTION
Whoops! In trying to clean up the CSS, I broke the blog titles in the tag list page. This fixes that. 