### PR TITLE
Redirecting

### DIFF
--- a/_authors/18F.md
+++ b/_authors/18F.md
@@ -9,4 +9,5 @@ state:
 github: 18F
 twitter: 18F
 team: 18F
+redirect_from: /team/18F/
 ---

--- a/_authors/aaron.md
+++ b/_authors/aaron.md
@@ -10,5 +10,4 @@ github:
 twitter:
 team: 18F
 redirect_from: /team/aaron/
-alumni: true
 ---

--- a/_authors/aaron.md
+++ b/_authors/aaron.md
@@ -6,9 +6,9 @@ full_name: Aaron Snow
 role: Executive Director
 city: Washington
 state: D.C.
-github: 
-twitter: 
+github:
+twitter:
 team: 18F
-redirect_from: /team/aaron
+redirect_from: /team/aaron/
 alumni: true
 ---

--- a/_authors/aaron.md
+++ b/_authors/aaron.md
@@ -10,4 +10,5 @@ github:
 twitter:
 team: 18F
 redirect_from: /team/aaron/
+alumni: true
 ---

--- a/_authors/ada-lovelace.md
+++ b/_authors/ada-lovelace.md
@@ -17,5 +17,5 @@ joke: |
 
   Due to other commitments, Ada will be working for the team only on April 1st. If you'd like to join Ada (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/ada-lovelace
+redirect_from: /team/ada-lovelace/
 ---

--- a/_authors/adam-kendall.md
+++ b/_authors/adam-kendall.md
@@ -9,5 +9,5 @@ role:
 state: VA
 team: Engineering
 twitter: 
-redirect_from: /team/adam-kendall
+redirect_from: /team/adam-kendall/
 ---

--- a/_authors/adrian-webb.md
+++ b/_authors/adrian-webb.md
@@ -9,5 +9,5 @@ role: Technical Architect
 state: D.C.
 team: Consulting
 twitter: 
-redirect_from: /team/adrian-webb
+redirect_from: /team/adrian-webb/
 ---

--- a/_authors/afeld.md
+++ b/_authors/afeld.md
@@ -9,5 +9,5 @@ state: NY
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/afeld
+redirect_from: /team/afeld/
 ---

--- a/_authors/alan-atlas.md
+++ b/_authors/alan-atlas.md
@@ -9,5 +9,5 @@ role:
 state: WA
 team: 
 twitter: 
-redirect_from: /team/alan-atlas
+redirect_from: /team/alan-atlas/
 ---

--- a/_authors/alan-brouilette.md
+++ b/_authors/alan-brouilette.md
@@ -9,5 +9,5 @@ role: Product Manager
 state: IL
 team: Product
 twitter: 
-redirect_from: /team/alan-brouilette
+redirect_from: /team/alan-brouilette/
 ---

--- a/_authors/alan-turing.md
+++ b/_authors/alan-turing.md
@@ -14,5 +14,5 @@ joke: |
 
   Due to other commitments, Mr. Turing will be working for the team only on April 1st. If you'd like to join Alan (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/alan-turing
+redirect_from: /team/alan-turing/
 ---

--- a/_authors/alan.md
+++ b/_authors/alan.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/alan
+redirect_from: /team/alan/
 ---

--- a/_authors/alex-bisker.md
+++ b/_authors/alex-bisker.md
@@ -9,5 +9,5 @@ role:
 state: New York
 team: Delivery
 twitter: 
-redirect_from: /team/alex-bisker
+redirect_from: /team/alex-bisker/
 ---

--- a/_authors/alex-pandel.md
+++ b/_authors/alex-pandel.md
@@ -9,5 +9,5 @@ role:
 state: CA
 team: 
 twitter: 
-redirect_from: /team/alex-pandel
+redirect_from: /team/alex-pandel/
 ---

--- a/_authors/alexander-hamilton.md
+++ b/_authors/alexander-hamilton.md
@@ -16,5 +16,5 @@ joke: |
 
   Due to other commitments, Alexander will be working for the team only on April 1st. If you'd like to join Alex (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/alexander-hamilton
+redirect_from: /team/alexander-hamilton/
 ---

--- a/_authors/alla.md
+++ b/_authors/alla.md
@@ -9,5 +9,5 @@ role: Deputy for Acquisition
 state: DC
 team: Acquisition
 twitter: 
-redirect_from: /team/alla
+redirect_from: /team/alla/
 ---

--- a/_authors/amanda-robinson.md
+++ b/_authors/amanda-robinson.md
@@ -9,5 +9,5 @@ role: Developer
 state: DC
 team: Delivery
 twitter: aertzeid
-redirect_from: /team/amanda-robinson
+redirect_from: /team/amanda-robinson/
 ---

--- a/_authors/amanda-schonfeld.md
+++ b/_authors/amanda-schonfeld.md
@@ -9,5 +9,5 @@ role:
 state: IL
 team: 
 twitter: 
-redirect_from: /team/amanda-schonfeld
+redirect_from: /team/amanda-schonfeld/
 ---

--- a/_authors/amber.md
+++ b/_authors/amber.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/amber
+redirect_from: /team/amber/
 ---

--- a/_authors/amos.md
+++ b/_authors/amos.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/amos
+redirect_from: /team/amos/
 ---

--- a/_authors/andre.md
+++ b/_authors/andre.md
@@ -13,5 +13,5 @@ project:
 - 18F Blog
 - 18f.gsa.gov
 - 18F Consulting
-redirect_from: /team/andre
+redirect_from: /team/andre/
 ---

