### PR TITLE
New project intros and layout refinements

### DIFF
--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -14,8 +14,10 @@ header_border: true
       <div class="usa-grid">
         <div class="hero-callout hero-callout-no_button background-dark">
           <h1 class="hero-callout-title">
-            {{ page.project-type }}:<br>
-            {{ page.title }}
+            {{ page.agency }}: <br>
+            <span class="hero-callout-alt_color">
+              {{ page.title }}
+            </span>
           </h1>
         </div>
       </div>

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -9,12 +9,14 @@ header_border: true
 
   {% if page.image %}
     <section class="hero"
-             style="background-image: url({{ site.baseurl }}{{ page.image }});"
-             aria-label="{{ page.image_accessibility }}">
+        style="background-image: url({{ site.baseurl }}{{ page.image }});"
+        aria-label="{{ page.image_accessibility }}">
       <div class="usa-grid">
         <div class="hero-callout hero-callout-no_button background-dark">
-          <h1 class="h3 hero-callout-title">{{ page.project-type }}:<br>
-          {{ page.title }}</h1>
+          <h1 class="hero-callout-title">
+            {{ page.project-type }}:<br>
+            {{ page.title }}
+          </h1>
         </div>
       </div>
     </section>

--- a/_posts/2016-07-06-illinois-fourth-grade-class-uses-every-kid-in-a-park-to-explore.md
+++ b/_posts/2016-07-06-illinois-fourth-grade-class-uses-every-kid-in-a-park-to-explore.md
@@ -6,125 +6,56 @@ authors:
 tags:
 - every kid in a park
 - agency work
-excerpt: "One fourth grade class in Monticello, Illinois used the Every
-Kid in the Park website to learn more about National Parks and create a
-culminating project for their school’s annual open house."
-description: "One fourth grade class in Monticello, Illinois used the
-Every Kid in the Park website to learn more about National Parks and
-create a culminating project for their school’s annual open house."
+excerpt: "One fourth grade class in Monticello, Illinois used the Every Kid in the Park website to learn more about National Parks and create a project for their school’s annual open house. We reached out to Washington Elementary fourth grade teacher Robyn Garrett to learn more about how she used national parks in her curriculum."
 image: /assets/blog/every-kid-in-a-park/nps-stamps.jpg
 ---
 
