### PR TITLE
Adds a trailing slash to the what-we-deliver link in nav

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,7 @@
   <a href="javascript:;" class="toggle">Menu</a>
   <a href="javascript:;" class="toggle hidden">Close</a>
   <ul class="hidden global-nav-links">
-    <li class="global-nav-link"><a href="{{site.baseurl}}/what-we-deliver">What we deliver</a></li>
+    <li class="global-nav-link"><a href="{{site.baseurl}}/what-we-deliver/">What we deliver</a></li>
     <li class="global-nav-link"><a href="{{site.baseurl}}/hire/">Hire us</a></li>
     <li class="global-nav-link"><a href="{{site.baseurl}}/join/">Join 18F</a></li>
   </ul>


### PR DESCRIPTION
Apparently the `/` is important. Without it we get a weird redirect to a page that doesn't exist. This should fix it!