### PR TITLE
Remove hire menu accorion, subnav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,7 +72,7 @@ defaults:
     path: "_hire"
   values:
     layout: default-image
-    include_subnav: true
+    # include_subnav: true
     subnav_anchor: /hire/
 
 frontmatter_tests:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -34,7 +34,7 @@ assigned:
                 text: 'Partnership playbook'
                 permalink: /hire/partnership-playbook/
                 in_menu: false
-                in_drawer: true
+                in_drawer: false
                 in_footer: false
                 in_subnav: true
                 children:


### PR DESCRIPTION
Temporarily remove menu accordion, subnav, so we can push to master. Continue this work on another branch

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/temporarily-hide-hire-subpages.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/temporarily-hide-hire-subpages)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/temporarily-hide-hire-subpages/)

Changes proposed in this pull request:


/cc @coreycaitlin 