--- a/_authors/andrew.md
+++ b/_authors/andrew.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Presidential Innovation Fellowship
-redirect_from: /team/andrew
+redirect_from: /team/andrew/
 ---

--- a/_authors/andrewmaier.md
+++ b/_authors/andrewmaier.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Design
-redirect_from: /team/andrewmaier
+redirect_from: /team/andrewmaier/
 ---

--- a/_authors/angela-colter.md
+++ b/_authors/angela-colter.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/angela-colter
+redirect_from: /team/angela-colter/
 ---

--- a/_authors/anna.md
+++ b/_authors/anna.md
@@ -9,5 +9,5 @@ role: Project Manager
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/anna
+redirect_from: /team/anna/
 ---

--- a/_authors/annalee.md
+++ b/_authors/annalee.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/annalee
+redirect_from: /team/annalee/
 ---

--- a/_authors/anthony-garvan.md
+++ b/_authors/anthony-garvan.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/anthony-garvan
+redirect_from: /team/anthony-garvan/
 ---

--- a/_authors/bateman.md
+++ b/_authors/bateman.md
@@ -9,5 +9,5 @@ state: DC
 github: batemapf
 twitter: 
 team: 
-redirect_from: /team/bateman
+redirect_from: /team/bateman/
 ---

--- a/_authors/becky.md
+++ b/_authors/becky.md
@@ -10,5 +10,5 @@ github:
 twitter: 
 email: rebecca.sweger@gsa.gov
 team: Delivery
-redirect_from: /team/becky
+redirect_from: /team/becky/
 ---

--- a/_authors/ben.md
+++ b/_authors/ben.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Presidential Innovation Fellows
-redirect_from: /team/ben
+redirect_from: /team/ben/
 ---

--- a/_authors/betsy-ross.md
+++ b/_authors/betsy-ross.md
@@ -14,5 +14,5 @@ joke: |
 
   Due to other commitments, Betsy will be working for the team only on April 1st. If you'd like to join Betsy (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/betsy-ross
+redirect_from: /team/betsy-ross/
 ---

--- a/_authors/bill.md
+++ b/_authors/bill.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/bill
+redirect_from: /team/bill/
 ---

--- a/_authors/blacktm.md
+++ b/_authors/blacktm.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/blacktm
+redirect_from: /team/blacktm/
 ---

--- a/_authors/boone.md
+++ b/_authors/boone.md
@@ -13,5 +13,5 @@ project:
 - 18f.gsa.gov
 - Dashboard
 - 18F EDU
-redirect_from: /team/boone
+redirect_from: /team/boone/
 ---

--- a/_authors/bradnunnally.md
+++ b/_authors/bradnunnally.md
@@ -9,5 +9,5 @@ state: MO
 github: 
 twitter: 
 team: Design
-redirect_from: /team/bradnunnally
+redirect_from: /team/bradnunnally/
 ---

--- a/_authors/brandon.md
+++ b/_authors/brandon.md
@@ -9,5 +9,5 @@ role: Consultant
 state: GA
 team: 18F Consulting
 twitter: 
-redirect_from: /team/brandon
+redirect_from: /team/brandon/
 ---

--- a/_authors/brendan.md
+++ b/_authors/brendan.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Engineering
-redirect_from: /team/brendan
+redirect_from: /team/brendan/
 ---

--- a/_authors/bret.md
+++ b/_authors/bret.md
@@ -9,5 +9,5 @@ role: Product Lead
 github: 
 twitter: 
 team: DevOps
-redirect_from: /team/bret
+redirect_from: /team/bret/
 ---

--- a/_authors/brethauer.md
+++ b/_authors/brethauer.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Design
-redirect_from: /team/brethauer
+redirect_from: /team/brethauer/
 ---

--- a/_authors/brian.md
+++ b/_authors/brian.md
@@ -9,5 +9,5 @@ role: Developer
 state: MN
 team: Delivery
 twitter: 
-redirect_from: /team/brian
+redirect_from: /team/brian/
 ---

--- a/_authors/britta-gustafson.md
+++ b/_authors/britta-gustafson.md
@@ -9,5 +9,5 @@ role: Content Designer
 state: CA
 team: Design
 twitter: ''
-redirect_from: /team/britta-gustafson
+redirect_from: /team/britta-gustafson/
 ---

--- a/_authors/captain-america.md
+++ b/_authors/captain-america.md
@@ -14,5 +14,5 @@ joke: |
 
   Due to other commitments, Mr. America will be working at 18F only on April 1st. If you'd like to join Mr. America (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/captain-america
+redirect_from: /team/captain-america/
 ---

--- a/_authors/carlo-costino.md
+++ b/_authors/carlo-costino.md
@@ -9,5 +9,5 @@ role: Software engineer
 state: D.C.
 team: Delivery
 twitter: 
-redirect_from: /team/carlo-costino
+redirect_from: /team/carlo-costino/
 ---

--- a/_authors/carolyn.md
+++ b/_authors/carolyn.md
@@ -9,5 +9,5 @@ role: User Experience Designer
 github: 
 twitter: 
 team: Design
-redirect_from: /team/carolyn
+redirect_from: /team/carolyn/
 ---

--- a/_authors/catherine.md
+++ b/_authors/catherine.md
@@ -9,5 +9,5 @@ state: Ohio
 github: catherinedevlin
 twitter: catherinedevlin
 team: Delivery
-redirect_from: /team/catherine
+redirect_from: /team/catherine/
 ---

--- a/_authors/chrisc.md
+++ b/_authors/chrisc.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/chrisc
+redirect_from: /team/chrisc/
 ---

