### PR TITLE
Reintroduce 'hire' image

### DIFF
--- a/pages/hire.md
+++ b/pages/hire.md
@@ -2,6 +2,7 @@
 title: Hire 18F
 permalink: /hire/
 image: /assets/img/page-feature/hire-us.jpg
+layout: default-image
 lead: Let’s work together to design services that empower your team, better serve the public, and tackle the big problems facing your agency.
 ---
 


### PR DESCRIPTION
The 'hire' page is missing an image in `dev` and `master`. This updates the layout so that it exists!

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hire-image.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hire-image)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/hire-image/)

/cc @coreycaitlin 
