### PR TITLE
Fixes the trailing slash deal

### DIFF
--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -107,7 +107,7 @@ module Jekyll
         url = lookup(input, "authors, url")
         name = lookup(input, "authors, full_name")
         if url
-          string = "<a href='#{url}'>#{name}/</a>"
+          string = "<a href='#{url}'>#{name}</a>"
         else
           string = name
         end


### PR DESCRIPTION
Removes the trailing slash on authors with outside URLs for their bios.