### PR TITLE
Blog spot-fixes for markdown

### DIFF
--- a/_posts/2016-03-29-best-practices-for-building-an-accessible-website-using-the-draft-us-web-design-standards.md
+++ b/_posts/2016-03-29-best-practices-for-building-an-accessible-website-using-the-draft-us-web-design-standards.md
@@ -77,7 +77,7 @@ user experience. We recommend using a screen reader and an accessibility
 API inspector tool such as Microsoft’s Inspect tool, available in the
 Windows SDK, or Mac OS X's built-in screen reader, VoiceOver.
 
-##Developed with WCAG 2.0 AA in mind
+## Developed with WCAG 2.0 AA in mind
 
 We developed the Draft Standards with [WCAG 2.0
 AA](https://www.w3.org/WAI/WCAG20/quickref/) in mind. The upcoming

--- a/_posts/2016-04-06-take-our-code-18f-projects-you-can-reuse.md
+++ b/_posts/2016-04-06-take-our-code-18f-projects-you-can-reuse.md
@@ -6,14 +6,7 @@ authors:
 tags:
 - tools you can use
 - open source
-excerpt: "We encourage you to adapt 18F open source projects for your work and
-personal purposes, whether you’re a fellow federal employee or outside
-government. We’ve put together a list of some 18F repositories that
-might be especially useful to you."
-description: "We encourage you to adapt 18F open source projects for your work and
-personal purposes, whether you’re a fellow federal employee or outside
-government. We’ve put together a list of some 18F repositories that
-might be especially useful to you."
+excerpt: "We encourage you to adapt 18F open source projects for your work and personal purposes, whether you’re a fellow federal employee or outside government. We’ve put together a list of some 18F repositories that might be especially useful to you."
 image:
 ---
 
@@ -136,7 +129,7 @@ resolution](https://github.com/18F/18f.gsa.gov/issues/1445).
 
 -   [**jekyll\_pages\_api\_search**](https://github.com/18F/jekyll_pages_api_search): Add search to your site, no server required.
 
-##If you use [Cloud Foundry](https://www.cloudfoundry.org/)
+## If you use [Cloud Foundry](https://www.cloudfoundry.org/)
 
 -   [**BOSH Release for New Relic server monitor**](https://github.com/cloudfoundry-community/newrelic-boshrelease): Set up New Relic to monitor your Cloud Foundry deployment ([more about BOSH](https://bosh.io/docs/about.html)).
 

--- a/_posts/2016-05-03-delivering-the-next-generation-of-digital-government.md
+++ b/_posts/2016-05-03-delivering-the-next-generation-of-digital-government.md
@@ -5,14 +5,8 @@ authors:
 - deniseroth
 tags:
 - gsa
-excerpt: "Today we take another step forward helping government develop the
-technology that the public and taxpayers deserve. I'm pleased to
-announce the creation of GSA's third service, the Technology
-Transformation Service."
-description: "Today we take another step forward helping government develop the
-technology that the public and taxpayers deserve. I'm pleased to
-announce the creation of GSA's third service, the Technology
-Transformation Service."
+- technology transformation service
+excerpt: "Today we take another step forward helping government develop the technology that the public and taxpayers deserve. I'm pleased to announce the creation of GSA's third service, the Technology Transformation Service."
 image:
 ---
 

--- a/_posts/2016-05-06-the-day-90-kids-came-to-code-with-18f.md
+++ b/_posts/2016-05-06-the-day-90-kids-came-to-code-with-18f.md
@@ -44,7 +44,7 @@ together.
 
 The two girls later wrote this note:
 
-![A hand-written note that says: Codeing is fun, but also tricky but we did our best]({{site.baserul}}/assets/blog/kids-to-work-day/kids-to-work-note.jpg)
+![A hand-written note that says: Codeing is fun, but also tricky but we did our best]({{site.baseurl}}/assets/blog/kids-to-work-day/kids-to-work-note.jpg)
 
 “Codeing [sic] is fun, but also tricky but we did our best.”
 

--- a/_posts/2016-05-10-gsa-invests-in-18fs-work-with-new-service.md
+++ b/_posts/2016-05-10-gsa-invests-in-18fs-work-with-new-service.md
@@ -6,6 +6,7 @@ authors:
 tags:
 - gsa
 - 18f
+- technology transformation service
 excerpt: "The GSA has created the Technology Transformation Service as a third pillar of services for federal agencies alongside the Public Buildings Service and Federal Acquisition Service."
 description: "The GSA has created the Technology Transformation Service as a third pillar of services for federal agencies alongside the Public Buildings Service and Federal Acquisition Service."
 image: /assets/blog/join-us/18F-IRL-2016.jpg

--- a/_posts/2016-05-23-a-sestina-on-sunsetting-content.md
+++ b/_posts/2016-05-23-a-sestina-on-sunsetting-content.md
@@ -1,5 +1,5 @@
 ---
-title: " A sestina on sunsetting content"
+title: "A sestina on sunsetting content"
 date: 2016-05-23
 authors:
 - emileigh

--- a/_posts/2016-07-13-technology-transformation-services-looking-for-new-commissioner.md
+++ b/_posts/2016-07-13-technology-transformation-services-looking-for-new-commissioner.md
@@ -6,6 +6,7 @@ authors:
 tags:
 - gsa
 - hiring
+- technology transformation service
 excerpt: "Now’s the time to get involved in transforming how the
 government builds, buys, and shares technology. Now’s the time to lead a
 growing office of talented and motivated people looking to help federal

--- a/_posts/2016-07-14-elaine-kamlley-a-developer-commited-diversity.md
+++ b/_posts/2016-07-14-elaine-kamlley-a-developer-commited-diversity.md
@@ -12,20 +12,14 @@ description: "All throughout the summer, we’ll be profiling members
 across the 18F team. We’re starting with Elaine Kamlley, who is both a
 front-end developer and a member of our Outreach Team*.*"
 image: /assets/img/team/elaine.jpg
+hero: false
 ---
 <figure class="align-right">
 	<img src="{{site.baseurl}}{{page.image}}" alt="Profile photo for Elaine Kamlley.">
 	<figcaption class="align-center">Elaine Kamlley, 18F team member</figcaption>
 </figure>
 
-*Over the next few months, we’ll be profiling members across the 18F
-team. We’re starting with Elaine Kamlley, who joined 18F in November of
-2014. Elaine is both a front-end developer and a member of our Outreach
-Team. Elaine also leads an internal diversity initiative that is
-currently conducting interviews inside and outside of 18F. In this
-interview, we talk to Elaine about pathways to 18F, how technology can
-help communities, and what it was like to work with the Department of
-the Treasury on a DATA Act prototype.*
+*Over the next few months, we’ll be profiling members across the 18F team. We’re starting with Elaine Kamlley, who joined 18F in November of 2014. Elaine is both a front-end developer and a member of our Outreach Team. Elaine also leads an internal diversity initiative that is currently conducting interviews inside and outside of 18F. In this interview, we talk to Elaine about pathways to 18F, how technology can help communities, and what it was like to work with the Department of the Treasury on a DATA Act prototype.*
 
 **Melody Kramer: Last summer, 20 teenagers from the State Department’s**
 [**TechGirls exchange


### PR DESCRIPTION
Follow-up to blockquote fixes — this is the result of my spot-checking the last year or so of blog posts for markdown issues.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/blog-fixes.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/blog-fixes)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/blog-fixes/)

/cc @gemfarmer 
