### PR TITLE
Add version to config (v1.1.1)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ logo: /assets/img/logos/18F-Logo-Bright-S.png
 feature_image: /assets/img/feature-background.jpg
 tag_dir: tags
 
+# app version number
+version: v1.1.0
+
 analytics:
   google:
     code: 'UA-48605964-1' # Change this to your GSA analytics code


### PR DESCRIPTION
Adds a version to the config file so that we can keep track of what version the code is at. I started at `v1.1.0` thinking that we were probably at `v1.0.0` when the current team started in October. Does this seem like an appropriate version?

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/version.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/version)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/version/)

/cc @gboone 

