### PR TITLE
Docker support(Update)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.3.1
+
+# set locales 
+RUN  apt-get update >/dev/null && \
+     apt-get install -y locales >/dev/null && \
+     echo "en_US UTF-8" > /etc/locale.gen  && \
+     locale-gen en_US.UTF-8  && \
+     export LANG=en_US.UTF-8  && \
+     export LANGUAGE=en_US:en  && \
+     export LC_ALL=en_US.UTF-8  
+
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+apt-get install -y nodejs
+
+
+COPY Gemfile Gemfile.lock /app/
+
+RUN cd /app && gem install bundler && bundle install

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ To dramatically speed up rebuild times (from more than 20 seconds to around 5), 
 
 You should be able to see the site at: http://127.0.0.1:4000
 
+## Alternative Installation using Docker
+Using Docker can make dependencies management easier, but can also slow down your build time. You can find out more in 
+[this discussion](https://github.com/18F/18f.gsa.gov/pull/1688#issue-152998027)    
+
+*To try this out on MacOS:*
+
+1. Install [Docker Toolbox](https://www.docker.com/products/docker-toolbox).
+2. Make sure Docker is running and `cd` into your project folder
+3. Run `docker-compose build` to build the docker image and its dependencies. You only need to build once, but if there was an error with the build , rebuild using  the  `--no-cache` option like so `docker-compose build --no-cache`  to avoid using the old version of the docker image.
+4. Run `docker-compose up`.
+   Note: if you want to run a single command and bypass your `Dockerfile` for debugging purposes, you can do like so `docker-compose run app <COMMAND>` (for instance, you can run bundle  `docker-compose run app bundle install`) 
+5. Visit [http://192.168.99.100:4000](http://192.168.99.100:4000/) in your browser.
+
 ## System security controls
 
 The site is a static website with HTML, CSS, and Javascript. Deployments are done through the Federalist platform.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+app:
+  build: ./
+  working_dir: /app
+  volumes:
+    - .:/app
+  entrypoint: ruby /app/docker_entrypoint.rb
+  command: ./serve --host 0.0.0.0 --incremental --trace
+  ports:
+    - "4000:4000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ app:
   volumes:
     - .:/app
   entrypoint: ruby /app/docker_entrypoint.rb
-  command: ./serve --host 0.0.0.0 --incremental --trace
+  command: ./serve  
   ports:
     - "4000:4000"

--- a/docker_entrypoint.rb
+++ b/docker_entrypoint.rb
@@ -1,0 +1,41 @@
+require 'etc'
+
+# We want our Docker process to use the same uid as the owner of the
+# repository checkout. This will ensure that any created files
+# have the same owner and can be accessed on the host system, rather than
+# being owned by root and hard to modify or delete.
+HOST_UID = File::Stat.new('/app').uid
+
+# This is just the username for the uid, for cosmetic purposes only really.
+HOST_USER = '18f_user'.freeze
+
+def does_username_exist(username)
+  Etc.getpwnam(username)
+  true
+rescue ArgumentError
+  false
+end
+
+def does_uid_exist(uid)
+  Etc.getpwuid(uid)
+  true
+rescue ArgumentError
+  false
+end
+
+
+def assume_uid
+  unless does_uid_exist(HOST_UID)
+    username = HOST_USER
+    username += '0' while does_username_exist(username)
+    home_dir = '/home/' + username
+    system("useradd -d #{home_dir} -m #{username} -u #{HOST_UID}")
+  end
+  ENV['HOME'] = '/home/' + Etc.getpwuid(HOST_UID).name
+  Process::UID.change_privilege(HOST_UID)
+  return unless Process.euid != HOST_UID
+end
+
+assume_uid
+
+exec(*ARGV)

--- a/docker_entrypoint.rb
+++ b/docker_entrypoint.rb
@@ -23,7 +23,6 @@ rescue ArgumentError
   false
 end
 
-
 def assume_uid
   unless does_uid_exist(HOST_UID)
     username = HOST_USER

--- a/serve
+++ b/serve
@@ -2,4 +2,4 @@ if [ -n $FAST_BUILDS ]; then
   export FAST_BUILDS=true;
 fi
 
-bundle exec jekyll serve --watch --incremental --config="_config.yml,_config-fast-builds.yml,_config-dev.yml"
+LC_ALL="en_US.UTF-8" bundle exec jekyll serve --watch --host 0.0.0.0 --trace --config="_config.yml,_config-fast-builds.yml,_config-dev.yml"

--- a/serve
+++ b/serve
@@ -2,4 +2,4 @@ if [ -n $FAST_BUILDS ]; then
   export FAST_BUILDS=true;
 fi
 
-LC_ALL="en_US.UTF-8" bundle exec jekyll serve --watch --host 0.0.0.0 --trace --config="_config.yml,_config-fast-builds.yml,_config-dev.yml"
+LC_ALL="en_US.UTF-8" bundle exec jekyll serve --watch --host 0.0.0.0  --config="_config.yml,_config-fast-builds.yml,_config-dev.yml"


### PR DESCRIPTION
[WIP] and update to https://github.com/18F/18f.gsa.gov/pull/1688

 * Based on this  [Gitlab forum post](https://gitlab.com/gitlab-org/gitlab-ce/issues/14983) added UTF-8 language support in `Dockerfile`  to fix `jekyll 3.3.0 | Error:  invalid byte sequence in US-ASCII`  but it doesn't seem to work. I am thinking that it has to do with bundler version discrepancies. 


cc @gboone @gemfarmer @toolness