--- a/_authors/christine.md
+++ b/_authors/christine.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/christine
+redirect_from: /team/christine/
 ---

--- a/_authors/christopher-goranson.md
+++ b/_authors/christopher-goranson.md
@@ -9,5 +9,5 @@ role: Project Manager
 state: TN
 team: 18F Consulting
 twitter: cgoranson
-redirect_from: /team/christopher-goranson
+redirect_from: /team/christopher-goranson/
 ---

--- a/_authors/clinton-troxel.md
+++ b/_authors/clinton-troxel.md
@@ -9,5 +9,5 @@ role: Developer
 state: WY
 team: Engineering
 twitter: 
-redirect_from: /team/clinton-troxel
+redirect_from: /team/clinton-troxel/
 ---

--- a/_authors/cm.md
+++ b/_authors/cm.md
@@ -9,5 +9,5 @@ state: PA
 github: cmc333333
 twitter: 
 team: Delivery
-redirect_from: /team/cm
+redirect_from: /team/cm/
 ---

--- a/_authors/colin-craig.md
+++ b/_authors/colin-craig.md
@@ -9,5 +9,5 @@ role:
 state: NC
 team: Engineering
 twitter: 
-redirect_from: /team/colin-craig
+redirect_from: /team/colin-craig/
 ---

--- a/_authors/colinmacarthur.md
+++ b/_authors/colinmacarthur.md
@@ -9,5 +9,5 @@ state: MA
 github: 
 twitter: 
 team: Design
-redirect_from: /team/colinmacarthur
+redirect_from: /team/colinmacarthur/
 ---

--- a/_authors/corey.mahoney.md
+++ b/_authors/corey.mahoney.md
@@ -9,5 +9,5 @@ role: Content designer
 state: CA
 team: Design
 twitter: 
-redirect_from: /team/corey.mahoney
+redirect_from: /team/corey.mahoney/
 ---

--- a/_authors/cristina.md
+++ b/_authors/cristina.md
@@ -9,5 +9,5 @@ role: Deputy Director
 state: DC
 team: Talent
 twitter: 
-redirect_from: /team/cristina
+redirect_from: /team/cristina/
 ---

--- a/_authors/diego.md
+++ b/_authors/diego.md
@@ -12,5 +12,5 @@ team: Products and Platforms
 project:
 - cloud.gov
 - DevOps Guild
-redirect_from: /team/diego
+redirect_from: /team/diego/
 ---

--- a/_authors/dmayercantu.md
+++ b/_authors/dmayercantu.md
@@ -7,6 +7,6 @@ role:
 team: 
 city: New York
 state: NY
-redirect_from: /team/dmayercantu
+redirect_from: /team/dmayercantu/
 alumni: true
 ---

--- a/_authors/duane-rollins.md
+++ b/_authors/duane-rollins.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/duane-rollins
+redirect_from: /team/duane-rollins/
 ---

--- a/_authors/ed-mullen.md
+++ b/_authors/ed-mullen.md
@@ -9,5 +9,5 @@ role: Product Strategist
 state: New York
 team: Change Strategy
 twitter: 
-redirect_from: /team/ed-mullen
+redirect_from: /team/ed-mullen/
 ---

--- a/_authors/egoodman.md
+++ b/_authors/egoodman.md
@@ -9,5 +9,5 @@ state: CA
 github: esgoodman
 twitter: egoodman
 team: Design
-redirect_from: /team/egoodman
+redirect_from: /team/egoodman/
 ---

--- a/_authors/elaine.md
+++ b/_authors/elaine.md
@@ -13,5 +13,5 @@ project:
 - 18f.gsa.gov
 - 18F Blog
 - DATA Act
-redirect_from: /team/elaine
+redirect_from: /team/elaine/
 ---

--- a/_authors/emaland.md
+++ b/_authors/emaland.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/emaland
+redirect_from: /team/emaland/
 ---

--- a/_authors/emileigh.md
+++ b/_authors/emileigh.md
@@ -14,5 +14,5 @@ project:
 - 18F Blog
 - Every Kid in a Park
 - OpenFEC
-redirect_from: /team/emileigh
+redirect_from: /team/emileigh/
 ---

--- a/_authors/eric.md
+++ b/_authors/eric.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/eric
+redirect_from: /team/eric/
 ---

--- a/_authors/erica.md
+++ b/_authors/erica.md
@@ -9,6 +9,6 @@ state: CA
 github: 
 twitter: 
 team: Design
-redirect_from: /team/erica
+redirect_from: /team/erica/
 alumni: true
 ---

--- a/_authors/ericronne.md
+++ b/_authors/ericronne.md
@@ -9,5 +9,5 @@ state: IL
 github: 
 twitter: 
 team: 
-redirect_from: /team/ericronne
+redirect_from: /team/ericronne/
 ---

--- a/_authors/estherchang.md
+++ b/_authors/estherchang.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Talent
-redirect_from: /team/estherchang
+redirect_from: /team/estherchang/
 ---

--- a/_authors/estherkim.md
+++ b/_authors/estherkim.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/estherkim
+redirect_from: /team/estherkim/
 ---

--- a/_authors/ethan.md
+++ b/_authors/ethan.md
@@ -7,5 +7,5 @@ role: Operations Specialist
 team: Operations
 city: Chicago
 state: IL
-redirect_from: /team/ethan
+redirect_from: /team/ethan/
 ---

--- a/_authors/fureigh.md
+++ b/_authors/fureigh.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/fureigh
+redirect_from: /team/fureigh/
 ---

