### PR TITLE
colin => colinmacarthur

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -249,7 +249,7 @@ jtindel:
   full_name: John Tindel
   first_name: John
   last_name: Tindel
-colin:
+colinmacarthur:
   full_name: Colin MacArthur
   first_name: Colin
   last_name: MacArthur

--- a/_posts/2015-06-15-building-a-better-welcome-wagon.md
+++ b/_posts/2015-06-15-building-a-better-welcome-wagon.md
@@ -5,7 +5,7 @@ layout: post
 authors:
 - mbland
 - emileigh
-- colin
+- colinmacarthur
 tags:
 - how we work
 - training

--- a/_posts/2015-08-10-18f-design-methods.md
+++ b/_posts/2015-08-10-18f-design-methods.md
@@ -4,7 +4,7 @@ date: 2015-08-10
 layout: post
 authors:
 - jeremy
-- colin
+- colinmacarthur
 - bradnunnally
 - jthibault
 - russ

--- a/_posts/2015-09-28-web-design-standards.md
+++ b/_posts/2015-09-28-web-design-standards.md
@@ -5,7 +5,7 @@ authors:
 - mollieruskin
 - carolyndew
 - mayabenari
-- colin
+- colinmacarthur
 tags:
 - proactive federal partner
 - our projects

--- a/_posts/2015-11-19-how-we-use-a-lean-approach-to-product-design.md
+++ b/_posts/2015-11-19-how-we-use-a-lean-approach-to-product-design.md
@@ -4,7 +4,7 @@ date: 2015-11-18
 layout: post
 authors:
 - brethauer
-- colin
+- colinmacarthur
 tags:
 - lean
 - design


### PR DESCRIPTION
Either `colin`'s name changed in the team api, or we always had it wrong in the author file. Either way, it's fixed now.