### PR TITLE
link to list of forks of analytics.usa.gov

### DIFF
--- a/pages/press.html
+++ b/pages/press.html
@@ -47,19 +47,7 @@ permalink: /press/
   <p>We publish our code repositories <a href="https://github.com/18F">on GitHub</a> and encourage the public to adapt our code and <a href="https://pages.18f.gov/guides/">guides</a> for their own projects.</p>
   <p>Here are some examples of how our projects have been adapted by others:</p>
   <ul>
-    <li>
-      Several governments have used/adapted the code that powers <a href="https://analytics.usa.gov">analytics.usa.gov</a>:
-      <ul>
-        <li><a href="https://bouldercolorado.gov/stats">City of Boulder</a></li>
-        <li><a href="http://webanalytics.lacity.org/">City of Los Angeles</a></li>
-        <li><a href="http://analytics.phila.gov/">City of Philadelphia</a></li>
-        <li><a href="http://analytics.cityofsacramento.org/">City of Sacramento</a></li>
-        <li><a href="http://analytics.smgov.net/">City of Santa Monica</a></li>
-        <li><a href="http://analytics.muni.org/">Municipality of Anchorage</a></li>
-        <li><a href="http://analytics.tdec.tn.gov/">Tennessee Department of Environment &amp; Conservation</a></li>
-        <li><a href="http://webanalytics.gov.je/">States of Jersey</a></li>
-      </ul>
-    </li>
+    <li><a href="https://github.com/18F/analytics.usa.gov#readme">A number of governments</a> have used/adapted the code that powers <a href="https://analytics.usa.gov">analytics.usa.gov</a></li>
     <li>The District of Columbia adapted <a href="https://pages.18f.gov/guides-template/">18F&#39;s Guides Template</a> into <a href="http://dcgov.github.io/guides-template/">their own</a>, which they are using for things like the <a href="http://dcgov.github.io/open-source-guidelines/">DC Government Open Source Guidelines</a>.</li>
     <li>Lovely, a real estate startup, created <a href="http://hub.livelovely.com.s3-website-us-east-1.amazonaws.com/">their documentation platform</a> by adapting <a href="https://github.com/18F/hub">the code created</a> for 18F&#39;s Hub. The Hub helps 18F organize our information and explore the connections between team members, projects, and skill sets. It serves as the go-to place for all team information.</li>
     <li><a href="https://pulse.cio.gov/">Pulse</a> was forked to check <a href="https://https.jetzt/">German</a> government domains for HTTPS.</li>


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/analytics-link.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/analytics-link)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/analytics-link/)

Changes proposed in this pull request:
- Link to list of forks of analytics.usa.gov. It's better to keep the canonical list with the project anyway, so we don't need to update in two places.

/cc @konklone 