### PR TITLE
Project pages prototype

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,9 @@ collections:
   press:
     output: true
     permalink: /press/:name/
+  projects:
+    output: true
+    permalink: projects/:path/
 
 defaults:
  -

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -1,0 +1,52 @@
+---
+layout: default
+header_border: true
+---
+
+<section class="usa-grid usa-section page-tag-results">
+  <h1>{{ page.title }}</h1>
+  <h2>{{ page.subtitle }}</h2>
+
+    {{ content }}
+
+    <ul class="post-list">
+      {% capture posts %}
+        {{ site.posts | where:"tags", page.project_tag }}
+      {% endcapture %}
+
+      <div class="tag-{{ page.project_tag }} blog-content" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
+
+      {% for post in posts %}
+      <!-- {{ post.title }} -->
+        <li>
+          <div class="usa-width-two-thirds">
+            <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+            <h2>
+              <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            </h2>
+            {% include post-author.html context='post' %}
+            {{ post.excerpt }}
+            <p>
+              <a class="link-arrow-right" href="{{ post.url | prepend: site.baseurl }}">Continue reading</a>
+            </p>
+            <span class="post-tags" itemprop="keywords">
+              {% for tag in post.tags %}
+                <a class="usa-label" href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}/">{{ tag }}
+                </a>
+              {% endfor %}
+            </span>
+          </div>
+          <div class="usa-width-one-third">
+            {% if post.image.size > 0 %}
+              <a class="media_link" href="{{ post.url | prepend: site.baseurl }}" title="link to post">
+                <img src="{{ site.baseurl }}{{ post.image }}" alt="">
+                <p class="usa-sr-only">continue reading</p>
+              </a>
+            {% endif %}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+</section>

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -7,7 +7,7 @@ header_border: true
 
 <section class="usa-grid usa-section page-tag-results">
   <section class="hero"
-           style="background-image: url({{ page.image_path }});"
+           style="background-image: url({{ site.baseurl }}{{ page.image_path }});"
            aria-label="{{ page.image_caption }}">
     <div class="usa-grid">
       <div class="hero-callout background-dark">

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -6,51 +6,53 @@ header_border: true
 {% assign matching_posts = page | match_posts %}
 
 <section class="usa-grid usa-section page-tag-results">
-
-  <figure>
-    <img src="{{ site.baseurl }}{{ page.image_path }}">
-    <figcaption>{{ page.image_caption }}</figcaption>
-  </figure>
-
-  <h1>{{ page.title }}</h1>
+  <section class="hero"
+           style="background-image: url({{ page.image_path }});"
+           aria-label="{{ page.image_caption }}">
+    <div class="usa-grid">
+      <div class="hero-callout background-dark">
+        <h1 class="h2">{{ page.title }}</h1>
+      </div>
+    </div>
+  </section>
 
   <h2>{{ page.subtitle }}</h2>
 
-    {{ content }}
+  {{ content }}
 
+  <h2>Our blog posts about the process</h2>
+
+  <div class="{% for tag in page.project_tags %}tag-{{ tag }}{% endfor %} blog-content" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
     <ul class="post-list">
-
-      <div class="tag-{{ page.project_tag }} blog-content" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
-
-      {% for post in matching_posts %}
-        <li>
-          <div class="usa-width-two-thirds">
-            <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
-            <h2>
-              <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-            </h2>
-            {% include post-author.html context='post' %}
-            {{ post.excerpt }}
-            <p>
-              <a class="link-arrow-right" href="{{ post.url | prepend: site.baseurl }}">Continue reading</a>
-            </p>
-            <span class="post-tags" itemprop="keywords">
-              {% for tag in post.tags %}
-                <a class="usa-label" href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}/">{{ tag }}
-                </a>
-              {% endfor %}
-            </span>
-          </div>
-          <div class="usa-width-one-third">
-            {% if post.image.size > 0 %}
-              <a class="media_link" href="{{ post.url | prepend: site.baseurl }}" title="link to post">
-                <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-                <p class="usa-sr-only">continue reading</p>
+    {% for post in matching_posts %}
+      <li>
+        <div class="usa-width-two-thirds">
+          <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
+          <h2>
+            <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+          </h2>
+          {% include post-author.html context='post' %}
+          {{ post.excerpt }}
+          <p>
+            <a class="link-arrow-right" href="{{ post.url | prepend: site.baseurl }}">Continue reading</a>
+          </p>
+          <span class="post-tags" itemprop="keywords">
+            {% for tag in post.tags %}
+              <a class="usa-label" href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}/">{{ tag }}
               </a>
