### PR TITLE
Use excerpt instead of description in header

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,9 +20,9 @@
   <meta property="og:title" content="{{ site.title | xml_escape }} | {{ site.title | xml_escape }}" />
 {% endif %}
 
-{% if page.description %}
-  <meta name="description" content="{{ page.description | xml_escape }}">
-  <meta property="og:description" content="{{ page.description | xml_escape }}" />
+{% if page.excerpt %}
+  <meta name="description" content="{{ page.excerpt | xml_escape }}">
+  <meta property="og:description" content="{{ page.excerpt | xml_escape }}" />
 {% else %}
   <meta name="description" content="{{ site.description | xml_escape }}">
   <meta property="og:description" content="{{ site.description | xml_escape }}" />

--- a/_sass/_components/tag-index.scss
+++ b/_sass/_components/tag-index.scss
@@ -3,7 +3,7 @@
 
 .page-tag-results {
   .hero {
-    padding-bottom: $section-margins;
+    padding-bottom: 6rem;
   }
 
   .hero-callout {

--- a/_sass/_components/tag-index.scss
+++ b/_sass/_components/tag-index.scss
@@ -3,7 +3,7 @@
 
 .page-tag-results {
   .hero {
-    padding-bottom: 6rem;
+    padding-bottom: $section-margins;
   }
 
   .hero-callout {


### PR DESCRIPTION
Fixes issue(s) #2032 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/deprecate-description.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/deprecate-description)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/deprecate-description/)

Changes proposed in this pull request:
- Change which item we're pulling into the page `head` element: it now uses `excerpt` instead of `description`

/cc @gemfarmer 

