### PR TITLE
Update data-private reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you're a new teammate, follow these steps and the #18f-site team will take ca
 
 NOTE: Bios and pictures are scheduled to be added at the end of each month.
 
-**You do not need to edit the team.json or authors.yml files in this repo,** we'll find it in `data-private`.
+**You do not need to edit the team.json or authors.yml files in this repo,** we'll find it in `team-api.18f.gov`.
 
 If you get stuck, or have any other questions, feel free to reach out to anyone on the 18f-site team in channel #18f-site.
 


### PR DESCRIPTION
Hi folks!  We're trying to help update documentation that references the `data-private` repo as that has been deprecated in favor of the `team-api.18f.gov` repo. I've created this PR to account for the changes needed in your documentation.

This changeset updates the reference to `data-private` in the README to be `team-api.18f.gov` due to recent changes in the Team API.  This is in reference to https://github.com/18F/team-api.18f.gov/issues/169

If you have any questions, please reach out to the practices team in the #hub Slack channel!