### PR TITLE
Deprecate authors fields

### DIFF
--- a/_authors/18F.md
+++ b/_authors/18F.md
@@ -3,11 +3,6 @@ name: 18F
 first_name: 18F
 last_name: 
 full_name: 18F
-role: Organization
-city: 
-state: 
-github: 18F
-twitter: 18F
 redirect_from: "/team/18F/"
 published: true
 ---

--- a/_authors/aaron.md
+++ b/_authors/aaron.md
@@ -3,11 +3,6 @@ name: aaron
 first_name: Aaron
 last_name: Snow
 full_name: Aaron Snow
-role: Executive Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/aaron/"
 alumni: true
 published: true

--- a/_authors/ada-lovelace.md
+++ b/_authors/ada-lovelace.md
@@ -3,9 +3,6 @@ first_name: Ada
 last_name: Lovelace
 full_name: Ada Lovelace
 name: ada-lovelace
-role: Developer
-city: London
-state: UK
 april-fools: 2016
 tags: april fools 2016
 redirect_to: "/april-fools/2016/"

--- a/_authors/adam-kendall.md
+++ b/_authors/adam-kendall.md
@@ -1,13 +1,8 @@
 ---
-city: Salem
 first_name: Adam
 full_name: Adam Kendall
-github: LinuxBozo
 last_name: Kendall
 name: adam-kendall
-role: 
-state: VA
-twitter: 
 redirect_from: "/team/adam-kendall/"
 published: false
 ---

--- a/_authors/adrian-webb.md
+++ b/_authors/adrian-webb.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Adrian
 full_name: Adrian Webb
-github: 
 last_name: Webb
 name: adrian-webb
-role: Technical Architect
-state: D.C.
-twitter: 
 redirect_from: "/team/adrian-webb/"
 published: false
 ---

--- a/_authors/afeld.md
+++ b/_authors/afeld.md
@@ -3,11 +3,6 @@ name: afeld
 first_name: Aidan
 last_name: Feldman
 full_name: Aidan Feldman
-role: Developer
-city: New York City
-state: NY
-github: 
-twitter: 
 redirect_from: "/team/afeld/"
 published: true
 ---

--- a/_authors/alan-atlas.md
+++ b/_authors/alan-atlas.md
@@ -1,13 +1,8 @@
 ---
-city: Seattle
 first_name: Alan
 full_name: Alan Atlas
-github: 
 last_name: Atlas
 name: alan-atlas
-role: 
-state: WA
-twitter: 
 redirect_from: "/team/alan-atlas/"
 published: true
 ---

--- a/_authors/alan-brouilette.md
+++ b/_authors/alan-brouilette.md
@@ -1,13 +1,8 @@
 ---
-city: Chicago
 first_name: Alan
 full_name: Alan Brouilette
-github: 
 last_name: Brouilette
 name: alan-brouilette
-role: Product Manager
-state: IL
-twitter: 
 redirect_from: "/team/alan-brouilette/"
 published: true
 ---

--- a/_authors/alan-turing.md
+++ b/_authors/alan-turing.md
@@ -3,9 +3,6 @@ first_name: Alan
 last_name: Turing
 full_name: Alan Turing
 name: alan-turing
-role: Testing Lead
-city: Bletchley Park
-state: UK
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/alan.md
+++ b/_authors/alan.md
@@ -3,11 +3,6 @@ name: alan
 first_name: Alan
 last_name: DeLevie
 full_name: Alan deLevie
-role: Acquisition Management Consultant
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/alan/"
 published: true
 ---

--- a/_authors/alex-bisker.md
+++ b/_authors/alex-bisker.md
@@ -1,13 +1,8 @@
 ---
-city: New York
 first_name: Alex
 full_name: Alex Bisker
-github: 
 last_name: Bisker
 name: alex-bisker
-role: 
-state: New York
-twitter: 
 redirect_from: "/team/alex-bisker/"
 published: true
 ---

--- a/_authors/alex-pandel.md
+++ b/_authors/alex-pandel.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Alex
 full_name: Alex Pandel
-github: 
 last_name: Pandel
 name: alex-pandel
-role: 
-state: CA
-twitter: 
 redirect_from: "/team/alex-pandel/"
 published: false
 ---

--- a/_authors/alexander-hamilton.md
+++ b/_authors/alexander-hamilton.md
@@ -3,9 +3,6 @@ first_name: Alexander
 last_name: Hamilton
 full_name: Alexander Hamilton
 name: alexander-hamilton
-role: Product Lead
-city: New York
-state: NY
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/alison.md
+++ b/_authors/alison.md
@@ -3,11 +3,6 @@ name: alison
 first_name: Alison
 last_name: Rowland
 full_name: Alison Rowland
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/alla.md
+++ b/_authors/alla.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Alla
 full_name: Alla Goldman Seiffert
-github: allalala
 last_name: Seiffert
 name: alla
-role: Deputy for Acquisition
-state: DC
-twitter: 
 redirect_from: "/team/alla/"
 published: true
 ---

--- a/_authors/amanda-robinson.md
+++ b/_authors/amanda-robinson.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Amanda
 full_name: Amanda Robinson
-github: ertzeid
 last_name: Robinson
 name: amanda-robinson
-role: Developer
-state: DC
-twitter: aertzeid
 redirect_from: "/team/amanda-robinson/"
 published: false
 ---

--- a/_authors/amanda-schonfeld.md
+++ b/_authors/amanda-schonfeld.md
@@ -1,13 +1,8 @@
 ---
-city: Chicago
 first_name: Amanda
 full_name: Amanda Schonfeld
-github: 
 last_name: Schonfeld
 name: amanda-schonfeld
-role: 
-state: IL
-twitter: 
 redirect_from: "/team/amanda-schonfeld/"
 published: false
 ---

--- a/_authors/amber.md
+++ b/_authors/amber.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Amber
 full_name: Amber Reed
-github: 
 last_name: Reed
 name: amber
-role: 
-state: 
-twitter: 
 redirect_from: "/team/amber/"
 published: false
 ---

--- a/_authors/amos.md
+++ b/_authors/amos.md
@@ -3,11 +3,6 @@ name: amos
 first_name: Amos
 last_name: Stone
 full_name: J. Amos Stone
-role: Developer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/amos/"
 published: true
 ---

--- a/_authors/amy-wilson.md
+++ b/_authors/amy-wilson.md
@@ -1,13 +1,8 @@
 ---
 name: amy-wilson
-city: 
 first_name: Amy
 full_name: Amy Wilson
-github: 
 last_name: Wilson
-role: 
-state: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/andre.md
+++ b/_authors/andre.md
@@ -3,11 +3,6 @@ name: andre
 first_name: Andre
 last_name: Francisco
 full_name: Andre Francisco
-role: Content Designer
-city: Washington
-state: D.C.
-github: awfrancisco
-twitter: andrefrancisco
 project:
 - 18F Blog
 - 18f.gsa.gov

--- a/_authors/andrew.md
+++ b/_authors/andrew.md
@@ -3,11 +3,6 @@ name: andrew
 first_name: Andrew
 last_name: Stroup
 full_name: Andrew Stroup
-role: Product and Technology Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/andrew/"
 published: false
 ---

--- a/_authors/andrewmaier.md
+++ b/_authors/andrewmaier.md
@@ -3,11 +3,6 @@ name: andrewmaier
 first_name: Andrew
 last_name: Maier
 full_name: Andrew Maier
-role: User Experience Designer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/andrewmaier/"
 published: true
 ---

--- a/_authors/andrewmcmahon.md
+++ b/_authors/andrewmcmahon.md
@@ -3,9 +3,6 @@ name: andrewmcmahon
 first_name: Andrew
 last_name: McMahon
 full_name: Andrew McMahon
-city: San Francisco
-state: CA
-role: 
 guest: true
 published: true
 ---

--- a/_authors/angela-colter.md
+++ b/_authors/angela-colter.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Angela
 full_name: Angela Colter
-github: 
 last_name: Colter
 name: angela-colter
-role: 
-state: 
-twitter: 
 redirect_from: "/team/angela-colter/"
 published: false
 ---

--- a/_authors/anna.md
+++ b/_authors/anna.md
@@ -3,11 +3,6 @@ name: anna
 full_name: Anna Heller Sebok
 first_name: Anna
 last_name: Sebok
-city: Washington
-state: DC
-role: Project Manager
-github: 
-twitter: 
 redirect_from: "/team/anna/"
 published: true
 ---

--- a/_authors/annalee.md
+++ b/_authors/annalee.md
@@ -3,11 +3,6 @@ name: annalee
 first_name: Annalee
 last_name: Flower Horne
 full_name: Annalee Flower Horne
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/annalee/"
 published: false
 ---

--- a/_authors/anthony-garvan.md
+++ b/_authors/anthony-garvan.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Tony
 full_name: Tony Garvan
-github: anthonygarvan
 last_name: Garvan
 name: anthony-garvan
