### PR TITLE
Alumni author pages

### DIFF
--- a/_authors/aaron.md
+++ b/_authors/aaron.md
@@ -10,4 +10,5 @@ github:
 twitter: 
 team: 18F
 redirect_from: /team/aaron
+alumni: true
 ---

--- a/_authors/alison.md
+++ b/_authors/alison.md
@@ -1,0 +1,14 @@
+---
+name: alison
+first_name: Alison
+last_name: Rowland
+full_name: Alison Rowland
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/david.md
+++ b/_authors/david.md
@@ -1,0 +1,14 @@
+---
+name: david
+first_name: Dave
+last_name: Best
+full_name: Dave Best
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/dmayercantu.md
+++ b/_authors/dmayercantu.md
@@ -8,4 +8,5 @@ team:
 city: New York
 state: NY
 redirect_from: /team/dmayercantu
+alumni: true
 ---

--- a/_authors/erica.md
+++ b/_authors/erica.md
@@ -10,4 +10,5 @@ github:
 twitter: 
 team: Design
 redirect_from: /team/erica
+alumni: true
 ---

--- a/_authors/garren.md
+++ b/_authors/garren.md
@@ -10,4 +10,5 @@ github:
 twitter: 
 team: 18F
 redirect_from: /team/garren
+alumni: true
 ---

--- a/_authors/gramirez.md
+++ b/_authors/gramirez.md
@@ -10,4 +10,5 @@ github:
 twitter: 
 team: Delivery
 redirect_from: /team/gramirez
+alumni: true
 ---

--- a/_authors/greg.md
+++ b/_authors/greg.md
@@ -1,0 +1,14 @@
+---
+name: greg
+first_name: Greg
+last_name: Godbout
+full_name: Greg Godbout
+city: 
+state: 
+role: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/jackie.md
+++ b/_authors/jackie.md
@@ -1,0 +1,14 @@
+---
+city: 
+first_name: Jackie
+full_name: Jackie Kazil
+github: 
+last_name: Kazil
+name: jackie
+role: 
+state: 
+team: 
+twitter: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/joe.md
+++ b/_authors/joe.md
@@ -1,0 +1,14 @@
+---
+name: joe
+first_name: Joe
+last_name: Polastre
+full_name: Joe Polastre
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/kara.md
+++ b/_authors/kara.md
@@ -10,4 +10,5 @@ github:
 twitter: 
 team: 18F
 redirect_from: /team/kara
+alumni: true
 ---

--- a/_authors/kara.md
+++ b/_authors/kara.md
@@ -10,5 +10,4 @@ github:
 twitter: 
 team: 18F
 redirect_from: /team/kara
-alumni: true
 ---

--- a/_authors/majma.md
+++ b/_authors/majma.md
@@ -1,0 +1,14 @@
+---
+name: majma
+first_name: Raphael
+last_name: Majma
+full_name: Raphael Majma
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/mbland.md
+++ b/_authors/mbland.md
@@ -1,0 +1,14 @@
+---
+name: mbland
+first_name: Mike
+full_name: Mike Bland
+last_name: Bland
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/melody.md
+++ b/_authors/melody.md
@@ -17,4 +17,5 @@ project:
 - 18F Hub
 - 18F Dashboard
 redirect_from: /team/melody
+alumni: true
 ---

--- a/_authors/michael-walker.md
+++ b/_authors/michael-walker.md
@@ -1,6 +1,6 @@
 ---
 city: Clinton
-first_name: Michael
+first_name: Greg
 full_name: Greg Walker
 github: mgwalker
 last_name: Walker

--- a/_authors/ozzy.md
+++ b/_authors/ozzy.md
@@ -1,0 +1,14 @@
+---
+name: ozzy
+first_name: Ozzy
+last_name: Johnson
+full_name: Ozzy Johnson
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/robert.md
+++ b/_authors/robert.md
@@ -1,0 +1,14 @@
+---
+city: 
+first_name: Robert
+full_name: Dr. Robert L. Read
+github: 
+last_name: Read
+name: robert
+role: 
+state: 
+team: 
+twitter: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/russ.md
+++ b/_authors/russ.md
@@ -1,0 +1,13 @@
+---
+city: Chicago
+first_name: Russ
+full_name: Russ Unger
+github: 
+last_name: Unger
+name: russ
+role: 
+state: 
+team: 
+twitter: 
+redirect_from: /team/romke
+---

--- a/_authors/sarah.md
+++ b/_authors/sarah.md
@@ -1,0 +1,14 @@
+---
+name: sarah
+first_name: Sarah
+last_name: Allen
+full_name: Sarah Allen
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/sean.md
+++ b/_authors/sean.md
@@ -1,0 +1,14 @@
+---
+name: sean
+first_name: Sean
+last_name: Herron
+full_name: Sean Herron
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+alumni: true
+---

--- a/_authors/shashank.md
+++ b/_authors/shashank.md
@@ -1,0 +1,13 @@
+---
+name: shashank
+first_name: Shashank
+last_name: Khandelwal
+full_name: Shashank Khandelwal
+role: 
+city: 
+state: 
+github: 
+twitter: 
+team: 
+redirect_from: 
+---

--- a/_authors/vdavez.md
+++ b/_authors/vdavez.md
@@ -1,6 +1,6 @@
 ---
 name: vdavez
-first_name: V David
+first_name: Dave
 last_name: Zvenyach
 full_name: V. David Zvenyach
 role: Acquisition Management Director

--- a/_layouts/default-profile.html
+++ b/_layouts/default-profile.html
@@ -6,7 +6,7 @@ layout: default
   <div class="usa-grid">
     <header>
       {% if page.full_name %}
-        <h1 class="section-heading section-heading-alt">Blog posts by: {{ page.full_name }} {% if page.alumni %}<span>(alumni)</span>{% endif %}</h1>
+        <h1 class="section-heading section-heading-alt">Blog posts by: {{ page.full_name }} {% if page.alumni %}<span>(18F alumni)</span>{% endif %}</h1>
       {% endif %}
     </header>
   </div>

--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -55,7 +55,7 @@ module Jekyll
         end
       end
       unless authored.empty?
-        list = "<#{@heading}>#{first_name}'s blog posts:</#{@heading}>"
+        list = "<#{@heading}>#{first_name}’s blog posts:</#{@heading}>"
         list << "<ul>"
         for a in authored
           list << "<li><a href='#{site_url}#{a.url}'>#{a.data['title']}</a></li>"

--- a/_posts/2015-02-18-steve-portigal-pre-event-qa-post.md
+++ b/_posts/2015-02-18-steve-portigal-pre-event-qa-post.md
@@ -1,5 +1,5 @@
 ---
-title: Five questions with steve portigal
+title: Five questions with Steve Portigal
 date: '2015-02-18'
 layout: post
 image: /assets/blog/speaker-series/portigal.jpg


### PR DESCRIPTION
Fixes issue(s) #1987 and #1637 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/frontmatter-fixes.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/frontmatter-fixes)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/frontmatter-fixes/)

Changes proposed in this pull request:
- Adds `alumni: true` for many 18F alumni
- Adds author yml files for several 18F alumni who were missing them, which makes their archive pages work
- Minor capitalization fix
- Adds Dave's first name
- Changes a `'` to a `’` in `author.rb`

/cc @gboone 
