### PR TITLE
temporarily disable pa11y-ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,12 +7,17 @@ dependencies:
   pre:
     - bundle install
     - bundle exec jekyll build
-    - nvm install stable && nvm alias default stable
+    # uncomment to restore pa11y-ci
+    # - nvm install stable && nvm alias default stable
+    #
     - npm test
-    - npm install -g pa11y-ci
+    # uncomment to restore pa11y-ci
+    # - npm install -g pa11y-ci
+    #
 
 test:
   pre:
     - bundle exec jekyll test
     - bundle exec htmlproofer _site --disable-external --allow-hash-href --empty-alt-ignore --url-ignore 18f@gsa.gov
-    - npm run --harmony lint-508
+    # uncomment to restore pa11y-ci
+    # - npm run --harmony lint-508


### PR DESCRIPTION
Per or discussion in retro, this PR will prevent Circle CI from running accessibility scanning.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/disable-pa11y-ci.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/disable-pa11y-ci)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/disable-pa11y-ci/)

Changes proposed in this pull request:
- disables the pa11i-ci build on CircleCI

/cc @coreycaitlin 