-role: 
-state: 
-twitter: 
 redirect_from: "/team/anthony-garvan/"
 published: true
 ---

--- a/_authors/bateman.md
+++ b/_authors/bateman.md
@@ -3,11 +3,6 @@ name: bateman
 first_name: Patrick
 last_name: Bateman
 full_name: Patrick Bateman
-role: Operations Director
-city: Washington
-state: DC
-github: batemapf
-twitter: 
 redirect_from: "/team/bateman/"
 published: false
 ---

--- a/_authors/becky.md
+++ b/_authors/becky.md
@@ -3,11 +3,6 @@ name: becky
 first_name: Becky
 last_name: Sweger
 full_name: Becky Sweger
-role: Developer
-city: Easthampton
-state: MA
-github: 
-twitter: 
 email: rebecca.sweger@gsa.gov
 redirect_from: "/team/becky/"
 published: true

--- a/_authors/ben.md
+++ b/_authors/ben.md
@@ -3,11 +3,6 @@ name: ben
 first_name: Ben
 last_name: Willman
 full_name: Ben Willman
-role: Director of Strategy, Presidential Innovation Fellows
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/ben/"
 published: false
 ---

--- a/_authors/betsy-ross.md
+++ b/_authors/betsy-ross.md
@@ -3,9 +3,6 @@ first_name: Betsy
 last_name: Ross
 full_name: Betsy Ross
 name: betsy-ross
-role: Visual Designer
-city: Philadelphia
-state: PA
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/bill.md
+++ b/_authors/bill.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Bill
 full_name: Bill Rooney
-github: 
 last_name: Rooney
 name: bill
-role: 
-state: 
-twitter: 
 redirect_from: "/team/bill/"
 published: true
 ---

--- a/_authors/blacktm.md
+++ b/_authors/blacktm.md
@@ -3,11 +3,6 @@ name: blacktm
 first_name: Tom
 last_name: Black
 full_name: Tom Black
-role: Tech and Data Architecture Consultant
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/blacktm/"
 published: true
 ---

--- a/_authors/bob-ballance.md
+++ b/_authors/bob-ballance.md
@@ -3,11 +3,6 @@ name: bob-ballance
 first_name: Bob
 last_name: Ballance
 full_name: Bob Ballance
-role: 
-city: 
-state: 
-github: 
-twitter: 
 project: 
 redirect_from: 
 published: true

--- a/_authors/boone.md
+++ b/_authors/boone.md
@@ -3,11 +3,6 @@ name: boone
 first_name: Greg
 last_name: Boone
 full_name: Greg Boone
-role: Developer
-city: Denver
-state: CO
-github: gboone
-twitter: gboone42
 project:
 - 18f.gsa.gov
 - Dashboard

--- a/_authors/bradnunnally.md
+++ b/_authors/bradnunnally.md
@@ -3,11 +3,6 @@ name: bradnunnally
 first_name: Brad
 last_name: Nunnally
 full_name: Brad Nunnally
-role: User Experience
-city: St. Louis
-state: MO
-github: 
-twitter: 
 redirect_from: "/team/bradnunnally/"
 published: true
 ---

--- a/_authors/brandon.md
+++ b/_authors/brandon.md
@@ -1,13 +1,8 @@
 ---
-city: Atlanta
 first_name: Brandon
 full_name: Brandon Kirby
-github: brandocalrissian
 last_name: Kirby
 name: brandon
-role: Consultant
-state: GA
-twitter: 
 redirect_from: "/team/brandon/"
 published: false
 ---

--- a/_authors/brendan.md
+++ b/_authors/brendan.md
@@ -3,11 +3,6 @@ name: brendan
 first_name: Brendan
 last_name: Sudol
 full_name: Brendan Sudol
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/brendan/"
 published: true
 ---

--- a/_authors/bret.md
+++ b/_authors/bret.md
@@ -3,11 +3,6 @@ name: bret
 full_name: Bret Mogilefsky
 first_name: Bret
 last_name: Mogilefsky
-city: San Francisco
-state: CA
-role: Product Lead
-github: 
-twitter: 
 redirect_from: "/team/bret/"
 published: true
 ---

--- a/_authors/brethauer.md
+++ b/_authors/brethauer.md
@@ -3,11 +3,6 @@ name: brethauer
 first_name: Nick
 last_name: Brethauer
 full_name: Nick Brethauer
-role: User Experience Designer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/brethauer/"
 published: true
 ---

--- a/_authors/brian.md
+++ b/_authors/brian.md
@@ -1,13 +1,8 @@
 ---
-city: Minneapolis
 first_name: Brian
 full_name: Brian Hedberg
-github: gemfarmer
 last_name: Hedberg
 name: brian
-role: Developer
-state: MN
-twitter: 
 redirect_from: "/team/brian/"
 published: false
 ---

--- a/_authors/britta-gustafson.md
+++ b/_authors/britta-gustafson.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Britta
 full_name: Britta Gustafson
-github: brittag
 last_name: Gustafson
 name: britta-gustafson
-role: Content Designer
-state: CA
-twitter: ''
 redirect_from: "/team/britta-gustafson/"
 published: true
 ---

--- a/_authors/captain-america.md
+++ b/_authors/captain-america.md
@@ -3,9 +3,6 @@ first_name: Captain
 last_name: America
 full_name: Captain America
 name: captain-america
-role: Developer
-city: Washington
-state: DC
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/carlo-costino.md
+++ b/_authors/carlo-costino.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Carlo
 full_name: Carlo Costino
-github: 
 last_name: Costino
 name: carlo-costino
-role: Software engineer
-state: D.C.
-twitter: 
 redirect_from: "/team/carlo-costino/"
 published: false
 ---

--- a/_authors/carolyn.md
+++ b/_authors/carolyn.md
@@ -3,11 +3,6 @@ name: carolyn
 first_name: Carolyn
 last_name: Dew
 full_name: Carolyn Dew
-city: Atlanta
-state: GA
-role: User Experience Designer
-github: 
-twitter: 
 redirect_from: "/team/carolyn/"
 published: true
 ---

--- a/_authors/cat-langel.md
+++ b/_authors/cat-langel.md
@@ -3,11 +3,6 @@ name: cat-langel
 first_name: Cat
 last_name: Langel
 full_name: Cat Langel
-role: 
-city: 
-state: 
-github: 
-twitter: 
 url: http://www.gsa.gov/portal/staffDirectory/contact/176573
 alumni: true
 redirect_from: 

--- a/_authors/catherine.md
+++ b/_authors/catherine.md
@@ -3,11 +3,6 @@ name: catherine
 first_name: Catherine
 last_name: Devlin
 full_name: Catherine Devlin
-role: Developer
-city: Dayton
-state: Ohio
-github: catherinedevlin
-twitter: catherinedevlin
 redirect_from: "/team/catherine/"
 published: true
 ---

--- a/_authors/chrisc.md
+++ b/_authors/chrisc.md
@@ -3,11 +3,6 @@ name: chrisc
 first_name: Chris
 last_name: Cairns
 full_name: Chris Cairns
-role: Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/chrisc/"
 published: true
 ---

--- a/_authors/christine-cawthorne.md
+++ b/_authors/christine-cawthorne.md
@@ -3,11 +3,6 @@ name: christine-cawthorne
 first_name: Christine
 last_name: Cawthorne
 full_name: Christine Cawthorne
-role: 
-city: 
-state: 
-github: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/christine.md
+++ b/_authors/christine.md
@@ -3,11 +3,6 @@ name: christine
 first_name: Christine
 last_name: Cheung
 full_name: Christine Cheung
-role: Front End Developer
-city: Los Angeles
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/christine/"
 published: false
 ---

--- a/_authors/christopher-goranson.md
+++ b/_authors/christopher-goranson.md
@@ -1,13 +1,8 @@
 ---
-city: Nashville
 first_name: Christopher
 full_name: Chris Goranson
-github: openglobe
 last_name: Goranson
 name: christopher-goranson
-role: Project Manager
-state: TN
-twitter: cgoranson
 redirect_from: "/team/christopher-goranson/"
 published: true
 ---

--- a/_authors/clara-tsao.md
+++ b/_authors/clara-tsao.md
@@ -1,13 +1,8 @@
 ---
 name: clara-tsao
-city: 
 first_name: Clara
 full_name: Clara Tsao
-github: 
 last_name: Tsao
-role: 
-state: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/clinton-troxel.md
+++ b/_authors/clinton-troxel.md
@@ -1,13 +1,8 @@
 ---
-city: Jackson
 first_name: Clinton
 full_name: Clint Troxel
-github: 
 last_name: Troxel
 name: clinton-troxel
-role: Developer
-state: WY
-twitter: 
 redirect_from: "/team/clinton-troxel/"
 published: false
 ---

--- a/_authors/cm.md
+++ b/_authors/cm.md
@@ -3,11 +3,6 @@ name: cm
 first_name: CM
 last_name: Lubinski
 full_name: CM Lubinski
