### PR TITLE
Update Gemfile to use 18f/jekyll-archives

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :jekyll_plugins do
   if ENV['FAST_BUILDS'] == 'true'
     puts 'not using jekyll-archives because its sloooooooooow'
   else
-    gem 'jekyll-archives', :git => 'https://github.com/jekyll/jekyll-archives.git'
+    gem 'jekyll-archives', :git => 'https://github.com/18F/jekyll-archives.git'
   end
 
   gem 'jekyll_pages_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/jekyll/jekyll-archives.git
-  revision: 90bfe8446c0fcb2f5d75a86553e090ef27be2350
+  remote: https://github.com/18F/jekyll-archives.git
+  revision: 53cef8a1a1c515d23ef9499d6affb77d13e70f54
   specs:
     jekyll-archives (2.1.0)
       jekyll (>= 2.4)


### PR DESCRIPTION
Fixes issue(s) #1947 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/tag-bug-2.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/tag-bug-2)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/tag-bug-2/)

Changes proposed in this pull request:
- references changes made on 18F/jekyll-archives
- replaces all dashes in archive tags

/cc @coreycaitlin @awfrancisco 
