### PR TITLE
Temporarily exclude partnership playbook pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ collections:
     output: true
     permalink: /project/:path/
   hire:
-    output: true
+    output: false
     permalink: /hire/:path/
 
 defaults:

--- a/pages/hire.md
+++ b/pages/hire.md
@@ -1,0 +1,24 @@
+---
+title: Hire 18F
+permalink: /hire/
+image: /assets/img/page-feature/hire-us.jpg
+lead: Let’s work together to design services that empower your team, better serve the public, and tackle the big problems facing your agency.
+---
+
+We can work with you to explore and define a variety of problems, and then we can help you build or buy a solution.
+
+Because of our limited resources, 18F is not able to take on every
+project that agencies propose. We select our projects through a
+qualification and evaluation process led by our Agency Partnerships
+Team. If you and 18F decide that we’re the right fit for a project and
+we have the necessary time and resources, we’ll work with you to draft
+the necessary documents to begin our partnership. You can read more
+about how we work with other agencies in our [Partnership
+Playbook](https://pages.18f.gov/partnership-playbook/).
+
+18F is a cost-recoverable office, which means that we do not receive
+appropriated funds from Congress and must charge our partner agencies to
+cover our costs. Funding is set up through [Interagency
+Agreements](https://pages.18f.gov/iaa-forms/).
+
+Do you have a project in mind? Let us know: [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov)


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide-hire-pages.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide-hire-pages)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/hide-hire-pages/)

Changes proposed in this pull request:
- prevents `/hire/partnership-playbook/` and subpages

/cc @coreycaitlin 