-role: Developer
-city: Pittsburgh
-state: PA
-github: cmc333333
-twitter: 
 redirect_from: "/team/cm/"
 published: true
 ---

--- a/_authors/colin-craig.md
+++ b/_authors/colin-craig.md
@@ -1,13 +1,8 @@
 ---
-city: Raleigh
 first_name: Colin
 full_name: Colin Craig
-github: 
 last_name: Craig
 name: colin-craig
-role: 
-state: NC
-twitter: 
 redirect_from: "/team/colin-craig/"
 published: true
 ---

--- a/_authors/colinmacarthur.md
+++ b/_authors/colinmacarthur.md
@@ -3,11 +3,6 @@ name: colinmacarthur
 first_name: Colin
 last_name: MacArthur
 full_name: Colin MacArthur
-role: User Experience Designer
-city: Boston
-state: MA
-github: 
-twitter: 
 redirect_from: "/team/colinmacarthur/"
 published: true
 ---

--- a/_authors/corey-mahoney.md
+++ b/_authors/corey-mahoney.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Corey
 full_name: Corey Mahoney
-github: 
 last_name: Mahoney
 name: corey-mahoney
-role: Content designer
-state: CA
-twitter: 
 redirect_from: "/team/corey.mahoney/"
 published: true
 ---

--- a/_authors/cristina.md
+++ b/_authors/cristina.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Cristina
 full_name: Cristina Brydges
-github: 
 last_name: Brydges
 name: cristina
-role: Deputy Director
-state: DC
-twitter: 
 redirect_from: "/team/cristina/"
 published: false
 ---

--- a/_authors/dahianna.md
+++ b/_authors/dahianna.md
@@ -4,8 +4,5 @@ first_name: Dahianna
 last_name: Salazar Foreman
 full_name: Dahianna Salazar Foreman
 published: true
-role: 
-city: 
-state: 
 ---
 

--- a/_authors/david.md
+++ b/_authors/david.md
@@ -3,11 +3,6 @@ name: david
 first_name: Dave
 last_name: Best
 full_name: Dave Best
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/deniseroth.md
+++ b/_authors/deniseroth.md
@@ -3,11 +3,6 @@ name: deniseroth
 first_name: Denise
 last_name: Roth
 full_name: Denise Turner Roth
-role: 
-city: 
-state: 
-github: 
-twitter: 
 url: http://www.gsa.gov/portal/content/100046
 redirect_from: 
 published: true

--- a/_authors/diego.md
+++ b/_authors/diego.md
@@ -3,11 +3,6 @@ name: diego
 first_name: Diego
 last_name: Lapiduz
 full_name: Diego Lapiduz
-role: Director of cloud.gov
-city: Austin
-state: TX
-github: dlapiduz
-twitter: dlapiduz
 project:
 - cloud.gov
 - DevOps Guild

--- a/_authors/dmayercantu.md
+++ b/_authors/dmayercantu.md
@@ -3,9 +3,6 @@ name: dmayercantu
 full_name: Diego Mayer-Cantu
 first_name: Diego
 last_name: Mayer-Cantu
-role: 
-city: New York
-state: NY
 redirect_from: "/team/dmayercantu/"
 alumni: true
 published: false

--- a/_authors/duane-rollins.md
+++ b/_authors/duane-rollins.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Duane
 full_name: Duane Rollins
-github: 
 last_name: Rollins
 name: duane-rollins
-role: 
-state: 
-twitter: 
 redirect_from: "/team/duane-rollins/"
 published: true
 ---

--- a/_authors/ed-mullen.md
+++ b/_authors/ed-mullen.md
@@ -1,13 +1,8 @@
 ---
-city: New York
 first_name: Ed
 full_name: Ed Mullen
-github: 
 last_name: Mullen
 name: ed-mullen
-role: Product Strategist
-state: New York
-twitter: 
 redirect_from: "/team/ed-mullen/"
 published: false
 ---

--- a/_authors/egoodman.md
+++ b/_authors/egoodman.md
@@ -3,11 +3,6 @@ name: egoodman
 first_name: Elizabeth
 last_name: Goodman
 full_name: Elizabeth Goodman
-role: Design Researcher
-city: San Francisco
-state: CA
-github: esgoodman
-twitter: egoodman
 redirect_from: "/team/egoodman/"
 published: true
 ---

--- a/_authors/elaine.md
+++ b/_authors/elaine.md
@@ -3,11 +3,6 @@ name: elaine
 first_name: Elaine
 last_name: Kamlley
 full_name: Elaine Kamlley
-role: Developer
-city: Washington
-state: D.C.
-github: elainekamlley
-twitter: elainekamlley
 project:
 - 18f.gsa.gov
 - 18F Blog

--- a/_authors/emaland.md
+++ b/_authors/emaland.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Eric
 full_name: Eric Maland
-github: emaland
 last_name: Maland
 name: emaland
-role: 
-state: 
-twitter: 
 redirect_from: "/team/emaland/"
 published: false
 ---

--- a/_authors/emileigh.md
+++ b/_authors/emileigh.md
@@ -3,11 +3,6 @@ first_name: Emileigh
 last_name: Barnes
 full_name: Emileigh Barnes
 name: emileigh
-github: emileighoutlaw
-twitter: emileighoutlaw
-role: Content Designer
-city: Washington
-state: D.C.
 project:
 - 18f.gsa.gov
 - 18F Blog

--- a/_authors/eric.md
+++ b/_authors/eric.md
@@ -3,11 +3,6 @@ name: eric
 first_name: Eric
 last_name: Mill
 full_name: Eric Mill
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/eric/"
 published: true
 ---

--- a/_authors/erica.md
+++ b/_authors/erica.md
@@ -3,11 +3,6 @@ name: erica
 first_name: Erica
 last_name: Deahl
 full_name: Erica Deahl
-role: Visual Designer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/erica/"
 alumni: true
 published: true

--- a/_authors/ericronne.md
+++ b/_authors/ericronne.md
@@ -3,11 +3,6 @@ name: ericronne
 first_name: Eric
 last_name: Ronne
 full_name: Eric Ronne
-role: 
-city: Chicago
-state: IL
-github: 
-twitter: 
 redirect_from: "/team/ericronne/"
 published: false
 ---

--- a/_authors/estherchang.md
+++ b/_authors/estherchang.md
@@ -3,11 +3,6 @@ name: estherchang
 first_name: Esther
 last_name: Chang
 full_name: Esther Chang
-role: Hiring Operations
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/estherchang/"
 published: false
 ---

--- a/_authors/estherkim.md
+++ b/_authors/estherkim.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Esther
 full_name: Esther Kim
-github: 
 last_name: Kim
 name: estherkim
-role: 
-state: 
-twitter: 
 redirect_from: "/team/estherkim/"
 published: false
 ---

--- a/_authors/ethan.md
+++ b/_authors/ethan.md
@@ -3,9 +3,6 @@ name: ethan
 full_name: Ethan Heppner
 first_name: Ethan
 last_name: Heppner
-role: Operations Specialist
-city: Chicago
-state: IL
 redirect_from: "/team/ethan/"
 published: false
 ---

--- a/_authors/fureigh.md
+++ b/_authors/fureigh.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Rhys
 full_name: Rhys Fureigh
-github: fureigh
 last_name: Fureigh
 name: fureigh
-role: 
-state: 
-twitter: 
 redirect_from: "/team/fureigh/"
 published: false
 ---

--- a/_authors/gail.md
+++ b/_authors/gail.md
@@ -3,11 +3,6 @@ name: gail
 first_name: Gail
 last_name: Swanson
 full_name: Gail Swanson
-city: Chicago
-state: IL
-role: User Experience Designer
-github: 
-twitter: 
 redirect_from: "/team/gail/"
 published: false
 ---

--- a/_authors/garren.md
+++ b/_authors/garren.md
@@ -3,11 +3,6 @@ name: garren
 first_name: Garren
 last_name: Givens
 full_name: Garren Givens
-role: Deputy Executive Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/garren/"
 alumni: true
 published: true

--- a/_authors/grace-hopper.md
+++ b/_authors/grace-hopper.md
@@ -3,9 +3,6 @@ first_name: Grace
 last_name: Hopper
 full_name: Admiral Grace Hopper
 name: grace-hopper
-role: Developer
-city: Washington
-state: DC
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/gramirez.md
+++ b/_authors/gramirez.md
@@ -3,11 +3,6 @@ name: gramirez
 first_name: Gabriel
 last_name: Ramírez
 full_name: Gabriel Ramírez
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/gramirez/"
 alumni: true
 published: true

--- a/_authors/gray.md
+++ b/_authors/gray.md
@@ -3,11 +3,6 @@ name: gray
 first_name: Gray
 last_name: Brooks
 full_name: Gray Brooks
