### PR TITLE
Add jekyll-seo-tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem 'jekyll-paginate'
   gem 'jekyll-redirect-from', '~> 0.9'
   gem 'jekyll_frontmatter_tests'
+  gem 'jekyll-seo-tag'
 end
 
 gem 'jemoji'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       jekyll (>= 2.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
+    jekyll-seo-tag (0.1.3)
+      jekyll (>= 2.0)
     jekyll-sitemap (0.8.1)
     jekyll-watch (1.3.0)
       listen (~> 3.0)
@@ -102,6 +104,7 @@ DEPENDENCIES
   jekyll-archives!
   jekyll-paginate
   jekyll-redirect-from (~> 0.9)
+  jekyll-seo-tag
   jekyll-sitemap
   jekyll_frontmatter_tests
   jekyll_pages_api

--- a/_config.yml
+++ b/_config.yml
@@ -19,10 +19,11 @@ exclude:
 - Gemfile
 - Gemfile.lock
 
-gems: 
+gems:
   - jekyll-sitemap
   - jekyll-archives
   - jekyll-redirect-from
+  - jekyll-seo-tag
 
 jekyll-archives:
   enabled:
@@ -82,3 +83,15 @@ collections:
     permalink: /press/:name/
 
 full_rebuild: true
+
+# SEO
+twitter:
+  username: "18F"
+
+logo: "/assets/images/favicons/18f-center-144.png"
+
+social:
+  type: "organization"
+  links:
+    - https://twitter.com/18F
+    - https://www.youtube.com/channel/UCmm0GRNzfwE9eghoKijMC3w 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="google-site-verification" content="vmVo2wbQpKGMHVpllQP7bQ0w5gICWD356VH9DNbv5f4" />
 
-
 <!-- Mobile Specific Metas
 ================================================== -->
 <meta name="HandheldFriendly" content="True">
@@ -13,48 +12,9 @@
 
 <!-- RSS feeds
 ================================================== -->
-
 <link rel="alternate" type="application/rss+xml" title="{{ site.title | xml_escape }} &raquo; Feed" href="/feed/" />
 
-<!-- Twitter and OpenGraph data
-================================================== -->
-<meta name="twitter:site" content="@18F">
-<meta name="twitter:creator" content="@18F">
-<meta property="og:site_name" content="{{ site.title | xml_escape }}" />
-<meta property="og:type" content="website" />
-
-<meta property="og:url" content="{{ site.url }}{{ page.url }}" />
-<link rel="canonical" href="{{ site.url }}{{ page.url }}" />
-
-<!-- title, description, and image may change per-page, per-post -->
-{% if page.title %}
-  <title>18F &mdash; {{ page.title }}</title>
-  <meta property="og:title" content="{{ page.title | xml_escape }}" />
-{% else %}
-  <title>{{ site.title }}</title>
-  <meta property="og:title" content="{{ site.title | xml_escape }}" />
-{% endif %}
-{% if page.description %}
-  <meta name="description" content="{{ page.description | xml_escape }}">
-  <meta property="og:description" content="{{ page.description | xml_escape }}" />
-{% elsif page.excerpt %}
-  <meta name="description" content="{{ page.excerpt | strip_html | xml_escape }}" />
-  <meta property="og:description" content="{{page.excerpt | strip_html | xml_escape }}" />
-{% else %}
-  <meta name="description" content="{{ site.description | xml_escape }}">
-  <meta property="og:description" content="{{ site.description | xml_escape }}" />
-{% endif %}
-
-<!-- use large summary card for posts with images, normal summary otherwise -->
-{% if page.image %}
-  <meta name="twitter:card" content="summary_large_image">
-  <meta property="og:image" content="{{ site.url }}{{ page.image }}" />
-{% else %}
-  <!-- until Twitter's card approver fixes itself, need to use summary_large_image here too because we can't get approved for both -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta property="og:image" content="{{ site.url }}/assets/images/18f-share-image.jpg" />
-{% endif %}
-
+{% seo %}
 
 <!-- Favicons
 ================================================== -->


### PR DESCRIPTION
This pull requests adds the Jekyll SEO Tag plugin.

You can [read more about specifically what the plugin does](https://github.com/benbalter/jekyll-seo-tag#what-it-does).

Similar to https://github.com/18F/18f.gsa.gov/pull/1335 it replaces the bespoke template in this repository with [a shared template](https://github.com/benbalter/jekyll-seo-tag/blob/master/lib/template.html).

This should support everything currently supported, plus next/previous URLs and JSON-LD post summary and site metadata. 

If there's anything the plugin doesn't do that you'd want it do to, I'd be glad to add it.

You can see example output [on my personal site](http://ben.balter.com) (output is explicitly commented).