--- a/_authors/gail.md
+++ b/_authors/gail.md
@@ -9,5 +9,5 @@ role: User Experience Designer
 github: 
 twitter: 
 team: Design
-redirect_from: /team/gail
+redirect_from: /team/gail/
 ---

--- a/_authors/garren.md
+++ b/_authors/garren.md
@@ -9,6 +9,6 @@ state: D.C.
 github: 
 twitter: 
 team: 18F
-redirect_from: /team/garren
+redirect_from: /team/garren/
 alumni: true
 ---

--- a/_authors/grace-hopper.md
+++ b/_authors/grace-hopper.md
@@ -16,5 +16,5 @@ joke: |
 
   Due to other commitments, Grace will be working for the team only on April 1st. If you'd like to join Grace (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/grace-hopper
+redirect_from: /team/grace-hopper/
 ---

--- a/_authors/gramirez.md
+++ b/_authors/gramirez.md
@@ -9,6 +9,6 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/gramirez
+redirect_from: /team/gramirez/
 alumni: true
 ---

--- a/_authors/gray.md
+++ b/_authors/gray.md
@@ -15,5 +15,5 @@ project:
 - "/Devleoper Program"
 - analytics.usa.gov
 - pulse.cio.gov
-redirect_from: /team/gray
+redirect_from: /team/gray/
 ---

--- a/_authors/hillary.md
+++ b/_authors/hillary.md
@@ -9,5 +9,5 @@ state: CA
 github: quepol
 twitter: hillary
 team: 18F
-redirect_from: /team/hillary
+redirect_from: /team/hillary/
 ---

--- a/_authors/holly.md
+++ b/_authors/holly.md
@@ -9,5 +9,5 @@ role: Director of Engineering
 github: hollyallen
 twitter: 
 team: Delivery
-redirect_from: /team/holly
+redirect_from: /team/holly/
 ---

--- a/_authors/jackiexu.md
+++ b/_authors/jackiexu.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/jackiexu
+redirect_from: /team/jackiexu/
 ---

--- a/_authors/jacobharris.md
+++ b/_authors/jacobharris.md
@@ -9,5 +9,5 @@ state: D.C.
 github: harrisj
 twitter: harrisj
 team: Delivery
-redirect_from: /team/jacobharris
+redirect_from: /team/jacobharris/
 ---

--- a/_authors/james-seppi.md
+++ b/_authors/james-seppi.md
@@ -9,5 +9,5 @@ state: Texas
 github: 
 twitter: 
 team: Engineering
-redirect_from: /team/james-seppi
+redirect_from: /team/james-seppi/
 ---

--- a/_authors/jameshupp.md
+++ b/_authors/jameshupp.md
@@ -7,5 +7,5 @@ role:
 team: 
 city: New York
 state: NY
-redirect_from: /team/jameshupp
+redirect_from: /team/jameshupp/
 ---

--- a/_authors/jamesscott.md
+++ b/_authors/jamesscott.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/jamesscott
+redirect_from: /team/jamesscott/
 ---

--- a/_authors/jamie.md
+++ b/_authors/jamie.md
@@ -9,5 +9,5 @@ state: CA
 github: jamiealbrecht
 twitter: jmealbrecht
 team: Talent
-redirect_from: /team/jamie
+redirect_from: /team/jamie/
 ---

--- a/_authors/jayhuie.md
+++ b/_authors/jayhuie.md
@@ -9,5 +9,5 @@ role:
 state: DC
 team: Consulting
 twitter: 
-redirect_from: /team/jayhuie
+redirect_from: /team/jayhuie/
 ---

--- a/_authors/jen.md
+++ b/_authors/jen.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/jen
+redirect_from: /team/jen/
 ---

--- a/_authors/jennmoran.md
+++ b/_authors/jennmoran.md
@@ -9,5 +9,5 @@ role:
 state: DC
 team: Talent
 twitter: 
-redirect_from: /team/jennmoran
+redirect_from: /team/jennmoran/
 ---

--- a/_authors/jentress.md
+++ b/_authors/jentress.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Talent
-redirect_from: /team/jentress
+redirect_from: /team/jentress/
 ---

--- a/_authors/jeremiak.md
+++ b/_authors/jeremiak.md
@@ -9,5 +9,5 @@ state: NY
 github: jeremiak
 twitter: jeremiak
 team: Delivery
-redirect_from: /team/jeremiak
+redirect_from: /team/jeremiak/
 ---

--- a/_authors/jeremy.md
+++ b/_authors/jeremy.md
@@ -9,5 +9,5 @@ state: NY
 github: 
 twitter: 
 team: Design
-redirect_from: /team/jeremy
+redirect_from: /team/jeremy/
 ---

--- a/_authors/jessedondero.md
+++ b/_authors/jessedondero.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/jessedondero
+redirect_from: /team/jessedondero/
 ---

--- a/_authors/jessie-posilkin.md
+++ b/_authors/jessie-posilkin.md
@@ -9,5 +9,5 @@ role:
 state: District of Columbia
 team: 
 twitter: 
-redirect_from: /team/jessie-posilkin
+redirect_from: /team/jessie-posilkin/
 ---

--- a/_authors/jessie.md
+++ b/_authors/jessie.md
@@ -9,5 +9,5 @@ role: Developer
 state: California
 team: Delivery
 twitter: 
-redirect_from: /team/jessie
+redirect_from: /team/jessie/
 ---

--- a/_authors/jez-humble.md
+++ b/_authors/jez-humble.md
@@ -9,5 +9,5 @@ role: Deputy Director of Infrastructure
 state: California
 team: 
 twitter: 
