### PR TITLE
Hides the unlabeled field from the DOM, addresses #a11y issues

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -11,7 +11,7 @@
       <form action="https://gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=cbc418738b" method="post" id="contact-form">
       <div class="form-group"><label class="sr-hide" for="FULLNAME">Your name</label><input type="text" placeholder="Your Name" id="FULLNAME" name="FULLNAME" /></div>
       <div class="form-group"><label class="sr-hide" for="EMAIL">Your email address (required)</label><input type="text" placeholder="your@email-address.com" id="EMAIL" required name="EMAIL" /></div>
-      <div style="position: absolute; left: -5000px;"><input type="text" name="b_6f1977de9eff4c384dc8d6527_cbc418738b" tabindex="-1" value=""></div>
+      <div style="position: absolute; left: -5000px;"><input type="hidden" name="b_6f1977de9eff4c384dc8d6527_cbc418738b" tabindex="-1" value=""></div>
       <input type="submit" class="button" value="Sign up to subscribe to our newsletter" />
       </form>
     </div>


### PR DESCRIPTION
We don't need to show that, and it's probably better that we don't anyway.

@adelevie this is a fix for the accessibility issue you reported on #blog this afternoon. It turns out we were not hiding a field that didn't need any user input anyway. This fixes the `input` to make it `type="hidden"` instead of `type="text"`. cc: @nickbristow @18F/blog 