### PR TITLE
Puts the newsletter link back

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -2,7 +2,7 @@
   <p>Receive updates about our work and news from the civic tech community.</p>
   <form action="https://gsa.us9.list-manage.com/subscribe/post?u=6f1977de9eff4c384dc8d6527&amp;id=cbc418738b" method="post" id="contact-form">
     <div class="form-group">
-      <label for="EMAIL">Your email</label>
+      <label id="newsletter" for="EMAIL">Your email</label>
       <input type="email" id="EMAIL" required="" name="EMAIL">
     </div>
     <div style="position: absolute; left: -5000px;">


### PR DESCRIPTION
Addresses #1608 

If you're sent or click on 18f.gsa.gov/#newsletter you get taken to the bottom of the page. I don't know that this is our best ever solution for the newsletter sign up. Particularly, I think it'd be easy to misunderstand what you're supposed to do at the bottom of the page depending on the context that sent you there. We'll leave #1608 open until we can test this and/or design a better interaction.