-role: Product Manager
-city: Washington
-state: D.C.
-github: 
-twitter: 
 project:
 - Analytics Guild
 - api.data.gov

--- a/_authors/greg.md
+++ b/_authors/greg.md
@@ -3,11 +3,6 @@ name: greg
 first_name: Greg
 last_name: Godbout
 full_name: Greg Godbout
-city: 
-state: 
-role: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/gsa-blog-team.md
+++ b/_authors/gsa-blog-team.md
@@ -3,9 +3,6 @@ name: gsa-blog-team
 first_name: GSA Blog Team
 last_name: 
 full_name: GSA Blog Team
-role: 
-city: 
-state: 
 published: true
 ---
 

--- a/_authors/gwynnekostin.md
+++ b/_authors/gwynnekostin.md
@@ -1,13 +1,8 @@
 ---
 name: gwynnekostin
-city: 
 first_name: Gwynne
 full_name: Gwynne Kostin
-github: 
 last_name: Kostin
-role: 
-state: 
-twitter: 
 guest: true
 url: https://www.digitalgov.gov/author/gkostin/
 redirect_from: 

--- a/_authors/hillary.md
+++ b/_authors/hillary.md
@@ -3,11 +3,6 @@ name: hillary
 first_name: Hillary
 last_name: Hartley
 full_name: Hillary Hartley
-role: Deputy Executive Director
-city: San Francisco
-state: CA
-github: quepol
-twitter: hillary
 redirect_from: "/team/hillary/"
 published: true
 ---

--- a/_authors/holly.md
+++ b/_authors/holly.md
@@ -3,11 +3,6 @@ name: holly
 full_name: Holly Allen
 first_name: Holly
 last_name: Allen
-city: San Francisco
-state: CA
-role: Director of Engineering
-github: hollyallen
-twitter: 
 redirect_from: "/team/holly/"
 published: false
 ---

--- a/_authors/jackie.md
+++ b/_authors/jackie.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Jackie
 full_name: Jackie Kazil
-github: 
 last_name: Kazil
 name: jackie
-role: 
-state: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/jackiexu.md
+++ b/_authors/jackiexu.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Jackie
 full_name: Jackie Xu
-github: 
 last_name: Xu
 name: jackiexu
-role: 
-state: 
-twitter: 
 redirect_from: "/team/jackiexu/"
 published: false
 ---

--- a/_authors/jacobharris.md
+++ b/_authors/jacobharris.md
@@ -3,11 +3,6 @@ name: jacobharris
 first_name: Jacob
 last_name: Harris
 full_name: Jacob Harris
-role: Developer
-city: Washington
-state: D.C.
-github: harrisj
-twitter: harrisj
 redirect_from: "/team/jacobharris/"
 published: true
 ---

--- a/_authors/james-seppi.md
+++ b/_authors/james-seppi.md
@@ -3,11 +3,6 @@ name: james-seppi
 first_name: James
 last_name: Seppi
 full_name: James Seppi
-role: Software Developer
-city: Austin
-state: Texas
-github: 
-twitter: 
 redirect_from: "/team/james-seppi/"
 published: false
 ---

--- a/_authors/jameshupp.md
+++ b/_authors/jameshupp.md
@@ -3,9 +3,6 @@ name: jameshupp
 full_name: James Hupp
 first_name: James
 last_name: Hupp
-role: 
-city: New York
-state: NY
 redirect_from: "/team/jameshupp/"
 published: false
 ---

--- a/_authors/jamesscott.md
+++ b/_authors/jamesscott.md
@@ -3,11 +3,6 @@ name: jamesscott
 first_name: James
 last_name: Scott
 full_name: James Scott
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/jamesscott/"
 published: false
 ---

--- a/_authors/jamie.md
+++ b/_authors/jamie.md
@@ -3,11 +3,6 @@ name: jamie
 first_name: Jamie
 last_name: Albrecht
 full_name: Jamie Albrecht
-role: Hiring Lead
-city: San Francisco
-state: CA
-github: jamiealbrecht
-twitter: jmealbrecht
 redirect_from: "/team/jamie/"
 published: true
 ---

--- a/_authors/jayhuie.md
+++ b/_authors/jayhuie.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Jay
 full_name: Jay Huie
-github: thecapacity
 last_name: Huie
 name: jayhuie
-role: 
-state: DC
-twitter: 
 redirect_from: "/team/jayhuie/"
 published: false
 ---

--- a/_authors/jeffwoodworth.md
+++ b/_authors/jeffwoodworth.md
@@ -1,13 +1,8 @@
 ---
 name: jeffwoodworth
-city: 
 first_name: Jeff
 last_name: Woodworth
 full_name: Jeff Woodworth
-github: 
-role: 
-state: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/jen.md
+++ b/_authors/jen.md
@@ -3,11 +3,6 @@ name: jen
 first_name: Jen
 last_name: Ehlers
 full_name: Jen Ehlers
-role: Visual Designer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/jen/"
 published: true
 ---

--- a/_authors/jennmoran.md
+++ b/_authors/jennmoran.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Jenn
 full_name: Jenn Moran
-github: 
 last_name: Moran
 name: jennmoran
-role: 
-state: DC
-twitter: 
 redirect_from: "/team/jennmoran/"
 published: false
 ---

--- a/_authors/jentress.md
+++ b/_authors/jentress.md
@@ -3,11 +3,6 @@ name: jentress
 first_name: Jen
 last_name: Tress
 full_name: Jen Tress
-role: Hiring Operations Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/jentress/"
 published: false
 ---

--- a/_authors/jeremiak.md
+++ b/_authors/jeremiak.md
@@ -3,11 +3,6 @@ name: jeremiak
 first_name: Jeremia
 last_name: Kimelman
 full_name: Jeremia Kimelman
-role: Developer
-city: New York
-state: NY
-github: jeremiak
-twitter: jeremiak
 redirect_from: "/team/jeremiak/"
 published: true
 ---

--- a/_authors/jeremy.md
+++ b/_authors/jeremy.md
@@ -3,11 +3,6 @@ name: jeremy
 first_name: Jeremy
 last_name: Canfield
 full_name: Jeremy Canfield
-role: User Experience Designer
-city: New York City
-state: NY
-github: 
-twitter: 
 redirect_from: "/team/jeremy/"
 published: true
 ---

--- a/_authors/jessedondero.md
+++ b/_authors/jessedondero.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Jesse
 full_name: Jesse Dondero
-github: 
 last_name: Dondero
 name: jessedondero
-role: 
-state: 
-twitter: 
 redirect_from: "/team/jessedondero/"
 published: false
 ---

--- a/_authors/jessie-posilkin.md
+++ b/_authors/jessie-posilkin.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Jessie
 full_name: Jessie Posilkin
-github: 
 last_name: Posilkin
 name: jessie-posilkin
-role: 
-state: District of Columbia
-twitter: 
 redirect_from: "/team/jessie-posilkin/"
 published: false
 ---

--- a/_authors/jessie.md
+++ b/_authors/jessie.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Jessie
 full_name: Jessie Young
-github: jessieay
 last_name: Young
 name: jessie
-role: Developer
-state: California
-twitter: 
 redirect_from: "/team/jessie/"
 published: true
 ---

--- a/_authors/jez-humble.md
+++ b/_authors/jez-humble.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Jez
 full_name: Jez Humble
-github: jezhumble
 last_name: Humble
 name: jez-humble
-role: Deputy Director of Infrastructure
-state: California
-twitter: 
 redirect_from: "/team/jez-humble/"
 published: true
 ---

--- a/_authors/jfinch.md
+++ b/_authors/jfinch.md
@@ -3,11 +3,6 @@ name: jfinch
 first_name: Jay
 last_name: Finch
 full_name: Jay Finch
-role: Engagement Management Consultant
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/jfinch/"
 published: true
 ---

--- a/_authors/jhunter.md
+++ b/_authors/jhunter.md
@@ -3,11 +3,6 @@ name: jhunter
 first_name: Jeannine
 last_name: Hunter
 full_name: Jeannine Hunter
-role: Content Strategist
-city: Washington
-state: D.C.
-github: jeanninehunter
-twitter: 
 project:
 - Content Lead
 - USCIS

--- a/_authors/joe.md
+++ b/_authors/joe.md
@@ -3,11 +3,6 @@ name: joe
 first_name: Joe
 last_name: Polastre
 full_name: Joe Polastre
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/joel-minton.md
+++ b/_authors/joel-minton.md
@@ -3,11 +3,6 @@ name: joel-minton
 first_name: Joel
 last_name: Minton
 full_name: Joel Minton
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/john-donmoyer.md
+++ b/_authors/john-donmoyer.md
@@ -1,13 +1,8 @@
 ---
-city: Chicago
 first_name: John
 full_name: John Donmoyer
-github: 
 last_name: Donmoyer
 name: john-donmoyer
-role: User Experience Designer
-state: IL
-twitter: 
 redirect_from: "/team/john-donmoyer/"
 published: false
 ---

