### PR TITLE
Fix accesslint scanning by chaining with jekyll server

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ machine:
 
 dependencies:
   pre:
+    - gem install bundler
     - bundle install
     - bundle exec jekyll build
     - npm install -g accesslint-cli
@@ -29,5 +30,5 @@ test:
     # uncomment to restore pa11y-ci
     # - npm run --harmony lint-508
   post:
-    - bundle exec jekyll serve --detach
-    - accesslint-ci scan http://localhost:4000
+    - bundle exec jekyll serve --detach && bundle exec accesslint-ci scan http://localhost:4000:
+        timeout: 1200


### PR DESCRIPTION
- Chain `accesslint-ci` command with `jekyll serve`.
- Fixes blank accesslint results by waiting for jekyll server to finish starting.

cc @gemfarmer 

[Fixes https://github.com/accesslint/accesslint-ci/issues/39]