### PR TITLE
Removes a trailing slash on previous post link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ timezone: America/New_York
 
 # blog archive at /blog
 paginate: 5
-paginate_path: "blog/page/:num"
+paginate_path: "blog/page/:num/"
 
 #emoji
 gems:

--- a/blog/index.html
+++ b/blog/index.html
@@ -57,7 +57,7 @@ layout: bare
   <section class="pagination">
     <div>
       {% if paginator.previous_page %}
-        <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}/">
+        <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}">
           <h1><i class="fa fa-chevron-left"></i> Previous</h1>
         </a>
       {% else %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -69,7 +69,7 @@ layout: bare
     </div>
     <div>
       {% if paginator.next_page %}
-      <a href="{{ site.baseurl }}{{ paginator.next_page_path }}/">
+      <a href="{{ site.baseurl }}{{ paginator.next_page_path }}">
         <h1>Next <i class="fa fa-chevron-right"></i></h1>
       </a>
       {% else %}


### PR DESCRIPTION
Removes the trailing slash on `paginator.previous_page_path` to close #1825. Let's make sure we test it on the preview before merging.