### PR TITLE
fix header content bug

### DIFF
--- a/assets/_sass/_custom.scss
+++ b/assets/_sass/_custom.scss
@@ -502,11 +502,10 @@
 .headline {
   background-color: #18f;
   color: white;
-  height: 8em;
   clear: both;
   position: relative;
   overflow: visible;
-  padding: 1em 0em 0 11.7em;
+  padding: 1em 0em 1em 11.7em;
   @include media($medium) {
     min-height: 6em !important;
     max-height: auto !important;
@@ -532,7 +531,6 @@
   }
   h1,
   h2 {
-    float: left;
     display: block;
     position: relative;
     clear: both;


### PR DESCRIPTION
This PR addresses https://github.com/18F/18f.gsa.gov/issues/1704

Note: this is a short-term fix -- we need to go back and clean up and trim a lot of this CSS, but for now, this should fix the content fitting issue.

Before:
![image](https://cloud.githubusercontent.com/assets/1060893/15194118/42145bec-178f-11e6-853a-f46ec93f97cc.png)

After:
![image](https://cloud.githubusercontent.com/assets/1060893/15194132/501b2ffe-178f-11e6-9926-a1326e74ace8.png)
 