### PR TITLE
AccessLint - Serve site with only recent blog posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.3.1"
 gem "redcarpet"
 gem "jekyll", '~> 3.1'
 gem "html-proofer"
-gem "accesslint-ci"
+gem "accesslint-ci", "0.2.5"
 
 group :jekyll_plugins do
   if ENV['FAST_BUILDS'] == 'true'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    accesslint-ci (0.2.4)
+    accesslint-ci (0.2.5)
       rest-client (~> 2.0)
       thor (~> 0.19)
     activesupport (4.2.7.1)
@@ -132,7 +132,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  accesslint-ci
+  accesslint-ci (= 0.2.5)
   html-proofer
   jekyll (~> 3.1)
   jekyll-archives!

--- a/_config-blog.yml
+++ b/_config-blog.yml
@@ -19,12 +19,14 @@ exclude:
 - feed*
 - Gemfile*
 - humans.txt
+- node_modules
 - package.json
 - robots.txt
 - search-index*
 - serve
 - sitemap.xml
 - system-security-plan.yml
+- vendor
 - _posts/2014-03-12-coming-soon.md
 - _posts/2014-03-19-hello-world-we-are-18f.md
 - _posts/2014-03-21-29-minutes.md

--- a/circle.yml
+++ b/circle.yml
@@ -11,15 +11,11 @@ machine:
 
 dependencies:
   pre:
-    - gem install bundler
-    - bundle install
     - npm install -g accesslint-cli
 
 test:
-  pre:
-    - bundle exec jekyll serve --detach && bundle exec accesslint-ci scan http://localhost:4000
   override:
-    # - bundle exec jekyll build
     - npm run test
     - npm run htmlproofer
-
+  post:
+    - ./serve-accesslint && bundle exec accesslint-ci scan http://localhost:4000

--- a/serve-accesslint
+++ b/serve-accesslint
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+LC_ALL="en_US.UTF-8" \
+bundle exec jekyll serve \
+  --detach \
+  --config="_config.yml,_config-blog.yml"


### PR DESCRIPTION
- Fix accesslint version.
- Update _config-blog.yml by running `ruby config_blog.rb`.
- Use config-blog.yml to only serve the 3 most recent posts.