### PR TITLE
Update a bunch of links to the .gov domain list to stay current

### DIFF
--- a/_posts/2014-12-18-a-complete-list-of-gov-domains.md
+++ b/_posts/2014-12-18-a-complete-list-of-gov-domains.md
@@ -17,7 +17,7 @@ tags:
 - open government
 
 ---
-<a target="_blank" href="https://gsa.github.io/data/dotgov-domains/2014-12-01-full.csv"><img src="{{ site.baseurl }}/assets/blog/dotgovs/dot-govs-screen.png" title="Excerpt of the .gov domain list" alt="A section of a spreadsheet of the .gov domain list" border: 1px solid #ccc;" /></a>
+<a target="_blank" href="https://github.com/GSA/data/blob/gh-pages/dotgov-domains/current-full.csv"><img src="{{ site.baseurl }}/assets/blog/dotgovs/dot-govs-screen.png" title="Excerpt of the .gov domain list" alt="A section of a spreadsheet of the .gov domain list" border: 1px solid #ccc;" /></a>
 
 There are a lot of `.gov` domains: over 5,300 of them. About 1,300 of these are used by the federal government's executive, legislative, and judicial branches. The rest are spread across states, territories, counties, cities, and native tribes.
 
@@ -25,16 +25,14 @@ For a while now, the public has been able to download a dataset of the [roughly 
 
 We're happy to say that the `.gov` registry is now releasing the **entire set of 5,300 `.gov` domains**, including those outside of the federal executive branch.
 
-<!-- more -->
-
-Some background: the `.gov` registry is a [centrally operated top-level domain](https://www.dotgov.gov) managed by the [Office of Government-wide Policy](http://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](http://www.gsa.gov/) (GSA). The associated [DotGov.gov](http://www.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
+Some background: the `.gov` registry is a [centrally operated top-level domain](https://www.dotgov.gov) managed by the [Office of Government-wide Policy](http://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](http://www.gsa.gov/) (GSA). The associated [DotGov.gov](https://www.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
 
 You can download the complete `.gov` domain list in CSV form here:
 
- * [https://gsa.github.io/data/dotgov-domains/2014-12-01-full.csv](https://gsa.github.io/data/dotgov-domains/2014-12-01-full.csv)
+ * [https://github.com/GSA/data/raw/gh-pages/dotgov-domains/current-full.csv](https://github.com/GSA/data/raw/gh-pages/dotgov-domains/current-full.csv)
 
-We’re hosting it on GSA's GitHub account, which also allows for [easy in-browser viewing of the full list](https://github.com/GSA/data/blob/gh-pages/dotgov-domains/2014-12-01-full.csv).
+We’re hosting it on GSA's GitHub account, which also allows for [easy in-browser viewing of the full list](https://github.com/GSA/data/blob/gh-pages/dotgov-domains/current-full.csv).
 
-**Note**: This dataset is an interim release and a snapshot in time, taken on December 1, 2014. The plan is for the complete dataset to be listed and regularly updated on Data.gov, replacing the current limited set.
+**Note**: This dataset is an interim release and a snapshot in time, first taken on December 1, 2014. While the data will continue to be updated for the foreseeable future, the long-term plan is for the complete dataset to be listed and regularly updated [on Data.gov](https://catalog.data.gov/dataset/gov-domains-api-c9856).
 
 In the meantime, we and the Office of Government-wide Policy hope this data is useful to the public, and to anyone helping make the `.gov` landscape better.


### PR DESCRIPTION
This updates [A complete list of .gov domains](https://18f.gsa.gov/2014/12/18/a-complete-list-of-gov-domains/) to link to the new central permalink, created in https://github.com/GSA/data/pull/32 for the 2016-06-30 release. This ensures the blog post won't send people to outdated data.

I also updated the text slightly to not call the data outdated, and to link to the Data.gov page, which I still hope will become canonical.