--- a/_authors/jonathanrubin.md
+++ b/_authors/jonathanrubin.md
@@ -3,11 +3,6 @@ name: jonathanrubin
 first_name: Jonathan
 last_name: Rubin
 full_name: Jonathan Rubin
-role: 
-city: 
-state: 
-github: 
-twitter: 
 project: 
 redirect_from: 
 published: true

--- a/_authors/josh.md
+++ b/_authors/josh.md
@@ -3,11 +3,6 @@ name: josh
 first_name: Josh
 last_name: Ruihley
 full_name: Josh Ruihley
-role: Product Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/josh/"
 published: false
 ---

--- a/_authors/joshbailes.md
+++ b/_authors/joshbailes.md
@@ -3,11 +3,6 @@ name: joshbailes
 first_name: Josh
 last_name: Bailes
 full_name: Josh Bailes
-role: Operations Specialist
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/joshbailes/"
 published: false
 ---

--- a/_authors/joshcarp.md
+++ b/_authors/joshcarp.md
@@ -3,11 +3,6 @@ name: joshcarp
 first_name: Josh
 last_name: Carp
 full_name: Josh Carp
-role: Developer
-city: Charlottesville
-state: VA
-github: 
-twitter: 
 redirect_from: "/team/joshcarp/"
 published: false
 ---

--- a/_authors/jtag.md
+++ b/_authors/jtag.md
@@ -3,11 +3,6 @@ name: jtag
 first_name: Jesse
 last_name: Taggert
 full_name: Jesse Taggert
-role: Design and Product Strategy Director
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/jtag/"
 published: true
 ---

--- a/_authors/jthibault.md
+++ b/_authors/jthibault.md
@@ -3,11 +3,6 @@ name: jthibault
 first_name: Jennifer
 last_name: Thibault
 full_name: Jennifer Thibault
-role: Visual Designer
-city: New York City
-state: NY
-github: jenniferthibault
-twitter: jlthibault
 redirect_from: "/team/jthibault/"
 published: true
 ---

--- a/_authors/jtindel.md
+++ b/_authors/jtindel.md
@@ -1,13 +1,8 @@
 ---
 name: jtindel
-city: 
 first_name: John
 full_name: John Tindel
-github: 
 last_name: Tindel
-role: 
-state: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/julia.md
+++ b/_authors/julia.md
@@ -3,11 +3,6 @@ name: julia
 first_name: Julia
 last_name: Elman
 full_name: Julia Elman
-role: Front End Designer
-city: Durham
-state: NC
-github: juliaelman
-twitter: juliaelman
 redirect_from: "/team/julia/"
 published: true
 ---

--- a/_authors/juliawinn.md
+++ b/_authors/juliawinn.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Julia
 full_name: Julia Winn
-github: 
 last_name: Winn
 name: juliawinn
-role: 
-state: D.C.
-twitter: 
 redirect_from: "/team/julia-winn"
 published: true
 ---

--- a/_authors/justin-herman.md
+++ b/_authors/justin-herman.md
@@ -3,11 +3,6 @@ name: justin-herman
 first_name: Justin
 last_name: Herman
 full_name: Justin Herman
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/justin.md
+++ b/_authors/justin.md
@@ -3,11 +3,6 @@ name: justin
 first_name: Justin
 last_name: Grevich
 full_name: Justin Grevich
-role: Developer
-city: Seattle
-state: WA
-github: 
-twitter: 
 redirect_from: "/team/justin/"
 published: false
 ---

--- a/_authors/kaitlin.md
+++ b/_authors/kaitlin.md
@@ -3,11 +3,6 @@ name: kaitlin
 first_name: Kaitlin
 last_name: Devine
 full_name: Kaitlin Devine
-role: Developer
-city: Washington
-state: D.C.
-github: kaitlin
-twitter: kaitlinbdevine
 redirect_from: "/team/kaitlin/"
 published: true
 ---

--- a/_authors/kane.md
+++ b/_authors/kane.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Kane
 full_name: Kane Baccigalupi
-github: 
 last_name: Baccigalupi
 name: kane
-role: 
-state: CA
-twitter: 
 redirect_from: "/team/kane/"
 published: true
 ---

--- a/_authors/kara.md
+++ b/_authors/kara.md
@@ -3,11 +3,6 @@ name: kara
 first_name: Kara
 last_name: DeFrias
 full_name: Kara DeFrias
-role: Senior Advisor
-city: San Diego
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/kara/"
 published: true
 ---

--- a/_authors/kate.md
+++ b/_authors/kate.md
@@ -3,11 +3,6 @@ name: kate
 first_name: Kate
 last_name: Garklavs
 full_name: Kate Garklavs
-role: Content Designer
-city: Portland
-state: OR
-github: 
-twitter: 
 redirect_from: "/team/kate/"
 published: true
 ---

--- a/_authors/kathrynconnolly.md
+++ b/_authors/kathrynconnolly.md
@@ -3,9 +3,6 @@ name: kathrynconnolly
 first_name: Kathryn
 last_name: Connolly
 full_name: Kathryn Connolly
-city: Washington
-state: D.C.
-role: Team Operations
 redirect_from: "/team/kathrynconnolly/"
 published: false
 ---

--- a/_authors/kedelman.md
+++ b/_authors/kedelman.md
@@ -3,11 +3,6 @@ name: kedelman
 full_name: Kathryn Edelman
 first_name: Kathryn
 last_name: Edelman
-city: Washington
-state: DC
-role: Acquisition Management Consultant
-github: 
-twitter: 
 redirect_from: "/team/kedelman/"
 published: true
 ---

--- a/_authors/kimberdowsett.md
+++ b/_authors/kimberdowsett.md
@@ -3,11 +3,6 @@ name: kimberdowsett
 first_name: Kimber
 last_name: Dowsett
 full_name: Kimber Dowsett
-role: Security Architect
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/kimberdowsett/"
 published: true
 ---

--- a/_authors/kinlane.md
+++ b/_authors/kinlane.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Kin
 full_name: Kin Lane
-github: 
 last_name: Lane
 name: kinlane
-role: 
-state: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/kris-rowley.md
+++ b/_authors/kris-rowley.md
@@ -3,11 +3,6 @@ name: kris-rowley
 first_name: Kris
 last_name: Rowley
 full_name: Kris Rowley
-role: 
-city: 
-state: 
-github: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/kristy-singletary.md
+++ b/_authors/kristy-singletary.md
@@ -3,9 +3,6 @@ name: kristy-singletary
 first_name: Kristy
 last_name: Singletary
 full_name: Kristy Singletary
-role: 
-city: 
-state: 
 guest: true
 published: true
 ---

--- a/_authors/krutivora.md
+++ b/_authors/krutivora.md
@@ -3,11 +3,6 @@ name: krutivora
 first_name: Kruti
 last_name: Vora
 full_name: Kruti Vora
-role: On detail
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/krutivora/"
 published: false
 ---

--- a/_authors/lane-becker.md
+++ b/_authors/lane-becker.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Lane
 full_name: Lane Becker
-github: 
 last_name: Becker
 name: lane-becker
-role: 
-state: 
-twitter: 
 redirect_from: "/team/lane-becker/"
 published: false
 ---

--- a/_authors/larry-bafundo.md
+++ b/_authors/larry-bafundo.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Larry
 full_name: Larry Bafundo
-github: 
 last_name: Bafundo
 name: larry-bafundo
-role: Project Manager
-state: CA
-twitter: 
 redirect_from: "/team/larry-bafundo/"
 published: false
 ---

--- a/_authors/laura-gerhardt.md
+++ b/_authors/laura-gerhardt.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Laura
 full_name: Laura Gerhardt
-github: 
 last_name: Gerhardt
 name: laura-gerhardt
-role: 
-state: DC
-twitter: 
 redirect_from: "/team/laura-gerhardt/"
 published: false
 ---

--- a/_authors/leah.md
+++ b/_authors/leah.md
@@ -3,11 +3,6 @@ name: leah
 first_name: Leah
 last_name: Bannon
 full_name: Leah Bannon
-role: Product Manager
-city: San Francisco
-state: CA
-github: leahbannon
-twitter: leahbannon
 redirect_from: "/team/leah/"
 published: true
 ---

--- a/_authors/leahg.md
+++ b/_authors/leahg.md
@@ -3,11 +3,6 @@ name: leahg
 first_name: Leah
 last_name: Gitter
 full_name: Leah Gitter
-role: Operations Specialist
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/leahg/"
 published: false
 ---

--- a/_authors/lenny-bogdonoff.md
+++ b/_authors/lenny-bogdonoff.md
@@ -1,13 +1,8 @@
 ---
-city: New York City
 first_name: Lenny
 full_name: Lenny Bogdonoff
-github: rememberlenny
 last_name: Bogdonoff
 name: lenny-bogdonoff
-role: General Developer
-state: NY
-twitter: 
 redirect_from: "/team/lenny-bogdonoff/"
 published: false
 ---

