### PR TITLE
Revised "Hire 18F" content

### DIFF
--- a/pages/hire.md
+++ b/pages/hire.md
@@ -3,23 +3,13 @@ title: Hire 18F
 permalink: /hire/
 image: /assets/img/page-feature/hire-us.jpg
 layout: default-image
-lead: Let’s work together to design services that empower your team, better serve the public, and tackle the big problems facing your agency.
+lead: Let’s work together to empower your team, tackle the big technology problems facing your agency, and transform how you deliver digital services.
 ---
 
-We can work with you to explore and define a variety of problems, and then we can help you build or buy a solution.
+Have a project in mind? Want to see if 18F can help your agency? Get in touch, and we'll set up a time to talk:
 
-Because of our limited resources, 18F is not able to take on every
-project that agencies propose. We select our projects through a
-qualification and evaluation process led by our Agency Partnerships
-Team. If you and 18F decide that we’re the right fit for a project and
-we have the necessary time and resources, we’ll work with you to draft
-the necessary documents to begin our partnership. You can read more
-about how we work with other agencies in our [Partnership
-Playbook](https://pages.18f.gov/partnership-playbook/).
+You can also email our Agency Partnerships team directly at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).
 
-18F is a cost-recoverable office, which means that we do not receive
-appropriated funds from Congress and must charge our partner agencies to
-cover our costs. Funding is set up through [Interagency
-Agreements](https://pages.18f.gov/iaa-forms/).
+Once we've worked together to define your problem, we can help you build or buy a solution. You can read more about how we work with agencies in our [Partnership Playbook](https://pages.18f.gov/partnership-playbook/).
 
-Do you have a project in mind? Let us know: [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov)
+18F is a cost-recoverable office, which means we don't receive appropriated funds from Congress and must charge our partner agencies to cover our costs. We use [Interagency Agreements](https://pages.18f.gov/iaa-forms/) to set up the terms of our projects.

--- a/pages/hire.md
+++ b/pages/hire.md
@@ -2,14 +2,40 @@
 title: Hire 18F
 permalink: /hire/
 image: /assets/img/page-feature/hire-us.jpg
-layout: default-image
-lead: Let’s work together to empower your team, tackle the big technology problems facing your agency, and transform how you deliver digital services.
+layout: default-intro
+lead: Let’s work together to tackle your agency’s technology problems and transform how you serve the public.
 ---
 
-Have a project in mind? Want to see if 18F can help your agency? Get in touch, and we'll set up a time to talk:
+## Get in touch
 
-You can also email our Agency Partnerships team directly at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).
+Have a project in mind? Want to see if 18F can help your agency?
 
-Once we've worked together to define your problem, we can help you build or buy a solution. You can read more about how we work with agencies in our [Partnership Playbook](https://pages.18f.gov/partnership-playbook/).
+Send us a little information about how to contact you, and we'll set up a time to talk about whether we can help you build or buy a solution.
+
+<form action="mailto:corey.mahoney@gsa.gov" method="post" enctype="text/plain">
+
+    <label for="input-name">What’s your name?</label>
+    <input id="input-name" name="input-name" type="text">
+
+    <label for="input-email">What email address should we use to contact you?</label>
+    <input id="input-email" name="input-email" type="email">
+
+    <label for="input-agency">What agency or office do you work for?</label>
+    <input id="input-agency" name="input-agency" type="text">
+
+    <label for="input-role">What’s your job title or role?</label>
+    <input id="input-role" name="input-role" type="text">
+
+    <label for="input-notes">Tell us a little about the problems you’re working on, or what project you’re hoping to work on with 18F.</label>
+    <textarea id="input-notes" name="input-notes" type="textarea"></textarea>
+
+    <input type="submit" value="Submit">
+</form>
+
+You can also email [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov) to reach Dan Kenny on our Agency Partnerships team.
+
+## How we work with partners
 
 18F is a cost-recoverable office, which means we don't receive appropriated funds from Congress and must charge our partner agencies to cover our costs. We use [Interagency Agreements](https://pages.18f.gov/iaa-forms/) to set up the terms of our projects.
