### PR TITLE
Serve accesslint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.3.1"
 gem "redcarpet"
 gem "jekyll", '~> 3.1'
 gem "html-proofer"
-gem "accesslint-ci"
+gem "accesslint-ci", "0.2.6"
 
 group :jekyll_plugins do
   if ENV['FAST_BUILDS'] == 'true'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.3.1"
 gem "redcarpet"
 gem "jekyll", '~> 3.1'
 gem "html-proofer"
+gem "accesslint-ci"
 
 group :jekyll_plugins do
   if ENV['FAST_BUILDS'] == 'true'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    accesslint-ci (0.2.4)
+      rest-client (~> 2.0)
+      thor (~> 0.19)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -18,6 +21,8 @@ GEM
     coderay (1.1.1)
     colorator (1.1.0)
     colored (1.2)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
     ethon (0.9.1)
       ffi (>= 1.3.0)
     ffi (1.9.14)
@@ -36,6 +41,8 @@ GEM
       typhoeus (~> 0.7)
       yell (~> 2.0)
     htmlentities (4.3.4)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     jekyll (3.3.0)
       addressable (~> 2.4)
@@ -82,8 +89,12 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
     method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.1)
+    netrc (0.11.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     parallel (1.9.0)
@@ -98,21 +109,30 @@ GEM
       ffi (>= 0.5.0)
     rb-readline (0.5.3)
     redcarpet (3.3.4)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     slop (3.6.0)
+    thor (0.19.4)
     thread_safe (0.3.5)
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     yell (2.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  accesslint-ci
   html-proofer
   jekyll (~> 3.1)
   jekyll-archives!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    accesslint-ci (0.2.4)
+    accesslint-ci (0.2.6)
       rest-client (~> 2.0)
       thor (~> 0.19)
     activesupport (4.2.7.1)
@@ -132,7 +132,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  accesslint-ci
+  accesslint-ci (= 0.2.6)
   html-proofer
   jekyll (~> 3.1)
   jekyll-archives!

--- a/_config-blog.yml
+++ b/_config-blog.yml
@@ -19,12 +19,14 @@ exclude:
 - feed*
 - Gemfile*
 - humans.txt
+- node_modules
 - package.json
 - robots.txt
 - search-index*
 - serve
 - sitemap.xml
 - system-security-plan.yml
+- vendor
 - _posts/2014-03-12-coming-soon.md
 - _posts/2014-03-19-hello-world-we-are-18f.md
 - _posts/2014-03-21-29-minutes.md

--- a/circle.yml
+++ b/circle.yml
@@ -1,23 +1,25 @@
+general:
+  artifacts:
+    - "tmp"
+
 machine:
   ruby:
     version:
       2.3.1
+  node:
+    version: 6.1.0
 
 dependencies:
   pre:
+    - gem install bundler
     - bundle install
-    - bundle exec jekyll build
-    # uncomment to restore pa11y-ci
-    # - nvm install stable && nvm alias default stable
-    #
-    - npm test
-    # uncomment to restore pa11y-ci
-    # - npm install -g pa11y-ci
-    #
+    - npm install -g accesslint-cli
 
 test:
   pre:
-    - bundle exec jekyll test
+    - bundle exec jekyll serve --detach && bundle exec accesslint-ci scan http://localhost:4000
+  override:
+    # - bundle exec jekyll build
+    - npm run test
     - npm run htmlproofer
-    # uncomment to restore pa11y-ci
-    # - npm run --harmony lint-508
+

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ general:
     - "tmp"
 
 machine:
+  environment:
+    ACCESSLINT_MASTER_BRANCH: dev
   ruby:
     version:
       2.3.1
@@ -11,15 +13,11 @@ machine:
 
 dependencies:
   pre:
-    - gem install bundler
-    - bundle install
     - npm install -g accesslint-cli
 
 test:
-  pre:
-    - bundle exec jekyll serve --detach && bundle exec accesslint-ci scan http://localhost:4000
   override:
-    # - bundle exec jekyll build
     - npm run test
     - npm run htmlproofer
-
+  post:
+    - ./serve-accesslint && bundle exec accesslint-ci scan http://localhost:4000

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "homepage": "https://18f.gsa.gov",
   "devDependencies": {
     "pa11y-ci": "^0.3.0"
+  },
+  "dependencies": {
+    "accesslint-cli": "^1.1.1"
   }
 }

--- a/serve-accesslint
+++ b/serve-accesslint
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+LC_ALL="en_US.UTF-8" \
+bundle exec jekyll serve \
+  --detach \
+  --config="_config.yml,_config-blog.yml"


### PR DESCRIPTION
18F version of PR #2133, submitted by @ckundo 👏 

The CircleCI tokens mentioned have been added to the repo settings, so we should receive comments on this PR 🙏 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/serve-accesslint.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/serve-accesslint)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/serve-accesslint/)

/cc @ckundo, @gboone 

<hr />

### Cameron's notes from the PR:

> - Install accesslint-ci and accesslint-cli.
> - Update _config-blog.yml by running `ruby config_blog.rb`.
> - Define a `serve-accesslint` script.
> - Use config-blog.yml to only serve the 3 most recent posts.
> - Compare errors with the most recent successful build of `dev` branch.
>
> AccessLint will fail unless you set these ENV variables (in your [Circle CI project settings](https://circleci.com/gh/18F/18f.gsa.gov/edit#env-vars)):
> 
> ```
> ACCESSLINT_API_TOKEN: <API token from https://accesslint.com>
> ACCESSLINT_GITHUB_USER: <GitHub user authenticated at https://accesslint.com>
> ```
> 
> /cc @gemfarmer 
> 
> Opening this PR instead of #2132, to try and address upstream commenting (see https://github.com/accesslint/accesslint-ci/issues/36)


