### PR TITLE
Author archives

### DIFF
--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -1,4 +1,37 @@
+require 'fileutils'
+
 module Jekyll
+  class AuthorFile < Page
+    def initialize(site, base, frontmatter)
+      @site = site
+      @base = base
+      @author = frontmatter['name']
+      @dir = "/author/#{@author}"
+      @frontmatter = frontmatter
+      @name = "index.html"
+
+      self.process(@name)
+      self.data = @frontmatter
+      self.name = @frontmatter['name']
+      self.content = "#{self.data['full_name']} is a guest author for 18f.gsa.gov. This is an archive of posts written by #{self.data['first_name']}."
+    end
+  end
+  class AuthorGenerator < Generator
+    safe true
+    def generate(site)
+      posts = site.collections['posts'].docs
+      authors = site.data['authors']
+      teamdocs = site.collections['team'].docs.map{ | t | t.data }
+      authors.delete_if{ |author| teamdocs.index { |i| i['name'] == author }}
+      authors.each_pair do |author, values|
+        frontmatter = values
+        frontmatter["name"] = author
+        frontmatter["posts"] = posts
+        frontmatter["layout"] = "profile"
+        site.pages << AuthorFile.new(site, site.source, frontmatter )
+      end
+    end
+  end
   class AuthorTag < Liquid::Tag
     def initialize(tag_name, author, tokens)
       super


### PR DESCRIPTION
A first stab at generating archives for authors who are not 18F team members.

Addresses #1637 by creating pages at /author/ for anybody who doesn't work for 18F but wrote a post on our blog. We're getting to the point where we've had many authors turn into guest authors simply because they left the team. Their names aren't linked and their posts are harder to find. That shouldn't be the case. It's harder for us to learn how many posts are being written by guest authors, and it's also hard for them to have an account of the words they wrote for us either as employees or fellow public servants.

Steps remaining:
1. I'm not happy with the copy on the generated pages. See the federalist preview for more context. Maybe we set up a different layout that puts the lists of posts up front and does something else with the side bar
2. This should probably be code reviewed. It seems pretty straightforward to me but I am also an amateur rubyist and really good at second guessing myself
3. We should change the blog post template to link to these pages when an author is listed