### PR TITLE
Style tweaks to the project page hero

### DIFF
--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -11,7 +11,8 @@ header_border: true
            aria-label="{{ page.image_accessibility }}">
     <div class="usa-grid">
       <div class="hero-callout hero-callout-no_button background-dark">
-        <h1 class="h3">{{ page.title }}</h1>
+        <h1 class="h3">Project:<br>
+        {{ page.title }}</h1>
       </div>
     </div>
   </section>

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -11,7 +11,7 @@ header_border: true
            aria-label="{{ page.image_accessibility }}">
     <div class="usa-grid">
       <div class="hero-callout hero-callout-no_button background-dark">
-        <h1 class="h3">Project:<br>
+        <h1 class="h3 hero-callout-title">Project:<br>
         {{ page.title }}</h1>
       </div>
     </div>

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -1,6 +1,6 @@
 ---
 layout: project-tag-results
-title: "Project: The Federal Election Commission"
+title: "The Federal Election Commission"
 subtitle: Making campaign data easier to use
 exerpt:
 image_path: /assets/img/home/hero-fec.png

--- a/_sass/_components/tag-index.scss
+++ b/_sass/_components/tag-index.scss
@@ -13,7 +13,7 @@
     padding-left: $paragraph-margins * 1.2;
   }
 
-  h1.h3 {
+  .hero-callout-title {
     line-height: 1.2;
   }
 

--- a/_sass/_components/tag-index.scss
+++ b/_sass/_components/tag-index.scss
@@ -3,11 +3,18 @@
 
 .page-tag-results {
   .hero {
-    padding-bottom: $section-margins;
+    padding-bottom: $section-margins * 1.5;
   }
 
   .hero-callout {
-    max-width: 26rem;
+    max-width: 21rem;
+    padding-top: $paragraph-margins;
+    padding-bottom: $paragraph-margins;
+    padding-left: $paragraph-margins * 1.2;
+  }
+
+  h1.h3 {
+    line-height: 1.2;
   }
 
   .post-list {

--- a/pages/home.html
+++ b/pages/home.html
@@ -8,7 +8,7 @@ title: Home
   <div class="usa-grid">
     <div class="hero-callout background-dark">
       <h2>We’re helping <span class="hero-callout-alt_color">the Federal Election Commission make campaign finance data easier to use.</span></h2>
-      <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/tags/fec-gov/">Learn more about fec.gov</a>
+      <a class="usa-button usa-button-big usa-button-secondary" href="{{ site.baseurl }}/project/fec-gov/">Learn more about fec.gov</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes issue(s) #2052 to match mocks mentioned in #2016 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-pg-tweaks.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-pg-tweaks)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/project-pg-tweaks/)

Changes proposed in this pull request:
- Changes spacing around the title element
- Moves `Project:` into the template itself and forces a line break after it

/cc @gemfarmer 