+
+You can read more about how we work with agencies in our [Partnership Playbook](https://pages.18f.gov/partnership-playbook/).

--- a/pages/hire.md
+++ b/pages/hire.md
@@ -2,40 +2,18 @@
 title: Hire 18F
 permalink: /hire/
 image: /assets/img/page-feature/hire-us.jpg
-layout: default-intro
+layout: default-image
 lead: Let’s work together to tackle your agency’s technology problems and transform how you serve the public.
 ---
 
-## Get in touch
+Have a project in mind? Want to see if 18F can help your agency? Email Dan Kenny on our Agency Partnerships team at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov&subject=18F%20website%20inquiry).
 
-Have a project in mind? Want to see if 18F can help your agency?
+We’ll set up a time to talk more, answer your questions, and ask about what you have in mind. Once we understand your office and the problems you're trying to solve, we'll figure out whether we can help you build or buy a solution.
 
-Send us a little information about how to contact you, and we'll set up a time to talk about whether we can help you build or buy a solution.
+<a class="usa-button" href="mailto:inquiries18F@gsa.gov?subject=18F%20Website%20Inquiry&body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20the%20problems%20you%27re%20working%20on%2C%20or%20what%20project%20you%27re%20hoping%20to%20work%20on%20with%2018F:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%3F%0A">Email us</a>
 
-<form action="mailto:corey.mahoney@gsa.gov" method="post" enctype="text/plain">
+**How we work with partners**
 
-    <label for="input-name">What’s your name?</label>
-    <input id="input-name" name="input-name" type="text">
-
-    <label for="input-email">What email address should we use to contact you?</label>
-    <input id="input-email" name="input-email" type="email">
-
-    <label for="input-agency">What agency or office do you work for?</label>
-    <input id="input-agency" name="input-agency" type="text">
-
-    <label for="input-role">What’s your job title or role?</label>
-    <input id="input-role" name="input-role" type="text">
-
-    <label for="input-notes">Tell us a little about the problems you’re working on, or what project you’re hoping to work on with 18F.</label>
-    <textarea id="input-notes" name="input-notes" type="textarea"></textarea>
-
-    <input type="submit" value="Submit">
-</form>
-
-You can also email [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov) to reach Dan Kenny on our Agency Partnerships team.
-
-## How we work with partners
-
-18F is a cost-recoverable office, which means we don't receive appropriated funds from Congress and must charge our partner agencies to cover our costs. We use [Interagency Agreements](https://pages.18f.gov/iaa-forms/) to set up the terms of our projects.
+18F is a cost-recoverable office, which means we don't receive appropriated funds from Congress and must charge our partner agencies for the work we do. We use [Interagency Agreements](https://pages.18f.gov/iaa-forms/) to set up the terms of our projects.
 
 You can read more about how we work with agencies in our [Partnership Playbook](https://pages.18f.gov/partnership-playbook/).

--- a/pages/hire.md
+++ b/pages/hire.md
@@ -6,7 +6,7 @@ layout: default-image
 lead: Let’s work together to tackle your agency’s technology problems and transform how you serve the public.
 ---
 
-Have a project in mind? Want to see if 18F can help your agency? Email Dan Kenny on our Agency Partnerships team at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov&subject=18F%20website%20inquiry).
+Have a project in mind? Want to see if 18F can help your agency? Email Dan Kenny on our Agency Partnerships team at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov?subject=18F%20Website%20Inquiry&body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20the%20problems%20you%27re%20working%20on%2C%20or%20what%20project%20you%27re%20hoping%20to%20work%20on%20with%2018F:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%3F%0A).
 
 We’ll set up a time to talk more, answer your questions, and ask about what you have in mind. Once we understand your office and the problems you're trying to solve, we'll figure out whether we can help you build or buy a solution.
 


### PR DESCRIPTION
Fixes the hire page part of #2067 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hire-rewrite.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hire-rewrite)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/hire-rewrite/)

Changes proposed in this pull request:
- Edit the content to focus on the essentials, with a more welcoming tone
- Tell people who they're contacting — in this case, @d-kenny 
- Include more default behavior in the `mailto` link, including subject and a template for body text
- Add a button

/cc @gemfarmer @gboone 
