### PR TITLE
Adds 18F's and TTS' vulnerability disclosure policy

### DIFF
--- a/_includes/footer/desktop.html
+++ b/_includes/footer/desktop.html
@@ -36,6 +36,9 @@
         <a href="{{ site.baseurl }}/open-source-policy/">Open source policy</a>
       </li>
       <li>
+        <a href="{{ site.baseurl }}/vulnerability-disclosure-policy/">Vulnerability disclosure</a>
+      </li>
+      <li>
         <a href="{{ site.baseurl }}/code-of-conduct/">Code of conduct</a>
       </li>
     </ul>

--- a/_includes/footer/mobile.html
+++ b/_includes/footer/mobile.html
@@ -34,6 +34,9 @@
           <a href="{{ site.baseurl }}/open-source-policy/">Open source policy</a>
         </li>
         <li>
+          <a href="{{ site.baseurl }}/vulnerability-disclosure-policy/">Vulnerability disclosure</a>
+        </li>
+        <li>
           <a href="{{ site.baseurl }}/code-of-conduct/">Code of conduct</a>
         </li>
       </ul>

--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -1,0 +1,70 @@
+---
+title: Vulnerability disclosure policy
+permalink: /vulnerability-disclosure-policy/
+layout: default-intro
+lead:
+---
+
+This is a copy of the vulnerability disclosure policy for 18F and TTS. The [official document lives in GitHub](https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md#vulnerability-disclosure-policy). If you would like to comment or suggest a change to the policy, please [open a GitHub issue](https://github.com/18F/vulnerability-disclosure-policy/issues).
+
+### Vulnerability Disclosure Policy
+
+As part of a US Government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
+
+We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
+
+This policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
+
+### Guidelines
+
+We require that you:
+
+* Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
+
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
+
+* Keep confidential any information about discovered vulnerabilities for 90 calendar days after you have notified us.
+
+### Scope
+
+This policy applies to the following systems:
+
+* [`vote.gov`](https://vote.gov)
+* [`analytics.usa.gov`](https://analytics.usa.gov)
+* [`calc.gsa.gov`](https://calc.gsa.gov)
+* [`micropurchase.18f.gov`](https://micropurchase.18f.gov)
+* [`18f.gsa.gov`](https://18f.gsa.gov)
+
+**Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. If you aren’t sure whether a system or endpoint is in scope or not, contact us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) before starting your research.
+
+**The following test types are not authorized:**
+
+* User interface bugs or typos.
+* Network denial of service (DoS or DDoS) tests.
+* Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
+
+If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) immediately**:
+
+* Personally identifiable information
+* Financial information. (e.g. credit card or bank account numbers)
+* Proprietary information or trade secrets of companies of any party
+
+### Authorization
+
+If you make a good faith effort to comply with this policy during your security research, we will consider your research to be authorized, will work with you to understand and resolve the issue quickly, and GSA will not initiate or recommend legal action related to your research.
+
+### Reporting a vulnerability
+
+We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) or [through this reporting form](https://docs.google.com/forms/d/e/1FAIpQLSdhr6REOq8QRZ3C2cRWVHWbjcGgdNL8_nVSGY1cBSl1-tfkWA/viewform). Reports may be submitted anonymously.
+
+Reports should include:
+
+* Description of the location and potential impact of the vulnerability.
+
+* A detailed description of the steps required to reproduce the vulnerability. Proof of concept (POC) scripts, screenshots, and screen captures are all helpful. Please use extreme care to properly label and protect any exploit code.
+
+* Any technical information and related materials we would need to reproduce the issue.
+
+Please keep your vulnerability reports current by sending us any new information as it becomes available.
+
+We may share your vulnerability reports with [US-CERT](https://www.us-cert.gov/ais), as well as any affected vendors or open source projects.

--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -5,13 +5,13 @@ layout: default-intro
 lead:
 ---
 
-This is a copy of the vulnerability disclosure policy for 18F and TTS. The [official document lives in GitHub](https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md#vulnerability-disclosure-policy). If you would like to comment or suggest a change to the policy, please [open a GitHub issue](https://github.com/18F/vulnerability-disclosure-policy/issues).
+This is a copy of the vulnerability disclosure policy for 18F and the Technology Transformation Service (TTS). The [official document lives in GitHub](https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md#vulnerability-disclosure-policy). If you would like to comment or suggest a change to the policy, please [open a GitHub issue](https://github.com/18F/vulnerability-disclosure-policy/issues).
 
 ### Vulnerability Disclosure Policy
 
-As part of a US Government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
+As part of a U.S. government agency, [GSA’s Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure.
 
-We want security researchers to feel comfortable reporting vulnerabilities they've discovered, as set out in this policy, so that we can fix them and keep our information safe.
+We want security researchers to feel comfortable reporting vulnerabilities they’ve discovered, as set out in this policy, so that we can fix them and keep our information safe.
 
 This policy describes **what systems and types of research** are covered under this policy, **how to send us** vulnerability reports, and **how long** we ask security researchers to wait before publicly disclosing vulnerabilities.
 
@@ -21,7 +21,7 @@ We require that you:
 
 * Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
 
-* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to “pivot” to other systems. Once you’ve established that a vulnerability exists, or encountered any of the sensitive data outlined below, you must stop your test and notify us immediately.
 
 * Keep confidential any information about discovered vulnerabilities for 90 calendar days after you have notified us.
 
@@ -46,7 +46,7 @@ This policy applies to the following systems:
 If you encounter any of the below on our systems while testing within the scope of this policy, **stop your test and notify us at [`18f-bug-bounty@gsa.gov`](mailto:18f-bug-bounty@gsa.gov) immediately**:
 
 * Personally identifiable information
-* Financial information. (e.g. credit card or bank account numbers)
+* Financial information (e.g. credit card or bank account numbers)
 * Proprietary information or trade secrets of companies of any party
 
 ### Authorization
@@ -60,9 +60,7 @@ We accept and discuss vulnerability reports at [`18f-bug-bounty@gsa.gov`](mailto
 Reports should include:
 
 * Description of the location and potential impact of the vulnerability.
-
 * A detailed description of the steps required to reproduce the vulnerability. Proof of concept (POC) scripts, screenshots, and screen captures are all helpful. Please use extreme care to properly label and protect any exploit code.
-
 * Any technical information and related materials we would need to reproduce the issue.
 
 Please keep your vulnerability reports current by sending us any new information as it becomes available.


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/vulnerability-disclosure-policy.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/vulnerability-disclosure-policy)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/vulnerability-disclosure-policy/)

Changes proposed in this pull request:
- Adds 18F's and TTs' [vulnerability disclosure policy](https://github.com/18F/vulnerability-disclosure-policy) to the main 18F site. It's structured similarly to the [open source policy page](https://18f.gsa.gov/open-source-policy), where we copy the document from the repo into the site, and link at the top to the GitHub repository as the official/canonical location.
- Updates the footer links in the mobile and desktop views to add a `Vulnerability disclosure` link. I omitted the word `policy` from the end of the link text, as it wasn't necessary and adding it caused the line to overflow in an aesthetically displeasing manner.
- Screenshots below.

<img width="1107" alt="screen shot 2016-10-30 at 5 50 04 pm" src="https://cloud.githubusercontent.com/assets/4592/19840337/bb3b4e60-9ec9-11e6-9821-c2dded7bdac0.png">

<img width="637" alt="screen shot 2016-10-30 at 5 48 55 pm" src="https://cloud.githubusercontent.com/assets/4592/19840341/bedc4dee-9ec9-11e6-8583-89750b88b41d.png">

/cc @jacobian @kimberbat @NoahKunin 
