### PR TITLE
Add project-page links to what we deliver, revise HHS intro

### DIFF
--- a/_projects/hhs-states.md
+++ b/_projects/hhs-states.md
@@ -15,10 +15,10 @@ project_url:
 
 Health and Human Services (HHS) is a federal agency, but many crucial HHS programs — like Medicaid — are administered by states.
 
-HHS encourages states to reduce technology risks by offering funding incentives for upgrading legacy systems — but many states struggle to implement current best practices in software contracts, especially while navigating federal and state contracting rules. HHS hired 18F to step in and help states set these projects up for success.
+HHS encourages states to upgrading legacy systems by offering funding incentives, but many states struggle to manage risk and build usable systems while navigating federal and state contracting rules. HHS hired 18F to step in and help states set these projects up for success through the technology acquisition process.
 
 ### Reducing risk by breaking up contracts
 
-In our first project with HHS, we helped California get on the right path to buying a new system for child welfare case management by facilitating a two-day workshop to break an overwhelming contract into smaller pieces (along with people from California’s Department of Social Services, the Office of Systems Integration, HHS, and Code for America).
+In our first project with HHS, we helped California get on the right path to buying a new system for child welfare case management by facilitating a two-day workshop to break a monolithic contract into smaller pieces (along with people from California’s Department of Social Services, the Office of Systems Integration, HHS, and Code for America).
 
 Next, HHS asked us to work with other states on similar projects to procure case management systems for child welfare programs. We also began applying what we learned to a new challenge: working with the Centers for Medicare and Medicaid Systems (also within HHS) to support states who were upgrading Medicaid data systems.

--- a/_projects/hhs-states.md
+++ b/_projects/hhs-states.md
@@ -15,10 +15,10 @@ project_url:
 
 Health and Human Services (HHS) is a federal agency, but many crucial HHS programs — like Medicaid — are administered by states.
 
-HHS encourages states to upgrading legacy systems by offering funding incentives, but many states struggle to manage risk and build usable systems while navigating federal and state contracting rules. HHS hired 18F to step in and help states set these projects up for success through the technology acquisition process.
+HHS encourages states to upgrade legacy systems by offering funding incentives, but many states struggle to manage risk and build usable systems while navigating federal and state contracting rules. HHS hired 18F to step in and help states set these projects up for success through the technology acquisition process.
 
 ### Reducing risk by breaking up contracts
 
-In our first project with HHS, we helped California get on the right path to buying a new system for child welfare case management by facilitating a two-day workshop to break a monolithic contract into smaller pieces (along with people from California’s Department of Social Services, the Office of Systems Integration, HHS, and Code for America).
+In our first project with HHS, we helped California get on the right path to buying a new system for child welfare case management by facilitating a two-day workshop to break a monolithic contract into smaller pieces (along with colleagues from California’s Department of Social Services, the Office of Systems Integration, and Code for America).
 
-Next, HHS asked us to work with other states on similar projects to procure case management systems for child welfare programs. We also began applying what we learned to a new challenge: working with the Centers for Medicare and Medicaid Systems (also within HHS) to support states who were upgrading Medicaid data systems.
+Next, HHS asked us to work with other states who needed to procure case management systems for child welfare. We also began applying what we learned to a new challenge: working with the Centers for Medicare and Medicaid Systems (also within HHS) to support states who were upgrading Medicaid data systems.

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -18,7 +18,7 @@ If your agency’s project has a digital component, our team of software develop
 
 - Improve a challenging user process by reimagining a daunting task, as we did with the [U.S. Citizenship and Immigration Service](https://my.uscis.gov/) and their immigration and visa processes.
 - Build a new site and API to showcase and synthesize data from multiple sources, as we did with Department of Education's [College Scorecard](https://collegescorecard.ed.gov/).
-- Help you make your data more accessible with a user-friendly site and developer tools, as we did with the [Federal Election Commission](https://beta.fec.gov/).
+- Help you make your data more accessible with a user-friendly site and developer tools, as we did with the [Federal Election Commission]({{ site.baseurl }}/project/fec-gov/).
 - Build web-based tools to streamline internal agency processes, as we did with [Communicart](https://cap.18f.gov/) and [CALC](https://calc.gsa.gov/).
 - Scope a solution or collaborate on an idea in a way that empowers you to meet the needs of your users, as we did with the [Department of Labor’s Wage and Hour Division](https://18f.gsa.gov/2015/09/09/how-a-two-day-spring-moved-an-agency-twenty-years-forward/).
 - Do user research and discovery sprints to promote a new digital model that houses information, as we did with NASA and the National Oceanic and Atmospheric Administration’s Climate Discovery project.
@@ -39,7 +39,7 @@ better results. If your agency is developing a new request for quotation
 for IT services or is interested in innovative ways to buy technology,
 our team is excited to work with you. We can help you:
 
-- Write agile, modular, and user-centered design into your request for quotations through our RFP Ghostwriting service, like we did with the [Department of Health and Human Services](https://18f.gsa.gov/2016/03/22/helping-california-buy-a-new-child-welfare-system/).
+- Write agile, modular, and user-centered design into your request for quotations through our RFP Ghostwriting service, like we did with the [Department of Health and Human Services]({{ site.baseurl }}/project/hhs-states/).
 - Develop a marketplace to buy IT services using modern techniques, like we did with the [Agile Blanket Purchase Agreement](https://pages.18f.gov/ads-bpa/).
 - Buy small pieces of open source code to advance your projects, like we’re doing with our [micro-purchase platform](https://micropurchase.18f.gov/).
   {% endmarkdown %}


### PR DESCRIPTION
Fixes issue(s) #2069 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-intros.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/project-intros)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/project-intros/)

Changes proposed in this pull request:
- Revise the HHS project intro to include the words "acquisition" and "monolithic"
- Change project links on `What we deliver` to go to project pages 🎉 

/cc @gemfarmer 

