### PR TITLE
removes the extra `/` on index line 96

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -93,7 +93,7 @@ permalink: /
       </div>
       <div class="blog-snippet" itemprop="articleBody">
         <p>{{ post.excerpt | strip_html }}</p>
-        <p><a href="{{ site.baseurl }}/{{ post.url }}">Continue reading &ldquo;{{ post.title }}&rdquo;...</a></p>
+        <p><a href="{{ site.baseurl }}{{ post.url }}">Continue reading &ldquo;{{ post.title }}&rdquo;...</a></p>
       </div>
     {% endfor %}
 


### PR DESCRIPTION
This should one-and-hopefully-for-all fix the wierd IP-address-instead-of-hostname error we saw in staging and production. Yes, it was that simple. I have no idea why I never caught this before :frowning: :person_frowning: but apparently when you put a slash between `{{ site.baseurl }}` and `{{ post.url }}` it changes `baseurl` to the IP address. WTF, Jekyll!