### PR TITLE
better GitHub link

### DIFF
--- a/_includes/navigation/footer-desktop.html
+++ b/_includes/navigation/footer-desktop.html
@@ -56,7 +56,7 @@
         <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
       </li>
       <li>
-        <a href="https://github.com/18F/18f.gsa.gov/edit/master/{{ page.path }}">Edit on GitHub</a>
+        <a href="https://github.com/18F/18f.gsa.gov/issues/new">File an issue</a>
       </li>
     </ul>
   </div>

--- a/_includes/navigation/footer-desktop.html
+++ b/_includes/navigation/footer-desktop.html
@@ -56,7 +56,7 @@
         <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
       </li>
       <li>
-        <a href="https://github.com/18F/18f.gsa.gov/issues/new">File an issue</a>
+        <a href="https://github.com/18F/18f.gsa.gov/issues/new">Report a bug</a>
       </li>
     </ul>
   </div>

--- a/_includes/navigation/footer-mobile.html
+++ b/_includes/navigation/footer-mobile.html
@@ -56,7 +56,7 @@
           <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
         </li>
         <li>
-          <a href="https://github.com/18F/18f.gsa.gov/issues/new">File an issue</a>
+          <a href="https://github.com/18F/18f.gsa.gov/issues/new">Report a bug</a>
         </li>
       </ul>
     </li>

--- a/_includes/navigation/footer-mobile.html
+++ b/_includes/navigation/footer-mobile.html
@@ -56,7 +56,7 @@
           <a href="mailto:18F@gsa.gov">18F@gsa.gov</a>
         </li>
         <li>
-          <a href="https://github.com/18F/18f.gsa.gov/edit/master/{{ page.path }}">Edit on GitHub</a>
+          <a href="https://github.com/18F/18f.gsa.gov/issues/new">File an issue</a>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
Fixes issue(s) #2220 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/github-link.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/github-link)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/github-link/)

Changes proposed in this pull request:
- Remove `edit on GitHub` link
- Replace with `File an issue` link that opens a new issue in this repo

/cc @maya @gboone 