-redirect_from: /team/jez-humble
+redirect_from: /team/jez-humble/
 ---

--- a/_authors/jfinch.md
+++ b/_authors/jfinch.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/jfinch
+redirect_from: /team/jfinch/
 ---

--- a/_authors/jhunter.md
+++ b/_authors/jhunter.md
@@ -20,5 +20,5 @@ project:
 - Diversity Listening Tour
 - Eligibility Platform Sprint
 - FEC
-redirect_from: /team/jhunter
+redirect_from: /team/jhunter/
 ---

--- a/_authors/john-donmoyer.md
+++ b/_authors/john-donmoyer.md
@@ -9,5 +9,5 @@ role: User Experience Designer
 state: IL
 team: Design
 twitter: 
-redirect_from: /team/john-donmoyer
+redirect_from: /team/john-donmoyer/
 ---

--- a/_authors/josh.md
+++ b/_authors/josh.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/josh
+redirect_from: /team/josh/
 ---

--- a/_authors/joshbailes.md
+++ b/_authors/joshbailes.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Legal
-redirect_from: /team/joshbailes
+redirect_from: /team/joshbailes/
 ---

--- a/_authors/joshcarp.md
+++ b/_authors/joshcarp.md
@@ -9,5 +9,5 @@ state: VA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/joshcarp
+redirect_from: /team/joshcarp/
 ---

--- a/_authors/jtag.md
+++ b/_authors/jtag.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/jtag
+redirect_from: /team/jtag/
 ---

--- a/_authors/jthibault.md
+++ b/_authors/jthibault.md
@@ -9,5 +9,5 @@ state: NY
 github: jenniferthibault
 twitter: jlthibault
 team: Design
-redirect_from: /team/jthibault
+redirect_from: /team/jthibault/
 ---

--- a/_authors/julia.md
+++ b/_authors/julia.md
@@ -9,5 +9,5 @@ state: NC
 github: juliaelman
 twitter: juliaelman
 team: Design
-redirect_from: /team/julia
+redirect_from: /team/julia/
 ---

--- a/_authors/justin.md
+++ b/_authors/justin.md
@@ -9,5 +9,5 @@ state: WA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/justin
+redirect_from: /team/justin/
 ---

--- a/_authors/kaitlin.md
+++ b/_authors/kaitlin.md
@@ -9,5 +9,5 @@ state: D.C.
 github: kaitlin
 twitter: kaitlinbdevine
 team: Delivery
-redirect_from: /team/kaitlin
+redirect_from: /team/kaitlin/
 ---

--- a/_authors/kane.md
+++ b/_authors/kane.md
@@ -9,5 +9,5 @@ role:
 state: CA
 team: 
 twitter: 
-redirect_from: /team/kane
+redirect_from: /team/kane/
 ---

--- a/_authors/kara.md
+++ b/_authors/kara.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: 18F
-redirect_from: /team/kara
+redirect_from: /team/kara/
 ---

--- a/_authors/kate.md
+++ b/_authors/kate.md
@@ -9,5 +9,5 @@ state: OR
 github: 
 twitter: 
 team: Design
-redirect_from: /team/kate
+redirect_from: /team/kate/
 ---

--- a/_authors/kathrynconnolly.md
+++ b/_authors/kathrynconnolly.md
@@ -7,5 +7,5 @@ city: Washington
 state: D.C.
 team: Operations
 role: Team Operations
-redirect_from: /team/kathrynconnolly
+redirect_from: /team/kathrynconnolly/
 ---

--- a/_authors/kedelman.md
+++ b/_authors/kedelman.md
@@ -9,5 +9,5 @@ role: Acquisition Management Consultant
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/kedelman
+redirect_from: /team/kedelman/
 ---

--- a/_authors/khandelwal.md
+++ b/_authors/khandelwal.md
@@ -10,5 +10,5 @@ github:
 twitter: 
 team: Consulting
 project: 
-redirect_from: /team/khandelwal
+redirect_from: /team/khandelwal/
 ---

--- a/_authors/kimberdowsett.md
+++ b/_authors/kimberdowsett.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Infrastructure Engineering
-redirect_from: /team/kimberdowsett
+redirect_from: /team/kimberdowsett/
 ---

--- a/_authors/krutivora.md
+++ b/_authors/krutivora.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: General Services Administration
-redirect_from: /team/krutivora
+redirect_from: /team/krutivora/
 ---

--- a/_authors/lane-becker.md
+++ b/_authors/lane-becker.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: Strategy
 twitter: 
-redirect_from: /team/lane-becker
+redirect_from: /team/lane-becker/
 ---

--- a/_authors/larry-bafundo.md
+++ b/_authors/larry-bafundo.md
@@ -9,5 +9,5 @@ role: Project Manager
 state: CA
 team: Delivery
 twitter: 
-redirect_from: /team/larry-bafundo
+redirect_from: /team/larry-bafundo/
 ---

--- a/_authors/laura-gerhardt.md
+++ b/_authors/laura-gerhardt.md
@@ -9,5 +9,5 @@ role:
 state: DC
 team: 
 twitter: 
-redirect_from: /team/laura-gerhardt
+redirect_from: /team/laura-gerhardt/
 ---

--- a/_authors/leah.md
+++ b/_authors/leah.md
@@ -9,5 +9,5 @@ state: CA
 github: leahbannon
 twitter: leahbannon
 team: Delivery
-redirect_from: /team/leah
+redirect_from: /team/leah/
 ---

