### PR TITLE
git stash, git pull => git fetch, git reset

### DIFF
--- a/go
+++ b/go
@@ -82,10 +82,9 @@ def ci_build
 end
 
 def server_build
-  puts 'Stashing (just in case)'
-  exec_cmd 'git stash'
-  puts 'Pulling from git'
-  exec_cmd 'git pull'
+  puts 'Fetching from git'
+  exec_cmd 'git fetch origin staging'
+  exec_cmd 'git reset --hard origin/staging'
   update_gems(development=false)
   reset
   puts 'building site'
@@ -95,10 +94,9 @@ def server_build
 end
 
 def production_build
-  puts 'Stashing (just in case)'
-  exec_cmd 'git stash'
-  puts 'Pulling from git'
-  exec_cmd 'git pull'
+  puts 'Fetching from git'
+  exec_cmd 'git fetch origin production'
+  exec_cmd 'git reset --hard origin/production'
   update_gems
   reset
   puts 'building site'


### PR DESCRIPTION
Since `git pull` has started stalling during automated deployment, these commands will hopefully solve the problem. Also obviates the need for `git stash`.

Inspired by: http://grimoire.ca/git/stop-using-git-pull-to-deploy

cc: @gboone 