### PR TITLE
Points to the correct location for policies

### DIFF
--- a/pages/code-of-conduct.md
+++ b/pages/code-of-conduct.md
@@ -5,6 +5,8 @@ layout: default-intro
 lead:
 ---
 
+This is a copy of the 18F code of conduct. The [official document lives in GitHub](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md). If you would like to comment or suggest a change to the policy, please do so there.
+
 ### Creating a culture of innovation
 
 We aspire to create a culture where people work joyfully, communicate openly about things that matter, and provide great services for the American people and the world. We would like our team and our communities (including government and private sector colleagues) to reflect the diversity of America. We want to foster diversity of all kinds&mdash;not just the classes protected in law. Diversity fosters innovation. Diverse teams are creative teams. We need a diversity of perspective to create solutions for the real and urgent challenges we face.

--- a/pages/open-source-policy.md
+++ b/pages/open-source-policy.md
@@ -5,6 +5,8 @@ layout: default-intro
 lead:
 ---
 
+This is a copy of the 18F open source policy. The [official document lives in GitHub](https://github.com/18F/open-source-policy/blob/master/policy.md). If you would like to comment or suggest a change to the policy, please do so there.
+
 ### 18F: An open source team
 
 [18F](https://18f.gsa.gov), a digital services delivery team within the [General Services Administration](http://gsa.gov), develops in-house digital solutions to help agencies meet the needs of the people and businesses they serve. This requires flexibility in how we code, with a focus on lowering costs for the American people, while improving their interactions with the U.S. Government.


### PR DESCRIPTION
The code of conduct and OSS policy both live in official GH repos. This change
points to the correct location for both and indicates how to suggest changes or
comment on those policies