### PR TITLE
Removed anti-aliasing from body

### DIFF
--- a/_sass/_components/layout.scss
+++ b/_sass/_components/layout.scss
@@ -37,6 +37,7 @@
 .background-dark {
   background-color: $color-dark;
   color: $color-white;
+  -webkit-font-smoothing: antialiased;
 
   h1,
   h2,

--- a/_sass/_core/typography.scss
+++ b/_sass/_core/typography.scss
@@ -4,7 +4,6 @@
 body {
   overflow-x: hidden;
   font-size: $base-font-size;
-  -webkit-font-smoothing: antialiased;
 }
 
 html, body, div, span, applet, object, iframe,
@@ -18,7 +17,6 @@ fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed,
 figure, figcaption, footer, header, section {
-  -webkit-font-smoothing: antialiased;
 }
 
 


### PR DESCRIPTION
Fixes issue(s) #2084 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/anti-anti-aliasing.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/anti-anti-aliasing)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/anti-anti-aliasing/)

Changes proposed in this pull request:
- Removed `antialiased` from body
- Added `antialiased` to `.background-dark` 

/cc @maya @coreycaitlin 
