### PR TITLE
Tag fix

### DIFF
--- a/_posts/2017-01-17-life-changing-magic-writing-release-notes.md
+++ b/_posts/2017-01-17-life-changing-magic-writing-release-notes.md
@@ -5,8 +5,8 @@ authors:
 tags:
 - best practices
 - product
-- fec-gov
-excerpt: "A key part of agile development is constantly shipping new features. With so many changes happening to the product every two weeks, it can be hard to keep track of how the product is growing and improving. Release notes help keep everyone on the team in the know about what’s shipping, give a clear list of features to check, and help always frame our work in terms of the value it delivers to users."
+- fec.gov
+excerpt: "A key part of agile development is constantly shipping new features. With so many changes happening to the product, it can be hard to keep track of how the product is growing and improving. Release notes help keep everyone on the team in the know about what’s shipping, give a clear list of features to check, and help always frame our work in terms of the value it delivers to users."
 ---
 A key part of agile development is constantly shipping new features. The
 team behind the Federal Election Commission’s (FEC) beta website ships


### PR DESCRIPTION
This corrects the `fec.gov` tag so this post will show up on the right project page.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/fec-tag-fix.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/fec-tag-fix)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/fec-tag-fix/)

/cc @awfrancisco 
