### PR TITLE
Update author page rollup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/18F/jekyll-archives.git
-  revision: 53cef8a1a1c515d23ef9499d6affb77d13e70f54
+  revision: 9ad78a4aa38de0af570a53f3c12558408e9537f7
   specs:
     jekyll-archives (2.1.0)
       jekyll (>= 2.4)

--- a/_layouts/default-profile.html
+++ b/_layouts/default-profile.html
@@ -7,7 +7,7 @@ layout: default
   <div class="usa-grid">
     <header>
       {% if page.full_name %}
-        <h1 class="section-heading section-heading-alt">Blog posts by {{ page.full_name }}{% if page.alumni %} <span>(18F alumni)</span>{% endif %}{% if page.guest %} <span>(Guest Author)</span>{% endif %}</h1>
+        <h1 class="section-heading section-heading-alt">Blog posts by {{ page.full_name }}{% if page.alumni %} <span>(18F alumni)</span>{% endif %}{% if page.guest %} <span>(guest author)</span>{% endif %}:</h1>
       {% endif %}
     </header>
   </div>

--- a/_layouts/default-profile.html
+++ b/_layouts/default-profile.html
@@ -1,16 +1,23 @@
 ---
 layout: default
 ---
+{% assign matching_posts = page | match_posts:'authors' | sort:'date' | reverse %}
 
 <section class="background-dark usa-section section-intro">
   <div class="usa-grid">
     <header>
       {% if page.full_name %}
-        <h1 class="section-heading section-heading-alt">Blog posts by: {{ page.full_name }} {% if page.alumni %}<span>(18F alumni)</span>{% endif %} {% if page.guest %}<span>(Guest Author)</span>{% endif %}</h1>
+        <h1 class="section-heading section-heading-alt">Blog posts by {{ page.full_name }}{% if page.alumni %} <span>(18F alumni)</span>{% endif %}{% if page.guest %} <span>(Guest Author)</span>{% endif %}</h1>
       {% endif %}
     </header>
   </div>
 </section>
-<section class="usa-grid usa-section usa-content">
-  {% authored_posts heading=h2%}
+<section class="usa-grid content-focus page-tag-results">
+  {%
+    include tag-results.html
+    posts=matching_posts
+    tags=page.tags
+    limit_metadata=true
+    trim_padding=true
+  %}
 </section>

--- a/_layouts/tag-results.html
+++ b/_layouts/tag-results.html
@@ -3,15 +3,17 @@ layout: default
 header_border: true
 ---
 
-<section class="usa-grid usa-section page-tag-results">
+<section class="usa-grid usa-section page-tag-results break-bottom">
   <a class="back-blog link-arrow-left" href="{{ site.baseurl }}/blog/">Blog</a>
   {% assign numberof = page.posts | size %}
   <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged {{ page.title }}</h1>
+</section>
 
+<section class="usa-grid content-focus page-tag-results">
   {%
     include tag-results.html
     posts=page.posts
     tags=page.tags
+    trim_padding=true
   %}
-
 </section>

--- a/_plugins/README.md
+++ b/_plugins/README.md
@@ -76,15 +76,20 @@ Returns:
           allowfullscreen></iframe>
 </div>```
 
-#### match_posts: finds posts that match a pages' `tags`
+#### match_posts: finds posts that match a pages' property. If the property is not specified, it defaults to `tags`
 
 Example:
 ```
 {{ page | match_posts }}
 ```
 
-Will look for all the posts on the entire site and return a list of posts that have any tag
-that matches the list of `tags` defined in a given project's frontmatter
+Example matching authors
+```
+{{ page | match_posts: 'authors' }}
+```
+
+Will look for all the posts on the entire site and return a list of posts that have any properties
+that matches the list defined in a given project's frontmatter
 
 ### Markdown rendering
 

--- a/_plugins/matching_posts.rb
+++ b/_plugins/matching_posts.rb
@@ -1,5 +1,15 @@
 module Jekyll
   module MatchingPosts
+    # Helper method to match apost property with its equivalent
+    # page property
+    def map_post_to_page(property)
+      post_map = {
+        authors: 'name',
+        tags: 'tags'
+      }
+      post_map[property.to_sym]
+    end
+
     # match_posts filter
     #
     # A liquid filter that takes a page object
@@ -13,12 +23,13 @@ module Jekyll
     # and return a list of posts that have any tag
     # that matches the list of `project_tags` defined
     # in a given project's frontmatter
-    def match_posts(page)
+    def match_posts(page, property = 'tags')
       matching_posts = []
-      page_tags = page['tags'] || []
+      page_property = map_post_to_page(property)
+      page_criteria = Array(page[page_property]) || []
       Jekyll.sites[0].posts.docs.each do |sitepost|
-        sitepost_tags = sitepost['tags'] || []
-        matching_post = sitepost_tags & page_tags
+        sitepost_criteria = sitepost[property] || []
+        matching_post = sitepost_criteria & page_criteria
         matching_posts << sitepost if matching_post.any?
       end
       matching_posts


### PR DESCRIPTION
Fixes issue(s) #1989 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/authors-page.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/authors-page)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/authors-page/)

Changes proposed in this pull request:
- updates the `match_posts` filter to allow for multiple kinds of page to post matching
- updates the author page rollup to include new tag-rollup layout
- centers the tag page

/cc @mugizico @coreycaitlin 

