### PR TITLE
add smart extension

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,8 +81,7 @@ markdown: RedcarpetExt
 highlighter: rouge
 redcarpet:
   syntax_highlighter: rouge
-  extensions:
-  - tables
+  extensions: ["tables", "quote"]
 
 include:
   - _navigation.json

--- a/pages/quote-example.md
+++ b/pages/quote-example.md
@@ -1,0 +1,9 @@
+---
+title: Quote Example
+permalink: /quotes/
+layout: default-image
+lead: Just another page demonstrating quotes
+---
+
+"Hey" "Test" 
+

--- a/pages/quote-example.md
+++ b/pages/quote-example.md
@@ -1,9 +1,0 @@
----
-title: Quote Example
-permalink: /quotes/
-layout: default-image
-lead: Just another page demonstrating quotes
----
-
-"Hey" "Test" 
-


### PR DESCRIPTION
Fixes issue(s) #2007 .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/smart-quotes.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/smart-quotes)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/smart-quotes/quotes)

Changes proposed in this pull request:
- adds `quotes` extension to render smart quotes
- adds `/quotes` page for testing(remove when merging)


/cc  @coreycaitlin 

