### PR TITLE
Adds codeclimate monitor

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+engines:
+  rubocop:
+    enabled: true
+  eslint:
+    enabled: true
+  scss-lint:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+  - "**.js"
+  - "_sass/**/*"
+exclude_paths:
+- "lib/tasks/**"
+- _sass/_libs/**/*
+- _sass/_core/syntax-highlighting.scss
+- assets/js/lib/**/*
+- bin
+- node_modules
+- .bundle
+- .sass-cache

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,16 +4,16 @@ env:
 extends: eslint:recommended
 
 rules:
-  brace-style: [warn, 1tbs]
-  curly: [warn, multi-line]
-  eqeqeq: warn
-  func-call-spacing: warn
-  linebreak-style: [warn, unix]
-  max-len: [warn, {code: 80}]
-  new-parens: warn
-  no-undef-init: warn
-  no-unused-expressions: warn
-  no-whitespace-before-property: warn
-  space-before-blocks: warn
-  space-before-function-paren: [warn, never]
-  spaced-comment: warn
+  brace-style: [1, "1tbs"]
+  curly: [1, "multi-line"]
+  eqeqeq: 1
+  func-call-spacing: 1
+  linebreak-style: [1, "unix"]
+  max-len: [1, 80]
+  new-parens: 1
+  no-undef-init: 1
+  no-unused-expressions: 1
+  no-whitespace-before-property: 1
+  space-before-blocks: 1
+  space-before-function-paren: [1, "never"]
+  spaced-comment: 1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Climate](https://codeclimate.com/github/18F/micropurchase/badges/gpa.svg)](https://codeclimate.com/github/18F/18f.gsa.gov)
+
 # 18F’s flagship website
 
 This repo houses the 18F website. We use the [Draft U.S. Web Design standards](https://standards.usa.gov/) as a front end framework. The site is built and served through [the Federalist platform](https://federalist.18f.gov).


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/codeclimate.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/codeclimate)

Changes proposed in this pull request:
- adds a badge to the README that tracks the code climate for this repo
- adds a .codeclimate.yml` configuration file so that codeclimate works on this repo
- updates the `eslintrc.yml` file to include current syntax

This doesn't need to be in the README (in my opinion), but to run codeclimate locally, you need to install Docker, Docker Machine, and run the [codeclimate CLI](https://github.com/codeclimate/codeclimate#prerequisites) through a docker image. The `analyze` command is [where the magic happens](https://github.com/codeclimate/codeclimate#usage):

```bash
docker run \                                                
  --interactive --tty --rm \
  --env CODECLIMATE_CODE="$PWD" \
  --volume "$PWD":/code \
  --volume /var/run/docker.sock:/var/run/docker.sock \
  --volume /tmp/cc:/tmp/cc \
  codeclimate/codeclimate analyze
```

/cc @gboone 