--- a/_authors/lindsay.md
+++ b/_authors/lindsay.md
@@ -3,11 +3,6 @@ name: lindsay
 first_name: Lindsay
 last_name: Young
 full_name: Lindsay Young
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/lindsay/"
 published: true
 ---

--- a/_authors/lisagelobter.md
+++ b/_authors/lisagelobter.md
@@ -3,11 +3,6 @@ name: lisagelobter
 first_name: Lisa
 last_name: Gelobter
 full_name: Lisa Gelobter
-role: 
-city: 
-state: 
-github: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/majma.md
+++ b/_authors/majma.md
@@ -3,11 +3,6 @@ name: majma
 first_name: Raphael
 last_name: Majma
 full_name: Raphael Majma
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/manger.md
+++ b/_authors/manger.md
@@ -3,11 +3,6 @@ name: manger
 first_name: Noah
 last_name: Manger
 full_name: Noah Manger
-role: Front End Designer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/manger/"
 published: true
 ---

--- a/_authors/marco.md
+++ b/_authors/marco.md
@@ -3,11 +3,6 @@ name: marco
 first_name: Marco
 last_name: Segreto
 full_name: Marco Segreto
-role: Front End Designer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 proejct:
 - Front End Guild
 redirect_from: "/team/marco/"

--- a/_authors/marinafox.md
+++ b/_authors/marinafox.md
@@ -1,13 +1,8 @@
 ---
 name: marinafox
-city: 
 first_name: Marina
 full_name: Marina Fox
-github: 
 last_name: Fox
-role: 
-state: 
-twitter: 
 guest: true
 url: https://www.digitalgov.gov/author/mfox/
 redirect_from: 

--- a/_authors/mark.md
+++ b/_authors/mark.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Mark
 full_name: Mark Nejbauer
-github: 
 last_name: Nejbauer
 name: mark
-role: 
-state: 
-twitter: 
 redirect_from: "/team/mark/"
 published: false
 ---

--- a/_authors/matt.md
+++ b/_authors/matt.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Matt
 full_name: Matt Spencer
-github: 
 last_name: Spencer
 name: matt
-role: 
-state: D.C.
-twitter: 
 redirect_from: "/team/matt/"
 published: false
 ---

--- a/_authors/mattchessen.md
+++ b/_authors/mattchessen.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Matt
 full_name: Matt Chessen, Department of State
-github: 
 last_name: Chessen
 name: mattchessen
-role: 
-state: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/maya.md
+++ b/_authors/maya.md
@@ -3,11 +3,6 @@ name: maya
 first_name: Maya
 last_name: Benari
 full_name: Maya Benari
-role: Front End Designer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/maya/"
 published: true
 ---

--- a/_authors/mbland.md
+++ b/_authors/mbland.md
@@ -3,11 +3,6 @@ name: mbland
 first_name: Mike
 full_name: Mike Bland
 last_name: Bland
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/mchopson.md
+++ b/_authors/mchopson.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Mark
 full_name: Mark Hopson
-github: 
 last_name: Hopson
 name: mchopson
-role: 
-state: D.C.
-twitter: 
 redirect_from: "/team/mark-hopson"
 published: true
 ---

--- a/_authors/meghana.md
+++ b/_authors/meghana.md
@@ -3,11 +3,6 @@ name: meghana
 first_name: Meghana
 last_name: Khandekar
 full_name: Meghana Khandekar
-role: User Experience Designer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/meghana/"
 published: true
 ---

--- a/_authors/melody.md
+++ b/_authors/melody.md
@@ -3,11 +3,6 @@ name: melody
 first_name: Melody
 last_name: Kramer
 full_name: Melody Kramer
-role: Outreach
-city: Chapel Hill
-state: NC
-github: melodykramer
-twitter: mkramer
 project:
 - 18f.gsa.gov
 - 18F Blog

--- a/_authors/memiwhitehead.md
+++ b/_authors/memiwhitehead.md
@@ -3,9 +3,6 @@ first_name: Memi
 last_name: Whitehead
 full_name: Memi Whitehead
 name: memiwhitehead
-role: 
-city: 
-state: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/mheadd.md
+++ b/_authors/mheadd.md
@@ -3,11 +3,6 @@ name: mheadd
 first_name: Mark
 last_name: Headd
 full_name: Mark Headd
-role: Innovation Specialist
-city: Syracuse
-state: New York
-github: mheadd
-twitter: mheadd
 published: true
 ---
 

--- a/_authors/mhz.md
+++ b/_authors/mhz.md
@@ -3,11 +3,6 @@ name: mhz
 first_name: Michelle
 last_name: Hertzfeld
 full_name: Michelle Hertzfeld
-role: Front End Designer
-city: Tucson
-state: AZ
-github: meiqimichelle
-twitter: meiqimichelle
 redirect_from: "/team/mhz/"
 published: true
 ---

--- a/_authors/micahsaul.md
+++ b/_authors/micahsaul.md
@@ -3,11 +3,6 @@ name: micahsaul
 first_name: Micah
 last_name: Saul
 full_name: Micah Saul
-role: Acting Engineering Director
-city: Portland
-state: OR
-github: 
-twitter: 
 redirect_from: "/team/micahsaul/"
 published: false
 ---

--- a/_authors/michael-balint.md
+++ b/_authors/michael-balint.md
@@ -3,11 +3,6 @@ name: michael-balint
 first_name: Michael
 last_name: Balint
 full_name: Michael Balint
-role: 
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/michael-balint/"
 published: false
 ---

--- a/_authors/michael-cata.md
+++ b/_authors/michael-cata.md
@@ -3,11 +3,6 @@ name: michael-cata
 first_name: Michael
 last_name: Cata
 full_name: Michael Cata
-role: Consultant
-city: New York
-state: NY
-github: 
-twitter: 
 redirect_from: "/team/michael-cata/"
 published: false
 ---

--- a/_authors/michael-torres.md
+++ b/_authors/michael-torres.md
@@ -1,13 +1,8 @@
 ---
-city: San Francisco
 first_name: Michael
 full_name: Michael Torres
-github: 
 last_name: Torres
 name: michael-torres
-role: 
-state: CA
-twitter: 
 redirect_from: "/team/michael-torres/"
 published: true
 ---

--- a/_authors/michael-walker.md
+++ b/_authors/michael-walker.md
@@ -1,13 +1,8 @@
 ---
-city: Clinton
 first_name: Greg
 full_name: Greg Walker
-github: mgwalker
 last_name: Walker
 name: michael-walker
-role: Practical Dev
-state: MS
-twitter: 
 redirect_from: "/team/michael-walker/"
 published: true
 ---

--- a/_authors/michelle-chronister.md
+++ b/_authors/michelle-chronister.md
@@ -3,11 +3,6 @@ name: michelle-chronister
 first_name: Michelle
 last_name: Chronister
 full_name: Michelle Chronister
-role: 
-city: 
-state: 
-github: 
-twitter: 
 alumni: true
 redirect_from: 
 published: true

--- a/_authors/mike-hsu.md
+++ b/_authors/mike-hsu.md
@@ -3,9 +3,6 @@ first_name: Mike
 last_name: Hsu
 full_name: Mike Hsu
 name: mike-hsu
-role: Product manager
-city: Washington
-state: D.C.
 redirect_from: "/team/mike-hsu/"
 published: false
 ---

--- a/_authors/mike-wilkening.md
+++ b/_authors/mike-wilkening.md
@@ -5,8 +5,5 @@ full_name: Mike Wilkening
 name: mike-wilkening
 guest: true
 published: true
-role: 
-city: 
-state: 
 ---
 

--- a/_authors/mollieruskin.md
+++ b/_authors/mollieruskin.md
@@ -3,11 +3,6 @@ name: mollieruskin
 first_name: Mollie
 last_name: Ruskin
 full_name: Mollie Ruskin
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/moncef.md
+++ b/_authors/moncef.md
@@ -3,11 +3,6 @@ name: moncef
 first_name: Moncef
 last_name: Belyamani
 full_name: Moncef Belyamani
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/moncef/"
 published: false
 ---

--- a/_authors/mossadeq-zia.md
+++ b/_authors/mossadeq-zia.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Mossadeq
 full_name: Mossadeq Zia
-github: mzia
 last_name: Zia
 name: mossadeq-zia
-role: DevOps Engineer
-state: DC
-twitter: 
 redirect_from: "/team/mossadeq-zia/"
 published: true
 ---

--- a/_authors/nick.md
+++ b/_authors/nick.md
@@ -3,11 +3,6 @@ name: nick
 first_name: Nick
 last_name: Bristow
 full_name: Nick Bristow
-role: Developer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 project:
 - Accessibility Guild
 redirect_from: "/team/nick/"

--- a/_authors/nicole-fenton.md
+++ b/_authors/nicole-fenton.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Nicole
 full_name: Nicole Fenton
