### PR TITLE
Fix JSON formatting in ES post

### DIFF
--- a/_posts/2016-04-08-how-we-get-high-availability-with-elasticsearch-and-ruby-on-rails.md
+++ b/_posts/2016-04-08-how-we-get-high-availability-with-elasticsearch-and-ruby-on-rails.md
@@ -85,23 +85,23 @@ But to make that simple query possible, we must de-normalize a report
 and its associated objects into a single "document" object, which might
 look like this:
 
-```
+```json
 {
-  id: 123,
-  title: "my report",
-  description: "all the apples fit to eat",
-  user: {
-    id: 456,
-    first_name: "Jane",
-    last_name: "Doe",
-    email: "janedoe@example.com",
-    groups: [ "SomeGroup", "AnotherGroup" ]
+  "id": 123,
+  "title": "my report",
+  "description": "all the apples fit to eat",
+  "user": {
+    "id": 456,
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "email": "janedoe@example.com",
+    "groups": [ "SomeGroup", "AnotherGroup" ]
   },
-  attachments: [
+  "attachments": [
     {
-      id: "abc123",
-      filename: "list-of-apple-orchards.csv",
-      content: "honeycrisp yummy, macintosh tasty, apple cores by the bushel"
+      "id": "abc123",
+      "filename": "list-of-apple-orchards.csv",
+      "content": "honeycrisp yummy, macintosh tasty, apple cores by the bushel"
     }
   ]
 }


### PR DESCRIPTION
This updates [the Elasticsearch post](https://18f.gsa.gov/2016/04/08/how-we-get-high-availability-with-elasticsearch-and-ruby-on-rails/) by @pkarman to fix the JSON syntax highlighting.

It changes this:

![image](https://cloud.githubusercontent.com/assets/4592/14395407/827b17ca-fd9f-11e5-83b3-5351ef6a2804.png)

Into this:

![image](https://cloud.githubusercontent.com/assets/4592/14395391/6f564b7e-fd9f-11e5-9b3e-7e5876fffc4f.png)