### PR TITLE
updates the production deploy to pull from the `staging` branch

### DIFF
--- a/go
+++ b/go
@@ -33,8 +33,7 @@ end
 
 def init
   begin
-    require 'bundler'
-  rescue LoadError
+    require 'bundler' LoadError
     puts "Installing Bundler gem..."
     exec_cmd 'gem install bundler'
     puts "Bundler installed; installing gems"
@@ -95,8 +94,8 @@ end
 
 def production_build
   puts 'Fetching from git'
-  exec_cmd 'git fetch origin production'
-  exec_cmd 'git reset --hard origin/production'
+  exec_cmd 'git fetch origin staging'
+  exec_cmd 'git reset --hard origin/staging'
   update_gems
   reset
   puts 'building site'

--- a/go
+++ b/go
@@ -33,7 +33,8 @@ end
 
 def init
   begin
-    require 'bundler' LoadError
+    require 'bundler'
+  rescue LoadError
     puts "Installing Bundler gem..."
     exec_cmd 'gem install bundler'
     puts "Bundler installed; installing gems"


### PR DESCRIPTION
This PR essentially deprecates the `production` branch. Since we're doing manual deploys to production and eventually moving the whole stack to 18F/federalist, that branch is redundant and only slows down our publication flow. Merging has no *immediate* effect but will allow us to skip the second pull request and just run the deployment script to rebuild production.