### PR TITLE
Changed newsletter email input to type='email'

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -10,7 +10,7 @@
     <div class="newsletter-form">
       <form action="https://gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=cbc418738b" method="post" id="contact-form">
       <div class="form-group"><label class="sr-hide" for="FULLNAME">Your name</label><input type="text" placeholder="Your Name" id="FULLNAME" name="FULLNAME" /></div>
-      <div class="form-group"><label class="sr-hide" for="EMAIL">Your email address (required)</label><input type="text" placeholder="your@email-address.com" id="EMAIL" required name="EMAIL" /></div>
+      <div class="form-group"><label class="sr-hide" for="EMAIL">Your email address (required)</label><input type="email" placeholder="your@email-address.com" id="EMAIL" required name="EMAIL" /></div>
       <div style="position: absolute; left: -5000px;"><input type="hidden" name="b_6f1977de9eff4c384dc8d6527_cbc418738b" tabindex="-1" value=""></div>
       <input type="submit" class="button" value="Sign up to subscribe to our newsletter" />
       </form>


### PR DESCRIPTION
Changed the newsletter email input field to `type="email"` to improve
usability, particularly on mobile devices where it brings up the email
specific keyboard.

Discussed in issue: [https://github.com/18F/18f.gsa.gov/issues/1608](https://github.com/18F/18f.gsa.gov/issues/1608)