-Last year, we worked with the Department of the Interior to launch the
-website for [Every Kid in a Park](https://everykidinapark.gov/), a
-program that gives U.S. fourth graders free access to all federal lands
-and waters — including national parks, forests, wildlife refuges, and
-marine sanctuaries — for a full year. (They can also bring their
-families with them for free.)
+Last year, we worked with the Department of the Interior to launch the website for [Every Kid in a Park](https://everykidinapark.gov/), a program that gives U.S. fourth graders free access to all federal lands and waters — including national parks, forests, wildlife refuges, and marine sanctuaries — for a full year. (They can also bring their families with them for free.)
 
-The website [everykidinapark.gov](https://everykidinapark.gov/) was
-designed, developed, and written for 10-year-olds. The site includes a
-comprehensive list of sites, explains how the program works, and shows
-how to print a pass.
+The website [everykidinapark.gov](https://everykidinapark.gov/) was designed, developed, and written for 10-year-olds. The site includes a comprehensive list of sites, explains how the program works, and shows how to print a pass.
 
-One fourth grade class in Monticello, Illinois took the Every Kid in the
-Park idea even further. They used the website to learn more about
-National Parks and create a culminating project for their school’s
-annual open house.
+One fourth grade class in Monticello, Illinois took the Every Kid in the Park idea even further. They used the website to learn more about National Parks and create a culminating project for their school’s annual open house.
 
-We reached out to Washington Elementary fourth grade teacher Robyn
-Garrett, who led the project, to learn more about how she used national
-parks and [Every Kid in a
-Park](https://18f.gsa.gov/tags/every-kid-in-a-park/) in her curriculum.
+We reached out to Washington Elementary fourth grade teacher Robyn Garrett, who led the project, to learn more about how she used national parks and [Every Kid in a Park](https://18f.gsa.gov/tags/every-kid-in-a-park/) in her curriculum.
 
-**Melody Kramer: Robyn, tell me a little bit about the end of the year
-project you created with your class.**
+**Melody Kramer: Robyn, tell me a little bit about the end of the year project you created with your class.**
 
-**Robyn Garrett:** Each year, I create a culminating project for our
-school’s end-of-the-year open house. The goal is to make history real to
-our fourth graders and to let them know it is still all around them.
+**Robyn Garrett:** Each year, I create a culminating project for our school’s end-of-the-year open house. The goal is to make history real to our fourth graders and to let them know it is still all around them.
 
-This year we utilized the [National Park Service
-website](https://www.nps.gov/index.htm) and [Every Kid In a
-Park](https://everykidinapark.gov/). We used the sites to research and
-connect our study of early American history and the impact our geography
-had on the decisions made by Native Americans and Early settlers.
+This year we utilized the [National Park Service website](https://www.nps.gov/index.htm) and [Every Kid In a Park](https://everykidinapark.gov/). We used the sites to research and connect our study of early American history and the impact our geography had on the decisions made by Native Americans and Early settlers.
 
-Each student selected a state at the beginning of the year to build a
-background for their final projects. The final project required them to
-build a structure to be created depicting a National Monument in their
-chosen state. The monument needed to include four lights wired to a
-switch to fulfill their science component. They had to write a paper
-that explained the historical significance of the monument, which
-fulfilled their writing component. Finally, they each had to give an
-oral presentation on their monument to the class, which helped with
-their speaking and listening skills.
+Each student selected a state at the beginning of the year to build a background for their final projects. The final project required them to build a structure to be created depicting a National Monument in their chosen state. The monument needed to include four lights wired to a switch to fulfill their science component. They had to write a paper that explained the historical significance of the monument, which fulfilled their writing component. Finally, they each had to give an oral presentation on their monument to the class, which helped with their speaking and listening skills.
 
 These projects were then displayed for our open house.
 
 ![Models of the Statue of Liberty and other national parks created by the fourth grade students.]({{ site.baseurl }}/assets/blog/every-kid-in-a-park/nps-models.jpg)
 
-*Monuments from National Park Service sites that were created by fourth graders
-in Monticello, IL.*
+*Monuments from National Park Service sites that were created by fourth graders in Monticello, IL.*
 
-**MK: Could you share what students researched and learned for their
-presentations?**
+**MK: Could you share what students researched and learned for their presentations?**
 
-**RG:** In addition to researching a specific monument, each student
-also selected a National Park to research. They reported on the
-location, when the park was formed, and who the president was who
-designated it. The significance of the park was researched and written
-into a “commercial” with three slides of pictures of their selected
-park. These then played during our open house.
+**RG:** In addition to researching a specific monument, each student also selected a National Park to research. They reported on the location, when the park was formed, and who the president was who designated it. The significance of the park was researched and written into a “commercial” with three slides of pictures of their selected park. These then played during our open house.
 
-Lastly, students used the internet to find the distance from Monticello,
-IL to the National Park they researched. This information was recorded
-in miles and driving time on the large map marking each park we
-researched.
+Lastly, students used the internet to find the distance from Monticello, IL to the National Park they researched. This information was recorded in miles and driving time on the large map marking each park we researched.
 
-The students were amazed by the size of the protected land and the
-beautiful sites. We watched bits and pieces of the PBS program on the
-National Parks, which endeared them to President Theodore Roosevelt,
-President Franklin Roosevelt, and John Muir. In turn, they found pages
-of quotes on the websites which we included on another wall of the gym.
+The students were amazed by the size of the protected land and the beautiful sites. We watched bits and pieces of the PBS program on the National Parks, which endeared them to President Theodore Roosevelt, President Franklin Roosevelt, and John Muir. In turn, they found pages of quotes on the websites which we included on another wall of the gym.
 
 ![Stamps for Glacier, Glacier Bay, Canyonlands, and other national parks drawn and colored by the fourth graders.]({{ site.baseurl }}/assets/blog/every-kid-in-a-park/nps-stamps.jpg)
 
-*Students made stamps for their National Park, which hung in the school
-gymnasium.*
+*Students made stamps for their National Park, which hung in the school gymnasium.*
 
 **MK: Did you use any lessons from the Every Kid in a Park website?**
 
-**RG:** We used the first three lessons (on [exploring federal lands
-and
-water](https://s3.amazonaws.com/ekip-prod/activities/scholastic-one.pdf),
-[environmental
-stewardship](https://s3.amazonaws.com/ekip-prod/activities/scholastic-two.pdf),
-and [our nation’s Native
-people](https://s3.amazonaws.com/ekip-prod/activities/scholastic-three.pdf))
-from Every Kid in a Park’s educator section.
+**RG:** We used the first three lessons (on [exploring federal lands and water](https://s3.amazonaws.com/ekip-prod/activities/scholastic-one.pdf), [environmental stewardship](https://s3.amazonaws.com/ekip-prod/activities/scholastic-two.pdf), and [our nation’s Native people](https://s3.amazonaws.com/ekip-prod/activities/scholastic-three.pdf)) from Every Kid in a Park’s educator section.
 
-The most impactful was the lesson on stewardship. We went on a field
-trip to the local 4-H camp and our lunch discussion was about how being
-good stewards of the land could make a difference right here and now.
-That is what every teacher strives for — students connecting the
-classroom to the world around them. Students reflected on parks they had
-visited and many that they hope to visit. I believe this program had a
-huge impact on my students.
+The most impactful was the lesson on stewardship. We went on a field trip to the local 4-H camp and our lunch discussion was about how being good stewards of the land could make a difference right here and now. That is what every teacher strives for — students connecting the classroom to the world around them. Students reflected on parks they had visited and many that they hope to visit. I believe this program had a huge impact on my students.
 
 **MK: Do you have a favorite park to visit?**
 
-**RG:** My favorite National Park is Canyon de Chelly. It is stunning
-and has a rich history that is difficult to understand unless shared by
-the people who live there. I was blessed to have had wonderful Navajo
-guides during my visits.
+**RG:** My favorite National Park is Canyon de Chelly. It is stunning and has a rich history that is difficult to understand unless shared by the people who live there. I was blessed to have had wonderful Navajo guides during my visits.
 
 **MK: Is there anything else you want to add?**
 
-**RG:** I will continue to incorporate these lessons into our studies.
-It is vital that our children understand the blessings of this great
-country and are impassioned to protect them.
+**RG:** I will continue to incorporate these lessons into our studies. It is vital that our children understand the blessings of this great country and are impassioned to protect them.
 
-The Every Kid in a Park initiative planted a seed with these students
-and their families. Thank you for making it such a positive part of my
-instruction.
+The Every Kid in a Park initiative planted a seed with these students and their families. Thank you for making it such a positive part of my instruction.

--- a/_projects/doi-every-kid-in-a-park.md
+++ b/_projects/doi-every-kid-in-a-park.md
@@ -1,6 +1,5 @@
 ---
 layout: project-tag-results
-project-type: "Project"
 agency: "Department of the Interior"
 title: "Every Kid in a Park"
 subtitle: Designing for every user

--- a/_projects/doi-every-kid-in-a-park.md
+++ b/_projects/doi-every-kid-in-a-park.md
@@ -1,0 +1,27 @@
+---
+layout: project-tag-results
+project-type: "Project"
+agency: "Department of the Interior"
+title: "Every Kid in a Park"
+subtitle: Designing for every user
+excerpt: We helped the Department of the Interior reach fourth graders and help kids discover public lands.
+image: /assets/blog/every-kid-in-a-park/glacier-park.jpg
+image_accessibility: "Photograph of a group of children wearing orange shirts at a national park"
+tags:
+- every kid in a park
+expiration_date:
+github_repo: https://github.com/18F/ekip-api
+project_url: https://www.everykidinapark.gov
+---
+
+Today, more than 80 percent of American families live in urban areas, and many lack easy access to outdoor spaces. The Department of the Interior created the Every Kid in a Park program to make it easier for fourth graders to discover public lands — but they needed a way for the program to reach fourth graders.
+
+The challenge was designing a website that fourth graders would be able to use. How do you design a federal website for an audience that doesn’t know the word federal?
+
+### Building a federal website for 10-year-olds
+
+Before we got involved, the Department of the Interior had already held events to talk to fourth graders and test out ideas for the website, so they were on the right path toward understanding real users and prioritizing their needs.
+
+We took that research and turned it into concrete design decisions. Our content designer wrote everything at a fourth grade reading level, including the legal section, privacy policy, and even the section for parents and guardians (we found kids were especially interested in the “grown-ups” section). Our visual designers used bright colors and pictures with families playing in parks (adults liked night landscapes, but kids found them scary).
+
+These design decisions helped make the program a huge success. Since it launched in September 2015, more than a million visitors to the site have downloaded nearly two million passes. This site showed what you can accomplish when you relentlessly focus on the needs of users — even when those users are still learning how to tie their shoes.

--- a/_projects/ed-college-scorecard.md
+++ b/_projects/ed-college-scorecard.md
@@ -1,6 +1,5 @@
 ---
 layout: project-tag-results
-project-type: "Project"
 agency: "Department of Education"
 title: "College Scorecard"
 subtitle: Turning data into informed choices

--- a/_projects/ed-college-scorecard.md
+++ b/_projects/ed-college-scorecard.md
@@ -1,0 +1,34 @@
+---
+layout: project-tag-results
+project-type: "Project"
+agency: "Department of Education"
+title: "College Scorecard"
+subtitle: Turning data into informed choices
+excerpt: We worked with the Department of Education to bring together federal data from several agencies to help students assess colleges and universities.
+image: /assets/blog/college-scorecard/college-scorecard-3.jpg
+image_accessibility: "Grayscale photograph of eleven people meeting in small groups during a workshop"
+tags:
+- college scorecard
+expiration_date:
+github_repo: https://github.com/RTICWDT/college-scorecard
+project_url: https://collegescorecard.ed.gov/
+---
+
+Higher education may be the single most important investment students can make in their futures, but finding reliable information about affordability and value can be difficult. The Department of Education wanted to bring together data from several agencies to help students make informed choices about what school to attend.
+
+The Department of Education had worked with the [U.S. Digital Service](https://www.usds.gov/) and other agencies to gather the data, but they needed help getting it online and making it usable.
+
+### Interactive and open data is usable data
+
+Before we wrote any code, we started with research about how students, parents, and guidance counselors use data and how frustrating it is to find unreliable numbers. We used that research to create a cardboard prototype, then took that prototype to students to see if we were on the right track.
+
+Ultimately, we decided to build several tools that would help get the data to the public:
+
+-   An API (application program interface) to help journalists, nonprofits, and private organizations access previously unreleased data from thousands of institutions.
+-   An interactive website where students can browse data about affordability, graduation rates, and how much students earn after graduation.
+-   A data site that supports academics, journalists, and researchers who are exploring college outcomes.
+
+College Scorecard has become a go-to resource for students and provided the data for many other tools that guide students in their decision-making process — even Google has integrated the data into search results.
+
+The process of building College Scorecard also had a profound effect on the Department of Education: their in-house digital service team has extended these iterative development and user-centered design techniques to other projects.
+

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -1,8 +1,7 @@
 ---
 layout: project-tag-results
-project-type: "Partner"
 agency: "Federal Election Commission"
-title: "Federal Election Commission"
+title: "beta.fec.gov"
 subtitle: Making campaign data easier to use
 excerpt: We helped the FEC make it easier for journalists and members of the public to use their data.
 image: /assets/img/home/hero-fec.png

--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -1,7 +1,8 @@
 ---
 layout: project-tag-results
-project-type: "Project"
-title: "The Federal Election Commission"
+project-type: "Partner"
+agency: "Federal Election Commission"
+title: "Federal Election Commission"
 subtitle: Making campaign data easier to use
 excerpt: We helped the FEC make it easier for journalists and members of the public to use their data.
 image: /assets/img/home/hero-fec.png

--- a/_projects/hhs-states.md
+++ b/_projects/hhs-states.md
@@ -1,7 +1,7 @@
 ---
 layout: project-tag-results
-project-type: "Partner"
-title: "Health and Human Services"
+agency: "Health and Human Services"
+title: "State and local procurement"
 subtitle: Helping states update crucial systems
 excerpt: HHS hired 18F to help states implement current best practices and upgrade legacy systems.
 image: /assets/img/projects/hero_stateandlocal.png

--- a/_sass/_components/tag-index.scss
+++ b/_sass/_components/tag-index.scss
@@ -3,18 +3,12 @@
 
 .page-tag-results {
   .hero {
-    padding-bottom: $section-margins * 1.5;
-  }
-
-  .hero-callout {
-    max-width: 21rem;
-    padding-top: $paragraph-margins;
-    padding-bottom: $paragraph-margins;
-    padding-left: $paragraph-margins * 1.2;
+    padding: $section-margins $paragraph-margins;
   }
 
   .hero-callout-title {
-    line-height: 1.2;
+    font-size: $h2-font-size * 0.85;
+    max-width: 22rem;
   }
 
   .post-list {

--- a/_sass/_core/variables.scss
+++ b/_sass/_core/variables.scss
@@ -5,7 +5,7 @@ $h3-font-size:       2.4rem;
 $h5-font-size:       1.4rem;
 $h6-font-size:       1.2rem;
 
-$base-font-size:	   1.8rem;
+$base-font-size:	 1.8rem;
 
 $tiny-font-size:     1.2rem;
 

--- a/pages/how-we-work.md
+++ b/pages/how-we-work.md
@@ -5,15 +5,9 @@ layout: default-intro
 lead: We’ll work hand-in-hand with your team, use modern techniques, and talk with real users to build the right thing, not just any thing.
 ---
 
-We find our way through every project by putting the needs of the public first.
-We use [human-centered design, agile methodologies, and open source software](https://playbook.cio.gov/)
-to build world-class digital services for the American public. We’re committed
-to working in the open, building accessible products, and deploying early and
-often.
+We find our way through every project by putting the needs of the public first. We use [human-centered design, agile methodologies, and open source software](https://playbook.cio.gov/) to build world-class digital services for the American public. We’re committed to working in the open, building accessible products, and deploying early and often.
 
-See exactly how we put all of those principles into practice by reading
-through our guides. We’re public about the standards we use,
-and we publish any guidance we create for our staff.
+See exactly how we put all of those principles into practice by reading through our guides. We’re public about the standards we use, and we publish any guidance we create for our staff.
 
 ### Our guides
 

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -18,11 +18,11 @@ redirect_from: /consulting/
 If your agency’s project has a digital component, our team of software developers, visual designers, writers, and security experts can help you build it. We can help you:
 
 - Improve a challenging user process by reimagining a daunting task, as we did with the [U.S. Citizenship and Immigration Service](https://my.uscis.gov/) and their immigration and visa processes.
-- Build a new site and API to showcase and synthesize data from multiple sources, as we did with Department of Education's [College Scorecard](https://collegescorecard.ed.gov/).
+- Build a new site and API to showcase and synthesize data from multiple sources, as we did with Department of Education's [College Scorecard]({{ site.baseurl }}/project/ed-college-scorecard/).
 - Help you make your data more accessible with a user-friendly site and developer tools, as we did with the [Federal Election Commission]({{ site.baseurl }}/project/fec-gov/).
 - Build web-based tools to streamline internal agency processes, as we did with [Communicart](https://cap.18f.gov/) and [CALC](https://calc.gsa.gov/).
 - Scope a solution or collaborate on an idea in a way that empowers you to meet the needs of your users, as we did with the [Department of Labor’s Wage and Hour Division](https://18f.gsa.gov/2015/09/09/how-a-two-day-spring-moved-an-agency-twenty-years-forward/).
-- Do user research and discovery sprints to promote a new digital model that houses information, as we did with NASA and the National Oceanic and Atmospheric Administration’s Climate Discovery project.
+- Do user research and discovery sprints to promote a new digital model that houses information, as we did with NASA and the National Oceanic and Atmospheric Administration’s [Climate Discovery project](https://climate-data-user-study.18f.gov/).
 {% endmarkdown %}
   </div>
 </section>
@@ -32,18 +32,15 @@ If your agency’s project has a digital component, our team of software develop
     <img src="{{ site.baseurl }}/assets/img/home-icons/innovative-ways.svg" alt="">
   </div>
   <div class="usa-width-two-thirds">
-  {% markdown %}
+{% markdown %}
 ### Innovative ways to buy technology
 
-We believe federal IT acquisitions can be faster, cheaper, and produce
-better results. If your agency is developing a new request for quotation
-for IT services or is interested in innovative ways to buy technology,
-our team is excited to work with you. We can help you:
+We believe federal IT acquisitions can be faster, cheaper, and produce better results. If your agency is developing a new request for quotation for IT services or is interested in innovative ways to buy technology, our team is excited to work with you. We can help you:
 
 - Write agile, modular, and user-centered design into your request for quotations through our RFP Ghostwriting service, like we did with the [Department of Health and Human Services]({{ site.baseurl }}/project/hhs-states/).
 - Develop a marketplace to buy IT services using modern techniques, like we did with the [Agile Blanket Purchase Agreement](https://pages.18f.gov/ads-bpa/).
 - Buy small pieces of open source code to advance your projects, like we’re doing with our [micro-purchase platform](https://micropurchase.18f.gov/).
-  {% endmarkdown %}
+{% endmarkdown %}
   </div>
 </section>
 
@@ -52,19 +49,15 @@ our team is excited to work with you. We can help you:
     <img src="{{ site.baseurl }}/assets/img/home-icons/government.svg" alt="">
   </div>
   <div class="usa-width-two-thirds">
-  {% markdown %}
+{% markdown %}
 ### Platforms built for government
 
-Federal agencies face a unique set of technology problems. We’re
-building a suite of secure, scalable tools and platforms that any agency
-can use to solve these common problems. Our platforms are built with the
-needs of government addressed right at the beginning and are being
-actively improved to meet your needs. We can help you:
+Federal agencies face a unique set of technology problems. We’re building a suite of secure, scalable tools and platforms that any agency can use to solve these common problems. Our platforms are built with the needs of government addressed right at the beginning and are being actively improved to meet your needs. We can help you:
 
 - Host your applications in the cloud with our [cloud.gov platform](https://cloud.gov/).
 - Build customizable and easy-to-maintain static sites with the [Federalist platform](https://federalist.18f.gov/).
 - Release and manage your API with [api.data.gov](https://api.data.gov/).
-  {% endmarkdown %}
+{% endmarkdown %}
   </div>
 </section>
 
@@ -73,18 +66,16 @@ actively improved to meet your needs. We can help you:
     <img src="{{ site.baseurl }}/assets/img/home-icons/path.svg" alt="">
   </div>
   <div class="usa-width-two-thirds">
-  {% markdown %}
+{% markdown %}
 ### A path to becoming a digitally-powered organization
 
-We can embed a fully-dedicated 18F team within your agency to work
-hand-in-hand with you to increase your internal digital capacity, help
-you form new digital habits, and ultimately drive organizational culture change. We can help you:
+We can embed a fully-dedicated 18F team within your agency to work hand-in-hand with you to increase your internal digital capacity, help you form new digital habits, and ultimately drive organizational culture change. We can help you:
 
 - Attract, empower, and grow your own digital team.
 - Adopt a DevOps culture and begin a transition to the cloud.
 - Institute lean-agile practices, including agile acquisitions.
 - Establish a model to modernize your legacy systems.
-  {% endmarkdown %}
+{% endmarkdown %}
   </div>
 </section>
 
@@ -93,17 +84,14 @@ you form new digital habits, and ultimately drive organizational culture change.
     <img src="{{ site.baseurl }}/assets/img/home-icons/modern-techniques.svg" alt="">
   </div>
   <div class="usa-width-two-thirds">
-  {% markdown %}
+{% markdown %}
 ### Modern digital service techniques
 
-We can provide your team with the skills and knowledge they need to
-modernize your agency’s digital services. We’ve also built a number of
-knowledge-sharing and documentation tools for 18F’s own use that you can
-copy and use at your agency. We can help you:
+We can provide your team with the skills and knowledge they need to modernize your agency’s digital services. We’ve also built a number of knowledge-sharing and documentation tools for 18F’s own use that you can copy and use at your agency. We can help you:
 
 - Run a workshop on agile software development, like the [Lego workshop we did with the Small Business Administration](https://18f.gsa.gov/2015/08/31/how-playing-with-legos-taught-executives-agile/) or the longer one we did with the [Social Security Administration](https://18f.gsa.gov/2015/02/11/a-story-of-an-agile-workshop/).
 - Host a design studio, like we did with the [Department of the Interior](https://18f.gsa.gov/2014/09/25/design-studio-onrr/).
 - Create your own lightweight knowledge sharing platform based off 18F’s [Guides](https://pages.18f.gov/guides-template/) and [Pages](https://pages.18f.gov/) projects.
-  {% endmarkdown %}
+{% endmarkdown %}
   </div>
 </section>

--- a/tests/schema/_projects.yml
+++ b/tests/schema/_projects.yml
@@ -1,6 +1,9 @@
 ---
 layout: "String"
 title: "String"
+agency: "String"
+subtitle: "String"
+excerpt: "String"
 
 tags:
   type: Array
@@ -14,5 +17,5 @@ config:
   - ..
   - .
   - .DS_Store
-  optional: ['subtitle', 'excerpt', 'image', 'image_accessibility', 'expiration_date', 'github_repo']
+  optional: ['image', 'image_accessibility', 'expiration_date', 'github_repo']
 ---


### PR DESCRIPTION
Fixes issue(s) #2104 and #2105 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/new-project-intros.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/new-project-intros)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/new-project-intros/)

Changes proposed in this pull request:
- Add College Scorecard and EKIP project intros as markdown files
- Add `agency` attribute to project intro frontmatter
- Add links from `What we deliver` to College Scorecard — and, bonus!, to the Climate Discovery report
- Simplify and improve hero image style on project intro pages

/cc @awfrancisco @gemfarmer @austinhernandez 
