### PR TITLE
Sets a default timezone

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,6 +46,7 @@ url: https://18f.gsa.gov
 title: 18F Digital Services Delivery
 name: 18F Digital Services Delivery
 description: "18F builds effective, user-centric digital services focused on the interaction between government and the people and businesses it serves."
+timezone: America/New_York
 
 # blog archive at /blog
 paginate: 5
@@ -69,6 +70,7 @@ defaults:
       type: "posts"
     values:
       layout: "post"
+
   -
     scope:
       collection: team


### PR DESCRIPTION
This should make for slightly more sensible time strings in the [feed](https://18f.gsa.gov/feed/). right now they're all set to `00:00` unless we pass something else with `date` on a post. That's `00:00+00:00` to be more accurate, or midnight, GMT. That turns out to be sometime between 2 and 7pm for most Americans, unless we set a different time, then it's even later in the day or maybe even the next day depending on what news readers do with the UTC time stamp.