### PR TITLE
dashboard links case fix

### DIFF
--- a/_plugins/dashboard.rb
+++ b/_plugins/dashboard.rb
@@ -79,9 +79,12 @@ module Dashboard
       if original_name.scan(/[A-Z]/).size > 0
         project_data['redirect_from'] = []
         project_data['redirect_from'].push("#{@baseurl}project/#{original_name}")
+        project_data['permalink'] = "#{@baseurl}project/#{original_name}"
       end
       project_data['name'] = original_name.downcase
-      project_data['permalink'] = "#{@baseurl}/#{project_data['name']}"
+      project_data['permalink'] ||= "#{@baseurl}project/#{project_data['name']}"
+
+      puts project_data.inspect
 
       munge_licenses project_data
       munge_github project_data, projects

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -19,7 +19,7 @@ permalink: /dashboard/
         {% if project.status != "Hold" %}
         <div class="dashboard-projects-content">
           <div>
-            <a href="{{ site.baseurl }}/project/{{ project_name | slugify }}"><h1>{{project.full_name}} <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i><span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1></a>
+            <a href="{{ site.baseurl }}/{{ project.permalink }}"><h1>{{project.full_name}} <i class="fa fa-chevron-right"></i><i class="fa fa-chevron-right"></i><span class="status {{ project.stage }}">{% if project.stage %}{{ project.stage }}{% else %}unknown{% endif %}</span></h1></a>
           </div>
           <div>
             <p>{% if project.description %}{{ project.description }}{% else %}Project description coming soon.{% endif %}</p>
@@ -35,7 +35,7 @@ permalink: /dashboard/
               {% endif %}
               <p><i class="fa fa-github-alt"></i> / <a class="github-url" href="https://github.com/{{repo_name}}">Code</a> / </p>
             {% endif %}
-            <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/project/{{ project_name }}">Metrics</a> / </p>
+            <p><i class="fa fa-bar-chart"></i> / <a href="{{ site.baseurl }}/{{ project.permalink }}">Metrics</a> / </p>
 
             {% capture blog %}{{ project.blogTag | default: project.blog }}{% endcapture %}
             {% assign tags = blog | split: ',' %}


### PR DESCRIPTION
use the permalink URL for dashboard index, and use the original (not downcased) project name in the permalink