-github: nicoleslaw
 last_name: Fenton
 name: nicole-fenton
-role: Content Designer
-state: New York
-twitter: nicoleslaw
 redirect_from: "/team/nicole-fenton/"
 published: true
 ---

--- a/_authors/noah.md
+++ b/_authors/noah.md
@@ -3,11 +3,6 @@ name: noah
 first_name: Noah
 last_name: Kunin
 full_name: Noah Kunin
-role: Director of Delivery Architecture + Infrastructure
-city: Washington
-state: D.C.
-github: https://github.com/noahkunin
-twitter: https://twitter.com/noahkunin
 redirect_from: "/team/noah/"
 published: true
 ---

--- a/_authors/nolson.md
+++ b/_authors/nolson.md
@@ -3,11 +3,6 @@ name: nolson
 first_name: Nathan
 last_name: Olson
 full_name: Nathan Olson
-role: Operations Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/nolson/"
 published: false
 ---

--- a/_authors/ozzy.md
+++ b/_authors/ozzy.md
@@ -3,11 +3,6 @@ name: ozzy
 first_name: Ozzy
 last_name: Johnson
 full_name: Ozzy Johnson
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/phaedra.md
+++ b/_authors/phaedra.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Phaedra
 full_name: Phaedra Chrousos
-github: 
 last_name: Chrousos
 name: phaedra
-role: 
-state: 
-twitter: 
 redirect_from: "/team/phaedra/"
 published: false
 ---

--- a/_authors/philip-reid.md
+++ b/_authors/philip-reid.md
@@ -3,9 +3,6 @@ first_name: Philip
 last_name: Reid
 full_name: Philip Reid
 name: philip-reid
-role: Engineer
-city: Washington
-state: DC
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/phoebe-espiritu.md
+++ b/_authors/phoebe-espiritu.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Phoebe
 full_name: Phoebe Espiritu
-github: 
 last_name: Phoebe
 name: phoebe-espiritu
-role: 
-state: 
-twitter: 
 redirect_from: "/team/phoebe-espiritu/"
 published: true
 ---

--- a/_authors/pia.md
+++ b/_authors/pia.md
@@ -3,11 +3,6 @@ name: pia
 first_name: Pia
 last_name: Scott
 full_name: Pia Scott
-role: Events Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/pia/"
 published: false
 ---

--- a/_authors/pkarman.md
+++ b/_authors/pkarman.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Peter
 full_name: Peter Karman
-github: pkarman
 last_name: Karman
 name: pkarman
-role: 
-state: 
-twitter: 
 redirect_from: "/team/pkarman/"
 published: true
 ---

--- a/_authors/porta.md
+++ b/_authors/porta.md
@@ -1,13 +1,8 @@
 ---
-city: Chicago
 first_name: Porta
 full_name: Porta Antiporta
-github: porta-antiporta
 last_name: Antiporta
 name: porta
-role: Product Lead
-state: IL
-twitter: 
 redirect_from: "/team/porta-antiporta"
 published: true
 ---

--- a/_authors/puja.md
+++ b/_authors/puja.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Puja
 full_name: Puja Balachander
-github: 
 last_name: Balachander
 name: puja
-role: Program Manager
-state: D.C.
-twitter: 
 redirect_from: "/team/puja/"
 published: false
 ---

--- a/_authors/randy-hart.md
+++ b/_authors/randy-hart.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Randy
 full_name: Randy Hart
-github: 
 last_name: Hart
 name: randy-hart
-role: Procurement Specialist
-state: DC
-twitter: 
 redirect_from: "/team/randy-hart/"
 published: false
 ---

--- a/_authors/raphy.md
+++ b/_authors/raphy.md
@@ -3,11 +3,6 @@ name: raphy
 first_name: Raphael
 last_name: Villas
 full_name: Raphael Villas
-role: Product Manager
-city: Chicago
-state: IL
-github: 
-twitter: 
 redirect_from: "/team/raphy/"
 published: false
 ---

--- a/_authors/rebeccapiazza.md
+++ b/_authors/rebeccapiazza.md
@@ -3,11 +3,6 @@ name: rebeccapiazza
 first_name: Rebecca
 last_name: Piazza
 full_name: Rebecca Piazza
-city: Washington
-state: D.C.
-role: Product Manager
-github: 
-twitter: 
 redirect_from: "/team/rebeccapiazza/"
 published: true
 ---

--- a/_authors/ric.md
+++ b/_authors/ric.md
@@ -3,11 +3,6 @@ name: ric
 first_name: Ric
 last_name: Miller
 full_name: Ric Miller
-role: Senior Advisor
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/ric/"
 published: false
 ---

--- a/_authors/robert.md
+++ b/_authors/robert.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Robert
 full_name: Dr. Robert L. Read
-github: 
 last_name: Read
 name: robert
-role: 
-state: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/robin-carnahan.md
+++ b/_authors/robin-carnahan.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Robin
 full_name: Robin Carnahan
-github: 
 last_name: Carnahan
 name: robin-carnahan
-role: 
-state: 
-twitter: 
 redirect_from: "/team/robin-carnahan/"
 published: true
 ---

--- a/_authors/robin-thottungal.md
+++ b/_authors/robin-thottungal.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Robin
 full_name: Robin A. Thottungal
-github: 
 last_name: Thottungal
 name: robin-thottungal
-role: 
-state: 
-twitter: 
 guest: true
 redirect_from: 
 published: true

--- a/_authors/roger-ruiz.md
+++ b/_authors/roger-ruiz.md
@@ -3,11 +3,6 @@ name: roger-ruiz
 first_name: Roger
 last_name: Ruiz
 full_name: Roger Ruiz
-role: Front-End Developer
-city: Richmond
-state: VA
-github: 
-twitter: 
 redirect_from: "/team/roger-ruiz/"
 published: false
 ---

--- a/_authors/romke.md
+++ b/_authors/romke.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Romke
 full_name: Romke De Haan
-github: 
 last_name: De Haan
 name: romke
-role: 
-state: 
-twitter: 
 redirect_from: "/team/romke/"
 published: false
 ---

--- a/_authors/russ.md
+++ b/_authors/russ.md
@@ -1,13 +1,8 @@
 ---
-city: Chicago
 first_name: Russ
 full_name: Russ Unger
-github: 
 last_name: Unger
 name: russ
-role: 
-state: 
-twitter: 
 redirect_from: "/team/romke"
 published: true
 ---

--- a/_authors/ryan-sibley.md
+++ b/_authors/ryan-sibley.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Ryan
 full_name: Ryan Sibley
-github: 
 last_name: Sibley
 name: ryan-sibley
-role: Content Designer
-state: DC
-twitter: 
 redirect_from: "/team/ryan-sibley/"
 published: true
 ---

--- a/_authors/ryan.md
+++ b/_authors/ryan.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Ryan
 full_name: Ryan Thurlwell
-github: 
 last_name: Thurwell
 name: ryan
-role: 
-state: 
-twitter: 
 redirect_from: "/team/ryan/"
 published: true
 ---

--- a/_authors/sally-ride.md
+++ b/_authors/sally-ride.md
@@ -3,9 +3,6 @@ first_name: Sally
 last_name: Ride
 full_name: Sally Ride
 name: sally-ride
-role: Deputy Director of Infrastructure
-city: San Diego
-state: CA
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/sam-eagle.md
+++ b/_authors/sam-eagle.md
@@ -3,9 +3,6 @@ first_name: Sam
 last_name: Eagle
 full_name: Sam the Eagle
 name: sam-eagle
-role: Press
-city: Washington
-state: DC
 april-fools: 2016
 redirect_to: "/april-fools/2016/"
 joke: |

--- a/_authors/sarah.md
+++ b/_authors/sarah.md
@@ -3,11 +3,6 @@ name: sarah
 first_name: Sarah
 last_name: Allen
 full_name: Sarah Allen
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/sarahcrane.md
+++ b/_authors/sarahcrane.md
@@ -3,11 +3,6 @@ name: sarahcrane
 first_name: Sarah
 last_name: Crane
 full_name: Sarah Crane
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/sasha.md
+++ b/_authors/sasha.md
@@ -3,11 +3,6 @@ name: sasha
 first_name: Sasha
 last_name: Magee
 full_name: Sasha Magee
-role: Developer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/sasha/"
 published: false
 ---

--- a/_authors/sean.md
+++ b/_authors/sean.md
@@ -3,11 +3,6 @@ name: sean
 first_name: Sean
 last_name: Herron
 full_name: Sean Herron
-role: 
-city: 
-state: 
-github: 
-twitter: 
 redirect_from: 
 alumni: true
 published: true

--- a/_authors/shashank.md
+++ b/_authors/shashank.md
@@ -3,11 +3,6 @@ name: shashank
 first_name: Shashank
 last_name: Khandelwal
 full_name: Shashank Khandelwal
