### PR TITLE
Make focus box for post image smaller

### DIFF
--- a/_includes/tag-results.html
+++ b/_includes/tag-results.html
@@ -7,10 +7,12 @@
       <li>
         <div class="usa-width-one-whole">
           {% if post.image.size > 0 %}
-            <a class="media_link usa-width-one-whole" href="{{ post.url | prepend: site.baseurl }}" title="link to post">
-              <img src="{{ site.baseurl }}{{ post.image }}" alt="">
-              <p class="usa-sr-only">continue reading</p>
-            </a>
+            <div class="usa-width-one-whole">
+              <a class="media_link" href="{{ post.url | prepend: site.baseurl }}" title="link to post" tabindex="-1">
+                <img src="{{ site.baseurl }}{{ post.image }}" alt="">
+                <span class="usa-sr-only">Continue reading about {{ post.title }}</span>
+              </a>
+            </div>
           {% endif %}
           {% unless include.limit_metadata %}
             <span class="post-date">{{ post.date | date: "%B %-d, %Y" }}</span>
@@ -32,7 +34,8 @@
           {% unless include.limit_metadata %}
             <span class="post-tags" itemprop="keywords">
               {% for tag in post.tags %}
-                <a class="usa-label" href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}/">{{ tag }}
+                <a class="usa-label" href="{{ site.baseurl }}/{{ site.tag_dir }}/{{ tag | slugify }}/">
+                  {{ tag }}
                 </a>
               {% endfor %}
             </span>


### PR DESCRIPTION
Fixes issue(s) #2192 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/image-focus.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/image-focus)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/image-focus/)

Changes proposed in this pull request:
- Reduces the size of the focus box around post preview images
- Removes the link surrounding the image from the tab order. It is redundant (there are already two other links to 'Continue to post') and comes before the title of the post.

/cc @coreycaitlin 