-            {% endif %}
-          </div>
-        </li>
-      {% endfor %}
+            {% endfor %}
+          </span>
+        </div>
+        <div class="usa-width-one-third">
+          {% if post.image.size > 0 %}
+            <a class="media_link" href="{{ post.url | prepend: site.baseurl }}" title="link to post">
+              <img src="{{ site.baseurl }}{{ post.image }}" alt="">
+              <p class="usa-sr-only">continue reading</p>
+            </a>
+          {% endif %}
+        </div>
+      </li>
+    {% endfor %}
     </ul>
   </div>
 

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -4,7 +4,14 @@ header_border: true
 ---
 
 <section class="usa-grid usa-section page-tag-results">
+
+  <figure>
+    <img src="{{ site.baseurl }}{{ page.image_path }}">
+    <figcaption>{{ page.image_caption }}</figcaption>
+  </figure>
+
   <h1>{{ page.title }}</h1>
+  
   <h2>{{ page.subtitle }}</h2>
 
     {{ content }}

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -3,6 +3,8 @@ layout: default
 header_border: true
 ---
 
+{% assign matching_posts = page | match_posts %}
+
 <section class="usa-grid usa-section page-tag-results">
 
   <figure>
@@ -11,20 +13,16 @@ header_border: true
   </figure>
 
   <h1>{{ page.title }}</h1>
-  
+
   <h2>{{ page.subtitle }}</h2>
 
     {{ content }}
 
     <ul class="post-list">
-      {% capture posts %}
-        {{ site.posts | where:"tags", page.project_tag }}
-      {% endcapture %}
 
       <div class="tag-{{ page.project_tag }} blog-content" itemprop="blogPosts" itemscope itemtype="http://schema.org/BlogPosting">
 
-      {% for post in posts %}
-      <!-- {{ post.title }} -->
+      {% for post in matching_posts %}
         <li>
           <div class="usa-width-two-thirds">
             <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>

--- a/_plugins/README.md
+++ b/_plugins/README.md
@@ -76,6 +76,16 @@ Returns:
           allowfullscreen></iframe>
 </div>```
 
+#### match_posts: finds posts that match a pages' `project_tags`
+
+Example:
+```
+{{ page | match_posts }}
+```
+
+Will look for all the posts on the entire site and return a list of posts that have any tag
+that matches the list of `project_tags` defined in a given project's frontmatter
+
 ### Markdown rendering
 
 #### [markdown.rb](markdown.rb)

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -15,9 +15,9 @@ module Jekyll
     # in a given project's frontmatter
     def match_posts(page)
       matching_posts = []
+      page_tags = page['project_tags'] || []
       Jekyll.sites[0].posts.docs.each do |sitepost|
         sitepost_tags = sitepost['tags'] || []
-        page_tags = page['project_tags'] || []
         matching_post = sitepost_tags & page_tags
         matching_posts << sitepost if matching_post.any?
       end

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -3,6 +3,19 @@ require 'rb-readline'
 
 module Jekyll
   module MatchingPosts
+    # match_posts filter
+    #
+    # A liquid filter that takes a page object
+    #
+    # Example:
+    # ```
+    # {{ page | match_posts }}
+    # ```
+    #
+    # Will look for all the posts on the site
+    # and return a list of posts that have any tag
+    # that matches the list of `project_tags` defined
+    # in a given project's frontmatter
     def match_posts(page)
       matching_posts = []
       Jekyll.sites[0].posts.docs.each do |sitepost|

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -1,0 +1,21 @@
+require 'pry'
+require 'rb-readline'
+
+module Jekyll
+  module MatchingPosts
+    def match_posts(page)
+      matching_posts = []
+      Jekyll.sites[0].posts.docs.each do |sitepost|
+        sitepost_tags = sitepost['tags'] || []
+        page_tags = page['project_tags'] || []
+        matching_post = sitepost_tags & page_tags
+        if matching_post.any?
+          matching_posts << sitepost
+        end
+      end
+      matching_posts
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::MatchingPosts)

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -1,6 +1,3 @@
-require 'pry'
-require 'rb-readline'
-
 module Jekyll
   module MatchingPosts
     # match_posts filter
