### PR TITLE
Jekyll update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 ruby  '2.2.3'
 gem 'redcarpet', '3.2.3'
-gem 'jekyll', '3.1.2'
+gem 'jekyll', '3.1.6'
 gem 'html-proofer'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       yell (~> 2.0)
     htmlentities (4.3.4)
     i18n (0.7.0)
-    jekyll (3.1.2)
+    jekyll (3.1.6)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -52,8 +52,8 @@ GEM
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
     jekyll-sitemap (0.10.0)
-    jekyll-watch (1.3.1)
-      listen (~> 3.0)
+    jekyll-watch (1.4.0)
+      listen (~> 3.0, < 3.1)
     jekyll_frontmatter_tests (0.0.6)
       jekyll (>= 2.0, < 4.0)
     jekyll_pages_api (0.1.5)
@@ -64,12 +64,12 @@ GEM
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
     json (1.8.3)
-    kramdown (1.10.0)
+    kramdown (1.11.1)
     liquid (3.0.6)
-    listen (3.0.6)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9.7)
-    mercenary (0.3.5)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
     method_source (0.8.2)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -84,9 +84,9 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.2.3)
-    rouge (1.10.1)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.21)
+    sass (3.4.22)
     slop (3.6.0)
     thread_safe (0.3.5)
     typhoeus (0.8.0)
@@ -100,7 +100,7 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer
-  jekyll (= 3.1.2)
+  jekyll (= 3.1.6)
   jekyll-archives!
   jekyll-feed
   jekyll-paginate


### PR DESCRIPTION
Not sure why there are three versions of this commit but the result is that Jekyll gets updated to 3.1.6, the latest and greatest Jekyll there is.

We're upgrading from 3.1.2 to 3.1.6, here are the blog posts for the current and intervening versions.

3.1.6: https://jekyllrb.com/news/2016/05/19/jekyll-3-1-6-released/
3.1.5: https://jekyllrb.com/news/2016/05/18/jekyll-3-1-5-released/
3.1.4: https://jekyllrb.com/news/2016/05/18/jekyll-3-1-4-released/
3.1.3: https://jekyllrb.com/news/2016/04/19/jekyll-3-1-3-released/