-role: Director of Data + Technical Architecture
-city: Washington
-state: D.C.
-github: 
-twitter: 
 project: 
 redirect_from:
 - "/team/khandelwal/"

--- a/_authors/shawn.md
+++ b/_authors/shawn.md
@@ -3,11 +3,6 @@ name: shawn
 first_name: Shawn
 last_name: Allen
 full_name: Shawn Allen
-role: Front End Designer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 redirect_from: "/team/shawn/"
 published: true
 ---

--- a/_authors/shawnique.md
+++ b/_authors/shawnique.md
@@ -3,11 +3,6 @@ name: shawnique
 first_name: Shawnique
 last_name: Muller
 full_name: Shawnique Muller
-role: Hiring Operations Specialist
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/shawnique/"
 published: false
 ---

--- a/_authors/smita.md
+++ b/_authors/smita.md
@@ -3,11 +3,6 @@ name: smita
 first_name: Smita
 last_name: Satiani
 full_name: Smita Satiani
-role: Business Development Director
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/smita/"
 published: false
 ---

--- a/_authors/stephanierivera.md
+++ b/_authors/stephanierivera.md
@@ -3,11 +3,6 @@ name: stephanierivera
 first_name: Stephanie
 last_name: Rivera
 full_name: Stephanie Rivera
-role: Business Strategy Director
-city: San Francisco
-state: CA
-github: 
-twitter: 
 project:
 - 18F Intake
 redirect_from: "/team/stephanierivera/"

--- a/_authors/steven-harms.md
+++ b/_authors/steven-harms.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Steven
 full_name: Steven Harms
-github: sharms
 last_name: Harms
 name: steven-harms
-role: 
-state: 
-twitter: 
 redirect_from: "/team/steven-harms/"
 published: false
 ---

--- a/_authors/steven-reilly.md
+++ b/_authors/steven-reilly.md
@@ -3,11 +3,6 @@ name: steven-reilly
 first_name: Steven
 last_name: Reilly
 full_name: Steven Reilly
-role: Acquisitions Specialist
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/steven-reilly/"
 published: true
 ---

--- a/_authors/stuart-drown.md
+++ b/_authors/stuart-drown.md
@@ -5,8 +5,5 @@ full_name: Stuart Drown
 name: stuart-drown
 guest: true
 published: true
-role: 
-city: 
-state: 
 ---
 

--- a/_authors/tadhg.md
+++ b/_authors/tadhg.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Tadhg
 full_name: Tadhg O'Higgins
-github: 
 last_name: O'Higgins
 name: tadhg
-role: 
-state: 
-twitter: 
 redirect_from: "/team/tadhg/"
 published: true
 ---

--- a/_authors/tgrandison.md
+++ b/_authors/tgrandison.md
@@ -1,13 +1,8 @@
 ---
 name: tgrandison
-city: 
 first_name: Tyrone
 full_name: Tyrone Grandison
-github: 
 last_name: Grandison
-role: 
-state: 
-twitter: 
 redirect_from: 
 published: true
 ---

--- a/_authors/theresa.md
+++ b/_authors/theresa.md
@@ -3,11 +3,6 @@ name: theresa
 first_name: Theresa
 last_name: Summa
 full_name: Theresa Summa
-role: Developer
-city: Berkeley
-state: CA
-github: theresaanna
-twitter: theresaanna
 project:
 - CALC
 redirect_from: "/team/theresa/"

--- a/_authors/timlowden.md
+++ b/_authors/timlowden.md
@@ -3,9 +3,6 @@ first_name: Tim
 last_name: Lowden
 full_name: Tim Lowden
 name: timlowden
-city: 
-state: 
-role: 
 redirect_from: 
 published: true
 ---

--- a/_authors/timothy-jones.md
+++ b/_authors/timothy-jones.md
@@ -3,9 +3,6 @@ first_name: Timothy
 last_name: Jones
 full_name: Tim Jones
 name: timothy-jones
-city: Washington
-state: D.C.
-role: Digital transformation lead
 redirect_from: "/team/timothy-jones/"
 published: false
 ---

--- a/_authors/unpublished_author.md
+++ b/_authors/unpublished_author.md
@@ -3,11 +3,6 @@ name: unpublished-author
 first_name: unpublished
 last_name: author
 full_name: Unpublished Author
-role: Testing
-city: 
-state: 
-github: 18F
-twitter: 18F
 published: false
 ---
 

--- a/_authors/valdiviezo.md
+++ b/_authors/valdiviezo.md
@@ -1,13 +1,8 @@
 ---
-city: 
 first_name: Victor
 full_name: Victor Valdiviezo
-github: 
 last_name: Valdiviezo
 name: valdiviezo
-role: 
-state: 
-twitter: 
 redirect_from: "/team/valdiviezo/"
 published: false
 ---

--- a/_authors/vdavez.md
+++ b/_authors/vdavez.md
@@ -3,11 +3,6 @@ name: vdavez
 first_name: Dave
 last_name: Zvenyach
 full_name: V. David Zvenyach
-role: Acquisition Management Director
-city: Washington
-state: D.C.
-github: vdavez
-twitter: vdavez
 redirect_from: "/team/vdavez/"
 published: true
 ---

--- a/_authors/victor-udoewa.md
+++ b/_authors/victor-udoewa.md
@@ -1,13 +1,8 @@
 ---
-city: Washington
 first_name: Victor
 full_name: Victor Udoewa
-github: 
 last_name: Udoewa
 name: victor-udoewa
-role: 
-state: D.C.
-twitter: 
 redirect_from: "/team/victor-udoewa/"
 published: true
 ---

--- a/_authors/victor.md
+++ b/_authors/victor.md
@@ -3,11 +3,6 @@ name: victor
 first_name: Victor
 last_name: Zapanta
 full_name: Victor Diaz Zapanta
-role: User Experience Designer
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/victor/"
 published: true
 ---

--- a/_authors/vraj-mohan.md
+++ b/_authors/vraj-mohan.md
@@ -3,11 +3,6 @@ name: vraj-mohan
 first_name: Vraj
 last_name: Mohan
 full_name: Vraj Mohan
-role: Developer
-city: Philadelphia
-state: PA
-github: 
-twitter: 
 redirect_from: "/team/vraj-mohan/"
 published: false
 ---

--- a/_authors/will.md
+++ b/_authors/will.md
@@ -3,11 +3,6 @@ name: will
 first_name: Will
 last_name: Slack
 full_name: Will Slack
-role: Products and Platforms Deputy Director
-city: Washington
-state: D.C.
-github: wslack
-twitter: wslack
 project:
 - Federalist
 redirect_from: "/team/will/"

--- a/_authors/willsullivan.md
+++ b/_authors/willsullivan.md
@@ -3,11 +3,6 @@ name: willsullivan
 first_name: Will
 last_name: Sullivan
 full_name: Will Sullivan
-role: Product Manager
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/willsullivan/"
 published: true
 ---

--- a/_authors/yoz.md
+++ b/_authors/yoz.md
@@ -3,11 +3,6 @@ name: yoz
 first_name: Yoz
 last_name: Grahame
 full_name: Yoz Grahame
-role: Developer
-city: San Francisco
-state: CA
-github: 
-twitter: 
 project:
 - Project Review
 redirect_from: "/team/yoz/"

--- a/_authors/yuda.md
+++ b/_authors/yuda.md
@@ -3,11 +3,6 @@ name: yuda
 first_name: John
 last_name: Yuda
 full_name: John Yuda
-role: Senior Product Design Advisor
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/yuda/"
 published: true
 ---

--- a/_authors/zaccohn.md
+++ b/_authors/zaccohn.md
@@ -3,11 +3,6 @@ name: zaccohn
 first_name: Zac
 last_name: Cohn
 full_name: Zac Cohn
-role: Design and Product Strategy Consultant
-city: Washington
-state: D.C.
-github: 
-twitter: 
 redirect_from: "/team/zaccohn/"
 published: true
 ---

--- a/tests/schema/_authors.yml
+++ b/tests/schema/_authors.yml
@@ -15,5 +15,5 @@ config:
   - ..
   - .
   - .DS_Store
-  optional: ['tumblr_url', 'github', 'twitter', 'role', 'city', 'state', 'team', 'last_name', 'team']
+  optional: ['last_name', 'team']
 ---

--- a/tests/schema/_authors.yml
+++ b/tests/schema/_authors.yml
@@ -3,10 +3,6 @@ name: "String"
 first_name: "String"
 last_name: "String"
 full_name: "String"
-role: "String"
-city: "String"
-state: "String"
-role: "String"
 published: Boolean
 config:
   path: '_authors'


### PR DESCRIPTION
Fixes issue(s) #2191 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/deprecate-fields.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/deprecate-fields)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/deprecate-fields/)

Changes proposed in this pull request:
- removes the `role`, `city`, `state`, `github`, `twitter`, `tumblr` fields from the author pages.

/cc @coreycaitlin @gboone @elainekamlley @awfrancisco 
