### PR TITLE
Redirect system() stderr to stdout

### DIFF
--- a/go
+++ b/go
@@ -28,7 +28,7 @@
 # Author: Mike Bland (michael.bland@gsa.gov)
 # Date:   2015-01-10
 def exec_cmd(cmd)
-  exit $?.exitstatus unless system(cmd)
+  exit $?.exitstatus unless system(cmd, :err => :out)
 end
 
 def init


### PR DESCRIPTION
Replacing the original `exec_cmd` with this:

```
def exec_cmd(cmd)
  if !system(cmd)
    puts "#{cmd}: #{$?}"
    exit($?.exitstatus)
  end
end
```

and refiring the webhook produced this:

```
Fetching from git
git fetch origin staging: pid 26648 SIGPIPE (signal 13)
```

Updating the `go` script on the server with this change and refiring the webhook appears to resolve the issue.

cc: @gboone 