--- a/_authors/leahg.md
+++ b/_authors/leahg.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Operations
-redirect_from: /team/leahg
+redirect_from: /team/leahg/
 ---

--- a/_authors/lenny-bogdonoff.md
+++ b/_authors/lenny-bogdonoff.md
@@ -9,5 +9,5 @@ role: General Developer
 state: NY
 team: 
 twitter: 
-redirect_from: /team/lenny-bogdonoff
+redirect_from: /team/lenny-bogdonoff/
 ---

--- a/_authors/lindsay.md
+++ b/_authors/lindsay.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/lindsay
+redirect_from: /team/lindsay/
 ---

--- a/_authors/manger.md
+++ b/_authors/manger.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Design
-redirect_from: /team/manger
+redirect_from: /team/manger/
 ---

--- a/_authors/marco.md
+++ b/_authors/marco.md
@@ -11,5 +11,5 @@ twitter:
 team: Design
 proejct:
 - Front End Guild
-redirect_from: /team/marco
+redirect_from: /team/marco/
 ---

--- a/_authors/mark.md
+++ b/_authors/mark.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/mark
+redirect_from: /team/mark/
 ---

--- a/_authors/matt.md
+++ b/_authors/matt.md
@@ -9,5 +9,5 @@ role:
 state: D.C.
 team: 
 twitter: 
-redirect_from: /team/matt
+redirect_from: /team/matt/
 ---

--- a/_authors/maya.md
+++ b/_authors/maya.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Design
-redirect_from: /team/maya
+redirect_from: /team/maya/
 ---

--- a/_authors/meghana.md
+++ b/_authors/meghana.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Design
-redirect_from: /team/meghana
+redirect_from: /team/meghana/
 ---

--- a/_authors/melody.md
+++ b/_authors/melody.md
@@ -16,6 +16,6 @@ project:
 - Federalist
 - 18F Hub
 - 18F Dashboard
-redirect_from: /team/melody
+redirect_from: /team/melody/
 alumni: true
 ---

--- a/_authors/mhz.md
+++ b/_authors/mhz.md
@@ -9,5 +9,5 @@ state: AZ
 github: meiqimichelle
 twitter: meiqimichelle
 team: Design
-redirect_from: /team/mhz
+redirect_from: /team/mhz/
 ---

--- a/_authors/micahsaul.md
+++ b/_authors/micahsaul.md
@@ -9,5 +9,5 @@ state: OR
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/micahsaul
+redirect_from: /team/micahsaul/
 ---

--- a/_authors/michael-balint.md
+++ b/_authors/michael-balint.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: 
-redirect_from: /team/michael-balint
+redirect_from: /team/michael-balint/
 ---

--- a/_authors/michael-cata.md
+++ b/_authors/michael-cata.md
@@ -9,5 +9,5 @@ state: NY
 github: 
 twitter: 
 team: 18F
-redirect_from: /team/michael-cata
+redirect_from: /team/michael-cata/
 ---

--- a/_authors/michael-torres.md
+++ b/_authors/michael-torres.md
@@ -9,5 +9,5 @@ role:
 state: CA
 team: Product
 twitter: 
-redirect_from: /team/michael-torres
+redirect_from: /team/michael-torres/
 ---

--- a/_authors/michael-walker.md
+++ b/_authors/michael-walker.md
@@ -9,5 +9,5 @@ role: Practical Dev
 state: MS
 team: AcqStack
 twitter: 
-redirect_from: /team/michael-walker
+redirect_from: /team/michael-walker/
 ---

--- a/_authors/mike-hsu.md
+++ b/_authors/mike-hsu.md
@@ -7,5 +7,5 @@ role: Product manager
 team: Delivery
 city: Washington
 state: D.C.
-redirect_from: /team/mike-hsu
+redirect_from: /team/mike-hsu/
 ---

--- a/_authors/moncef.md
+++ b/_authors/moncef.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/moncef
+redirect_from: /team/moncef/
 ---

--- a/_authors/mossadeq-zia.md
+++ b/_authors/mossadeq-zia.md
@@ -9,5 +9,5 @@ role: DevOps Engineer
 state: DC
 team: Infrastructure
 twitter: 
-redirect_from: /team/mossadeq-zia
+redirect_from: /team/mossadeq-zia/
 ---

--- a/_authors/nick.md
+++ b/_authors/nick.md
@@ -11,5 +11,5 @@ twitter:
 team: Delivery
 project:
 - Accessibility Guild
-redirect_from: /team/nick
+redirect_from: /team/nick/
 ---

--- a/_authors/nicole-fenton.md
+++ b/_authors/nicole-fenton.md
@@ -9,5 +9,5 @@ role: Content Designer
 state: New York
 team: design
 twitter: nicoleslaw
-redirect_from: /team/nicole-fenton
+redirect_from: /team/nicole-fenton/
 ---

--- a/_authors/noah.md
+++ b/_authors/noah.md
@@ -9,5 +9,5 @@ state: D.C.
 github: https://github.com/noahkunin
 twitter: https://twitter.com/noahkunin
 team: DevOps
-redirect_from: /team/noah
+redirect_from: /team/noah/
 ---

--- a/_authors/nolson.md
+++ b/_authors/nolson.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Presidential Innovation Fellowship
-redirect_from: /team/nolson
+redirect_from: /team/nolson/
 ---

--- a/_authors/phaedra.md
+++ b/_authors/phaedra.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/phaedra
+redirect_from: /team/phaedra/
 ---

