### PR TITLE
Issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to reproduce the behavior
+- [ ]
+- [ ]
+- [ ]
+
+## This is issue is done when:
+- [ ]
+- [ ]
+- [ ]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Fixes issue(s) # .
+
+[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)
+
+[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/BRANCH_NAME/)
+
+Changes proposed in this pull request:
+-
+-
+-
+
+/cc relevant people


### PR DESCRIPTION
For #1933 

This PR makes templates for new issues and pull request templates. These templates will populate the content field when an issue or pull request is made. 

The issue for this PR says to add 'associated documentation', but I'm not sure where that would go, as it is fairly self-evident. 