### PR TITLE
Change capitalization

### DIFF
--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -7,7 +7,7 @@ lead:
 
 This is a copy of the vulnerability disclosure policy for 18F and the Technology Transformation Service (TTS). The [official document lives in GitHub](https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md#vulnerability-disclosure-policy). If you would like to comment or suggest a change to the policy, please [open a GitHub issue](https://github.com/18F/vulnerability-disclosure-policy/issues).
 
-### Vulnerability Disclosure Policy
+### Vulnerability disclosure policy
 
 As part of a U.S. government agency, [GSA's Technology Transformation Service](http://gsa.gov/tts) takes seriously our responsibility to protect the public's information, including financial and personal information, from unwarranted disclosure.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- change capitalization to "vulnerability disclosure policy"

Per @konklone, this policy is not a proper noun and should be lower case in all instances.