### PR TITLE
Remove version number

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,9 +12,6 @@ feature_image: /assets/img/feature-background.jpg
 tag_dir: tags
 github_repo: https://github.com/18F/18f.gsa.gov/blob/master
 
-# app version number
-version: v1.1.0
-
 analytics:
   google:
     code: 'UA-48605964-1' # Change this to your GSA analytics code


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/removes-version.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/removes-version)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/removes-version/)

Changes proposed in this pull request:
- Removes the version number in the `_config.yml` so that we no longer confuse people with the wrong version

/cc @coreycaitlin 