--- a/_authors/philip-reid.md
+++ b/_authors/philip-reid.md
@@ -16,5 +16,5 @@ joke: |
 
   Due to other commitments, Philip will be working for the team only on April 1st. If you'd like to join Philip (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/philip-reid
+redirect_from: /team/philip-reid/
 ---

--- a/_authors/phoebe-espiritu.md
+++ b/_authors/phoebe-espiritu.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/phoebe-espiritu
+redirect_from: /team/phoebe-espiritu/
 ---

--- a/_authors/pia.md
+++ b/_authors/pia.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Outreach
-redirect_from: /team/pia
+redirect_from: /team/pia/
 ---

--- a/_authors/pkarman.md
+++ b/_authors/pkarman.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/pkarman
+redirect_from: /team/pkarman/
 ---

--- a/_authors/puja.md
+++ b/_authors/puja.md
@@ -9,5 +9,5 @@ role: Program Manager
 state: D.C.
 team: Presidential Innovation Fellowship
 twitter: 
-redirect_from: /team/puja
+redirect_from: /team/puja/
 ---

--- a/_authors/randy-hart.md
+++ b/_authors/randy-hart.md
@@ -9,5 +9,5 @@ role: Procurement Specialist
 state: DC
 team: Consulting
 twitter: 
-redirect_from: /team/randy-hart
+redirect_from: /team/randy-hart/
 ---

--- a/_authors/raphy.md
+++ b/_authors/raphy.md
@@ -9,5 +9,5 @@ state: IL
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/raphy
+redirect_from: /team/raphy/
 ---

--- a/_authors/rebeccapiazza.md
+++ b/_authors/rebeccapiazza.md
@@ -9,5 +9,5 @@ role: Product Manager
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/rebeccapiazza
+redirect_from: /team/rebeccapiazza/
 ---

--- a/_authors/ric.md
+++ b/_authors/ric.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: 18F
-redirect_from: /team/ric
+redirect_from: /team/ric/
 ---

--- a/_authors/robin-carnahan.md
+++ b/_authors/robin-carnahan.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/robin-carnahan
+redirect_from: /team/robin-carnahan/
 ---

--- a/_authors/roger-ruiz.md
+++ b/_authors/roger-ruiz.md
@@ -9,5 +9,5 @@ state: VA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/roger-ruiz
+redirect_from: /team/roger-ruiz/
 ---

--- a/_authors/romke.md
+++ b/_authors/romke.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/romke
+redirect_from: /team/romke/
 ---

--- a/_authors/ryan-sibley.md
+++ b/_authors/ryan-sibley.md
@@ -9,5 +9,5 @@ role: Content Designer
 state: DC
 team: Design
 twitter: 
-redirect_from: /team/ryan-sibley
+redirect_from: /team/ryan-sibley/
 ---

--- a/_authors/ryan.md
+++ b/_authors/ryan.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/ryan
+redirect_from: /team/ryan/
 ---

--- a/_authors/sally-ride.md
+++ b/_authors/sally-ride.md
@@ -16,5 +16,5 @@ joke: |
 
   Due to other commitments, Sally will be working for the team only on April 1st. If you'd like to join Sally (and not just for April 1) you can <a href="https://pages.18f.gov/joining-18f/">see all of our openings and learn more about working at 18F</a>.)
 layout: nothing
-redirect_from: /team/sally-ride
+redirect_from: /team/sally-ride/
 ---

--- a/_authors/sam-eagle.md
+++ b/_authors/sam-eagle.md
@@ -16,5 +16,5 @@ joke: |
 
   *As of press time, Sam had not yet been introduced to Slack.
 layout: nothing
-redirect_from: /team/sam-eagle
+redirect_from: /team/sam-eagle/
 ---

--- a/_authors/sasha.md
+++ b/_authors/sasha.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/sasha
+redirect_from: /team/sasha/
 ---

--- a/_authors/shawn.md
+++ b/_authors/shawn.md
@@ -9,5 +9,5 @@ state: CA
 github: 
 twitter: 
 team: Design
-redirect_from: /team/shawn
+redirect_from: /team/shawn/
 ---

--- a/_authors/shawnique.md
+++ b/_authors/shawnique.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Talent
-redirect_from: /team/shawnique
+redirect_from: /team/shawnique/
 ---

--- a/_authors/smita.md
+++ b/_authors/smita.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Presidential Innovation Fellowship
-redirect_from: /team/smita
+redirect_from: /team/smita/
 ---

--- a/_authors/stephanierivera.md
+++ b/_authors/stephanierivera.md
@@ -11,5 +11,5 @@ twitter:
 team: Strategy
 project:
 - 18F Intake
-redirect_from: /team/stephanierivera
+redirect_from: /team/stephanierivera/
 ---

--- a/_authors/steven-harms.md
+++ b/_authors/steven-harms.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/steven-harms
+redirect_from: /team/steven-harms/
 ---

--- a/_authors/steven-reilly.md
+++ b/_authors/steven-reilly.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Acquisitions
-redirect_from: /team/steven-reilly
+redirect_from: /team/steven-reilly/
 ---

--- a/_authors/tadhg.md
+++ b/_authors/tadhg.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/tadhg
+redirect_from: /team/tadhg/
 ---

--- a/_authors/theresa.md
+++ b/_authors/theresa.md
@@ -11,5 +11,5 @@ twitter: theresaanna
 team: Delivery
 project:
 - CALC
-redirect_from: /team/theresa
+redirect_from: /team/theresa/
 ---

--- a/_authors/timothy-jones.md
+++ b/_authors/timothy-jones.md
@@ -7,5 +7,5 @@ city: Washington
 state: D.C.
 role: Digital transformation lead
 team: 18F Consulting