@@ -22,9 +19,7 @@ module Jekyll
         sitepost_tags = sitepost['tags'] || []
         page_tags = page['project_tags'] || []
         matching_post = sitepost_tags & page_tags
-        if matching_post.any?
-          matching_posts << sitepost
-        end
+        matching_posts << sitepost if matching_post.any?
       end
       matching_posts
     end

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -4,11 +4,11 @@ title: "Project: The Federal Election Commission"
 subtitle: Making campaign data easier to use
 image_path: /assets/img/home/hero-fec.png
 image_caption: Image of the FEC data explorer with stylized magnifying glass.
-project_tag: fec.gov
-<!-- permalink:  -->
-expiration_date: 
-github_repo: 
-project_url: 
+project_tags:
+- fec.gov
+expiration_date:
+github_repo:
+project_url:
 ---
 
 ## Background

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -2,13 +2,14 @@
 layout: project-tag-results
 title: "Project: The Federal Election Commission"
 subtitle: Making campaign data easier to use
+exerpt:
 image_path: /assets/img/home/hero-fec.png
 image_caption: Image of the FEC data explorer with stylized magnifying glass.
 project_tags:
 - fec.gov
 expiration_date:
-github_repo:
-project_url:
+github_repo: https://github.com/18F/openFEC-web-app
+project_url: https://beta.fec.gov/
 ---
 
 ## Background

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -1,8 +1,9 @@
 ---
 layout: project-tag-results
-title: Our work with the Federal Election Commission
+title: "Project: The Federal Election Commission"
 subtitle: Making campaign data easier to use
-hero_image: 
+image_path: /assets/img/home/hero-fec.png
+image_caption: Image of the FEC data explorer with stylized magnifying glass.
 project_tag: fec.gov
 <!-- permalink:  -->
 expiration_date: 

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -1,0 +1,21 @@
+---
+layout: project-tag-results
+title: Our work with the Federal Election Commission
+subtitle: Making campaign data easier to use
+hero_image: 
+project_tag: fec.gov
+<!-- permalink:  -->
+expiration_date: 
+github_repo: 
+project_url: 
+---
+
+## Background
+
+The Federal Election Commission (FEC) is the agency responsible for regulating campaign finance activity in federal elections. The data they collect and publish is used by transparency groups and journalists to inform the public about who donates to campaigns and how money is spent around federal elections.
+
+## How 18F has helped
+
+The legacy FEC website, fec.gov, is dense. It holds a tremendous amount of complex campaign finance data, legal resources, and information about the rules on raising and spending money in elections. In addition, the FEC had never worked with user-centered design or agile development methods.
+
+As 18F started talking to stakeholders and users, it became clear that what seemed at first to be a simple redesign of fec.gov was actually a much larger challenge. Not only did we need to make the thing, we had to work with FEC to transform its whole approach to making things.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -38,7 +38,6 @@
 @import "_components/search-results";
 @import "_components/footer";
 
-
 // 18F site templates
 // ==========================
 


### PR DESCRIPTION
WIP because of an issue with the image path

Fixes issue(s) #1968 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-pgs.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-pgs/)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/project-pgs/projects/fec-gov)

Changes proposed in this pull request:
- adds new `/projects/` url and jekyll collection
- adds `project-tag-results.html` layout
- adds fec-gov.md file with the new project page template
- adds `match_posts`, a new way to filter for tags within non-post pages and collections with related documentation

/cc @coreycaitlin @ericronne 
