### PR TITLE
Removes a not-great looking hero image

### DIFF
--- a/_posts/2016-02-19-how-and-why-we-built-the-micro-purchase-platform.md
+++ b/_posts/2016-02-19-how-and-why-we-built-the-micro-purchase-platform.md
@@ -16,6 +16,7 @@ description: "This past December, 18F launched a micro-purchase platform to enab
 vendors to place bids on opportunities to deliver open source code that
 costs $3,500 or less. This is a look at how and why we built this platform."
 image: /assets/blog/micro-purchase/micro-purchase-homepage2.jpg
+hero: false
 ---
 
 This past December, 18F launched a micro-purchase platform to enable


### PR DESCRIPTION
The image will still be used as the share graphic, but not as a banner above the post.

😎 [Preview](https://federalist.18f.gov/preview/18f/18f.gsa.gov/hero-remove/2016/02/19/how-and-why-we-built-the-micropurchase-platform/)

cc @18F/blog 