-redirect_from: /team/timothy-jones
+redirect_from: /team/timothy-jones/
 ---

--- a/_authors/valdiviezo.md
+++ b/_authors/valdiviezo.md
@@ -9,5 +9,5 @@ role:
 state: 
 team: 
 twitter: 
-redirect_from: /team/valdiviezo
+redirect_from: /team/valdiviezo/
 ---

--- a/_authors/vdavez.md
+++ b/_authors/vdavez.md
@@ -9,5 +9,5 @@ state: D.C.
 github: vdavez
 twitter: vdavez
 team: Acquisition
-redirect_from: /team/vdavez
+redirect_from: /team/vdavez/
 ---

--- a/_authors/victor-udoewa.md
+++ b/_authors/victor-udoewa.md
@@ -9,5 +9,5 @@ role:
 state: D.C.
 team: Consulting
 twitter: 
-redirect_from: /team/victor-udoewa
+redirect_from: /team/victor-udoewa/
 ---

--- a/_authors/victor.md
+++ b/_authors/victor.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Design
-redirect_from: /team/victor
+redirect_from: /team/victor/
 ---

--- a/_authors/vraj-mohan.md
+++ b/_authors/vraj-mohan.md
@@ -9,5 +9,5 @@ state: PA
 github: 
 twitter: 
 team: 18F
-redirect_from: /team/vraj-mohan
+redirect_from: /team/vraj-mohan/
 ---

--- a/_authors/will.md
+++ b/_authors/will.md
@@ -11,5 +11,5 @@ twitter: wslack
 team: Products and Platforms
 project:
 - Federalist
-redirect_from: /team/will
+redirect_from: /team/will/
 ---

--- a/_authors/willsullivan.md
+++ b/_authors/willsullivan.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/willsullivan
+redirect_from: /team/willsullivan/
 ---

--- a/_authors/yoz.md
+++ b/_authors/yoz.md
@@ -11,5 +11,5 @@ twitter:
 team: Delivery
 project:
 - Project Review
-redirect_from: /team/yoz
+redirect_from: /team/yoz/
 ---

--- a/_authors/yuda.md
+++ b/_authors/yuda.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Delivery
-redirect_from: /team/yuda
+redirect_from: /team/yuda/
 ---

--- a/_authors/zaccohn.md
+++ b/_authors/zaccohn.md
@@ -9,5 +9,5 @@ state: D.C.
 github: 
 twitter: 
 team: Consulting
-redirect_from: /team/zaccohn
+redirect_from: /team/zaccohn/
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ collections:
     permalink: /press/:name/
   projects:
     output: true
-    permalink: project/:path/
+    permalink: /project/:path/
 
 defaults:
  -

--- a/_config.yml
+++ b/_config.yml
@@ -92,11 +92,14 @@ exclude:
   - node_modules
 # jekyll plugins
 gems:
-  - jekyll-sitemap
-  - jekyll-archives
   - jekyll-redirect-from
+  - jekyll-archives
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-sitemap
+
+whitelist:
+  - jekyll-redirect-from
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:
   # Uncomment this to speed up site generation while developing.

--- a/_config.yml
+++ b/_config.yml
@@ -92,14 +92,12 @@ exclude:
   - node_modules
 # jekyll plugins
 gems:
-  - jekyll-redirect-from
+  - jekyll-sitemap
   - jekyll-archives
+  - jekyll-redirect-from
   - jekyll-feed
   - jekyll-seo-tag
-  - jekyll-sitemap
 
-whitelist:
-  - jekyll-redirect-from
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:
   # Uncomment this to speed up site generation while developing.

--- a/pages/author.md
+++ b/pages/author.md
@@ -1,0 +1,4 @@
+---
+layout: default
+permalink: /author/
+---

--- a/pages/team.html
+++ b/pages/team.html
@@ -1,5 +1,0 @@
----
-permalink: /team/
-redirect_to:
-- /
----

--- a/pages/team.md
+++ b/pages/team.md
@@ -1,0 +1,5 @@
+---
+permalink: /team/
+redirect_to:
+- /author/
+---

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,6 +3,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
+  <!-- Site url: {{ site.url }} -->
+  <!-- Site baseurls: {{ site.base_url }} -->
   {% if site.url %}
     {% if site.baseurl == "" %}
       {% if site.env == 'development' %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,8 +3,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
-  <!-- Site url: {{ site.url }} -->
-  <!-- Site baseurls: {{ site.base_url }} -->
+  <!-- url: {{ site.url }} -->
+  <!-- baseurl: {{ site.base_url }} -->
   {% if site.url %}
     {% if site.baseurl == "" %}
       {% if site.env == 'development' %}


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/redirecting.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/redirection)

I think the issue that we were seeing with redirecting issues in production are the result of the following two factors:
- the `redirect_from` front matter properties contained paths that didn't end in forward slashes. This leads to files like `aaron.html` instead of `aaron/index.html` in `_site`, which is needed for federalist to work properly
- The `redirect_from` gem is likely creating the absolute url that it is redirecting the page to by looking at the configuration `site.url`, so it is getting `18f.gsa.gov` on federalist, instead of `federalist.18f.gov`. This _shouldn't_ be an issue on the live site. IMHO it isn't necessary to debug a redirecting issue if we are only seeing it in our staging environment. Especially because it will probably take a lot of extra time/work

NOTE (tldr): this is fixed locally and in production 🎉  for `team` --> `author`, but not for Federalist preview branches 😢 

/cc @mugizico 