### PR TITLE
link directly to the #devops-public chat room from the blog posts

### DIFF
--- a/_posts/2015-10-09-cloud-gov-launch.md
+++ b/_posts/2015-10-09-cloud-gov-launch.md
@@ -118,5 +118,5 @@ broadly.
 
 If you're interested in [cloud.gov](https://cloud.gov), be sure to
 drop your email address in the [form located at https://cloud.gov](https://cloud.gov/#contact), or
-drop by our [#devops-public Slack channel](https://chat.18f.gov/) to
+drop by our [#devops-public Slack channel](https://chat.18f.gov/?channel=devops-public) to
 chat about it.

--- a/_posts/2015-11-13-answering-common-questions-about-cloud-gov.md
+++ b/_posts/2015-11-13-answering-common-questions-about-cloud-gov.md
@@ -155,4 +155,4 @@ Right now, we’re running a small pilot program. If you’re interested in
 gaining access, please [provide your email address here](https://cloud.gov/#contact), as we will be expanding access over time.
 
 Please feel welcome to come by our [#devops-public Slack
-channel](https://chat.18f.gov/) to chat with the cloud.gov team!
+channel](https://chat.18f.gov/?channel=devops-public) to chat with the cloud.gov team!


### PR DESCRIPTION
https://chat.18f.gov now supports linking directly to the channel! See https://github.com/18F/chat/pull/5 for more information.