### PR TITLE
Remove deprecated tags and some markdown cleanup

### DIFF
--- a/_posts/2014-03-31-announcing-fbopen-government-opportunities-made-easier.md
+++ b/_posts/2014-03-31-announcing-fbopen-government-opportunities-made-easier.md
@@ -12,7 +12,6 @@ tags:
 - api
 - procurement
 - fbopen
-- marketplaces
 - acquisition services
 ---
 

--- a/_posts/2014-04-01-ask-us-almost-anything.md
+++ b/_posts/2014-04-01-ask-us-almost-anything.md
@@ -8,33 +8,20 @@ image:
 authors:
 - 18F
 tags:
-- outreach
 - how we work
+- events
+- presidential innovation fellows
 hero: false
 ---
 
-[GitHub for Government](https://github.com/government) did their very
-first [AMA (Ask Me
-Anything)](https://github.com/government/ask-me-anything) last week with
-[Philadelphia's Chief Data Officer, Mark
-Headd](https://github.com/government/ask-me-anything/issues/1). After
-some prodding by GitHub's Head Bureaucat, [Ben
-Balter](https://github.com/benbalter), 18F decided to use this new
-avenue to do some Q&A.
+[GitHub for Government](https://github.com/government) did their very first [AMA (Ask Me Anything)](https://github.com/government/ask-me-anything) last week with [Philadelphia's Chief Data Officer, Mark Headd](https://github.com/government/ask-me-anything/issues/1). After some prodding by GitHub's Head Bureaucat, [Ben Balter](https://github.com/benbalter), 18F decided to use this new avenue to do some Q&A.
 
-If you have questions about [18F](https://18f.gsa.gov/) or the
-[Presidential Innovation Fellows](https://wh.gov/innovationfellows)
-program, please come [ask us (almost)
-anything](https://github.com/government/ask-me-anything/issues/4)!
+If you have questions about [18F](https://18f.gsa.gov/) or the [Presidential Innovation Fellows](https://wh.gov/innovationfellows) program, please come [ask us (almost) anything](https://github.com/government/ask-me-anything/issues/4)!
 
-**18F AMA:
-[government/ask-me-anything\#4](https://github.com/government/ask-me-anything/issues/4 "18F: newly-launched initiative to bring effective, user-centric digital services to the federal government")**
+**18F AMA: [government/ask-me-anything\#4](https://github.com/government/ask-me-anything/issues/4 "18F: newly-launched initiative to bring effective, user-centric digital services to the federal government")**
 
--   [About
-    18F](https://18f.gsa.gov/18f/team/culture/2014/03/19/hello-world-we-are-18f/)
--   Who's answering? [Team 18F](https://18f.gsa.gov/#team),
-    [fellows](https://www.whitehouse.gov/innovationfellows/meet-the-fellows)
+-   [About 18F](https://18f.gsa.gov/18f/team/culture/2014/03/19/hello-world-we-are-18f/)
+-   Who's answering? [Team 18F](https://18f.gsa.gov/#team), [fellows](https://www.whitehouse.gov/innovationfellows/meet-the-fellows)
 -   [Apply to be a Presidential Innovation Fellow](https://pif.gsa.gov/)
 
-P.S. The deadline for the current fellowship application is April 7,
-2014!
+P.S. The deadline for the current fellowship application is April 7, 2014!

--- a/_posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.md
+++ b/_posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.md
@@ -12,7 +12,6 @@ tags:
 - api
 - best practices
 - user-centered design
-- partners in government
 ---
 
 Easy access to detailed tracking of processes has become more and more popular. Whether using Amazon.com, UPS, Uber or United Airlines, people expect instant feedback. They want to immediately see the status of a process upon which they depend.

--- a/_posts/2014-06-25-intro-to-apis-working-with-urls-json-apis-and-open.md
+++ b/_posts/2014-06-25-intro-to-apis-working-with-urls-json-apis-and-open.md
@@ -18,8 +18,8 @@ tags:
 - api
 - best practices
 - workshop
-- outreach
 - how we work
+- events
 
 ---
 

--- a/_posts/2014-12-22-protosketch.md
+++ b/_posts/2014-12-22-protosketch.md
@@ -2,16 +2,13 @@
 title: "Sketching with code: protosketching"
 layout: post
 date: 2015-01-06
-
 authors:
 - alan
 - robert
-
 tags:
 - collaboration tools
 - agile
 - navy reserve
-
 description: Meetings are boring. Prototypes are cool. Use the meeting to build the prototype. We call building a prototype in three hours or less "protosketching."
 excerpt: Meetings are boring. Prototypes are cool. Use the meeting to build the prototype. We call building a prototype in three hours or less "protosketching."
 

--- a/_posts/2014-12-22-protosketch.md
+++ b/_posts/2014-12-22-protosketch.md
@@ -19,135 +19,47 @@ image: /assets/blog/2014/12/protosketch.jpg
 ---
 *Giving program managers the freedom to sleep at night*
 
-Meetings are boring. Prototypes are cool. Use the meeting to
-build the prototype. We call building a prototype in three hours or less
-*protosketching*.
+Meetings are boring. Prototypes are cool. Use the meeting to build the prototype. We call building a prototype in three hours or less *protosketching*.
 
-Developers and designers working in bureaucratic organizations can astonish
-their colleagues by building clickable prototypes in a one-to-three hour
-meeting. Designers often sketch on paper and developers often prototype with
-code. We argue that you should sometimes sketch in code — protosketching.
-Being able to do this within a meeting sparks the imagination. Even if the
-protosketch is wrong, it gives you something concrete to review and elevates
-the discussion to issues of data, design, and functionality. In the words of
-Ward Cunningham,
+Developers and designers working in bureaucratic organizations can astonish their colleagues by building clickable prototypes in a one-to-three hour meeting. Designers often sketch on paper and developers often prototype with code. We argue that you should sometimes sketch in code — protosketching. Being able to do this within a meeting sparks the imagination. Even if the protosketch is wrong, it gives you something concrete to review and elevates the discussion to issues of data, design, and functionality. In the words of Ward Cunningham,
 
-> “The best way to get the right answer on the Internet is not to ask a
-question, it's to post the wrong answer.”
+> “The best way to get the right answer on the Internet is not to ask a question, it's to post the wrong answer.”
 
-Why not be wrong with your protosketch in the meeting, and turn the meeting
-into something that gives you the right answer?
+Why not be wrong with your protosketch in the meeting, and turn the meeting into something that gives you the right answer?
 
-Agile and lean methodologies focus on testing hypotheses as quickly as
-possible — **protosketching allows us to rapidly create hypotheses designed
-with engaged stakeholders.** Agile works in timeboxes called “sprints,”
-which are usually a few weeks long. Sometimes agile practitioners work even
-faster, on often but not always throwaway experiments called
-[spikes](http://www.extremeprogramming.org/rules/spike.html). Protosketching
-is just a spike limited to the timebox of a single sales, design, or
-brainstorming meeting. This short timebox guarantees that you are making a
-cheap gamble that liberates you from any commitment to try to recover the
-sunk cost of your short investment. In our experience, this immediate
-exploration is game-changing for federal agencies.
+Agile and lean methodologies focus on testing hypotheses as quickly as possible — **protosketching allows us to rapidly create hypotheses designed with engaged stakeholders.** Agile works in timeboxes called “sprints,” which are usually a few weeks long. Sometimes agile practitioners work even faster, on often but not always throwaway experiments called [spikes](http://www.extremeprogramming.org/rules/spike.html). Protosketching is just a spike limited to the timebox of a single sales, design, or brainstorming meeting. This short timebox guarantees that you are making a cheap gamble that liberates you from any commitment to try to recover the sunk cost of your short investment. In our experience, this immediate exploration is game-changing for federal agencies.
 
-The goal isn't to produce anything close to production-ready software, but
-rather to use a clickable prototype to get closer to user needs and
-functions. Since the goal is to learn about stakeholder understanding of
-user needs, there shouldn't be much thought given to choosing programming
-languages, databases, or design frameworks. Just go with what will quickly
-get a clickable page into the hands of the end-user in order to get
-feedback, because the protosketch is just part of the process.
+The goal isn't to produce anything close to production-ready software, but rather to use a clickable prototype to get closer to user needs and functions. Since the goal is to learn about stakeholder understanding of user needs, there shouldn't be much thought given to choosing programming languages, databases, or design frameworks. Just go with what will quickly get a clickable page into the hands of the end-user in order to get feedback, because the protosketch is just part of the process.
 
 ## Why to protosketch in the government
 
 The fundamental reason to protosketch is to have fewer sleepless nights.
 
-Agile and lean methodologies promote continuous learning. This fundamentally
-reduces risk by allowing bad ideas to be tested by the end-user and
-discarded quickly—rather than surviving deep into the final production
-process. Protosketching demonstrates this in a shorter time frame.
+Agile and lean methodologies promote continuous learning. This fundamentally reduces risk by allowing bad ideas to be tested by the end-user and discarded quickly—rather than surviving deep into the final production process. Protosketching demonstrates this in a shorter time frame.
 
-In the federal government, this speed has historically been an unattainable
-experience. Many agencies do not have the technical resources in-house. They
-may wish to employ outside resources to perform this experimentation and
-testing, but may be stymied by the delay imposed of the procurement process.
+In the federal government, this speed has historically been an unattainable experience. Many agencies do not have the technical resources in-house. They may wish to employ outside resources to perform this experimentation and testing, but may be stymied by the delay imposed of the procurement process.
 
-Imagine how liberating it would be to many executives and program managers
-to have protosketching services available on demand to test out ideas in a
-single hour or afternoon as part of a user-centered design process? This may
-prevent months of errant planning caused by not interacting with the
-end-user early enough in the program. More importantly, it may allow
-opportunities to be discovered that might not have been discovered until
-years later.
+Imagine how liberating it would be to many executives and program managers to have protosketching services available on demand to test out ideas in a single hour or afternoon as part of a user-centered design process? This may prevent months of errant planning caused by not interacting with the end-user early enough in the program. More importantly, it may allow opportunities to be discovered that might not have been discovered until years later.
 
-Every agency deserves this ability to realize its mission more effectively
-and to save taxpayer money.
+Every agency deserves this ability to realize its mission more effectively and to save taxpayer money.
 
 ## De-risking the procurement process
 
-In a typical procurement setting, prospective contractors might be the most
-technical voices in the room, creating a risk of technical asymmetry. A
-protosketcher, whether they are from [18F
-Consulting]({{ site.baseurl }}/consulting) or from within the agency,
-should act as a trusted technical adviser to the program manager. A meeting
-with a protosketcher will significantly mitigate any asymmetry in technical
-expertise between the agency and prospective contractors by demonstrating
-technical possibilities and the ease of various solutions. The program
-manager will better understand what they want to get out of an RFP and be
-empowered to write on based on a more certain understanding of the problem
-and possible solutions. Contractors will find this specificity and clarity
-refreshing and produce lower, more accurate bids. The American people will
-be rewarded with less vendor lock-in, more cost effective maintenance, and
-effectively evolving digital services. Oh and better digital experiences!
+In a typical procurement setting, prospective contractors might be the most technical voices in the room, creating a risk of technical asymmetry. A protosketcher, whether they are from [18F Consulting]({{ site.baseurl }}/consulting) or from within the agency, should act as a trusted technical adviser to the program manager. A meeting with a protosketcher will significantly mitigate any asymmetry in technical expertise between the agency and prospective contractors by demonstrating technical possibilities and the ease of various solutions. The program manager will better understand what they want to get out of an RFP and be empowered to write on based on a more certain understanding of the problem and possible solutions. Contractors will find this specificity and clarity refreshing and produce lower, more accurate bids. The American people will be rewarded with less vendor lock-in, more cost effective maintenance, and effectively evolving digital services. Oh and better digital experiences!
 
 ## Protosketching in the wild: actual experience
 
-At [18F](https://18f.gsa.gov/), we have protosketched for prospective
-clients in three meetings and also for our audience at the last 18F Demo
-Day.
+At [18F](https://18f.gsa.gov/), we have protosketched for prospective clients in three meetings and also for our audience at the last 18F Demo Day.
 
-At a three-hour meeting with the Department of Labor (DOL), we protosketched a
-mobile application for Investigators to use in the field. With great
-foresight, the DOL had brought actual Investigators (the end-user for this
-case) into the meeting. The DOL was seeking to streamline workflows for
-their investigators who often found themselves spending precious time on
-redundant and often non-user-friendly data entry. For example, it was common
-for investigators to keep track of data on a highly specialized spreadsheet
-template which could later be uploaded to a DOL case management system.
-While one member of the 18F team discussed project goals and explained the
-benefits of a modular, API-driven system architecture, the other 18F staff
-members protosketched a user interface made possible by such an
-architecture.
+At a three-hour meeting with the Department of Labor (DOL), we protosketched a mobile application for Investigators to use in the field. With great foresight, the DOL had brought actual Investigators (the end-user for this case) into the meeting. The DOL was seeking to streamline workflows for their investigators who often found themselves spending precious time on redundant and often non-user-friendly data entry. For example, it was common for investigators to keep track of data on a highly specialized spreadsheet template which could later be uploaded to a DOL case management system. While one member of the 18F team discussed project goals and explained the benefits of a modular, API-driven system architecture, the other 18F staff members protosketched a user interface made possible by such an architecture.
 
-Several investigators at the meeting were able to provide dynamic feedback
-as they interacted with the mobile application on their own smartphones. A
-technology stack comprised of Ruby, Sinatra, and Bootstrap made it easy to
-rapidly create clickable forms and sortable tables. Because Bootstrap is a
-responsive layout, the protosketches were just as compelling on the
-investigators’ mobile phones as they were on the projector. This was an
-initial step in design process which led to wireframes and more extensive
-prototypes.
+Several investigators at the meeting were able to provide dynamic feedback as they interacted with the mobile application on their own smartphones. A technology stack comprised of Ruby, Sinatra, and Bootstrap made it easy to rapidly create clickable forms and sortable tables. Because Bootstrap is a responsive layout, the protosketches were just as compelling on the investigators’ mobile phones as they were on the projector. This was an initial step in design process which led to wireframes and more extensive prototypes.
 
-We recently did a very similar three-hour session with the U.S. Navy Reserve. In a
-world where agencies are used to having to go through a lengthy procurement
-process and a requirements writing phase in order to see any design or
-prototype at all, this is a game-changer.
+We recently did a very similar three-hour session with the U.S. Navy Reserve. In a world where agencies are used to having to go through a lengthy procurement process and a requirements writing phase in order to see any design or prototype at all, this is a game-changer.
 
-<img src="{{ site.baseurl }}/assets/blog/2014/12/protosketch.jpg" class="align-left" alt="A
-protosketch running on a phone" />
+<img src="{{ site.baseurl }}/assets/blog/2014/12/protosketch.jpg" class="align-left" alt="A protosketch running on a phone" />
 
-At another protosketch meeting, this time with GSA Human Resources, we
-protosketched a human resources dashboard which simulated combining several
-siloed data sources. We [built](https://github.com/18F/aaa-exp-proto1) a
-[sample dashboard](https://18f.github.io/aaa-exp-proto1/) with
-[jQuery](http://jquery.com/), static [JSON](http://www.json.org/) files,
-[Bootstrap](http://getbootstrap.com/), and were able to preview it via
-[GitHub pages](https://pages.github.com/). As the sample dashboard was
-displayed on the projector, participants quickly pointed out fields that
-they’d like to see included, excluded, or modified. Even better than that,
-though, was the lively discussion between participants. Seeing a clickable,
-interactive demo helped them test out hypotheses as a team about the
-features they needed most.
+At another protosketch meeting, this time with GSA Human Resources, we protosketched a human resources dashboard which simulated combining several siloed data sources. We [built](https://github.com/18F/aaa-exp-proto1) a [sample dashboard](https://18f.github.io/aaa-exp-proto1/) with [jQuery](http://jquery.com/), static [JSON](http://www.json.org/) files, [Bootstrap](http://getbootstrap.com/), and were able to preview it via [GitHub pages](https://pages.github.com/). As the sample dashboard was displayed on the projector, participants quickly pointed out fields that they’d like to see included, excluded, or modified. Even better than that, though, was the lively discussion between participants. Seeing a clickable, interactive demo helped them test out hypotheses as a team about the features they needed most.
 
 ## Summary of our technique: reuse on steroids
 
@@ -155,18 +67,8 @@ Do these successes prove how smart we are?
 
 No.
 
-They prove that we know how to reuse work that others have spent
-person-years, sometimes person-centuries, making freely available for
-everyone to reuse (see our upcoming post, “How to Protosketch”). We are also
-reusing our own experience with these systems. We are practiced at quickly
-installing, configuring, and in some cases, programming, powerful systems.
+They prove that we know how to reuse work that others have spent person-years, sometimes person-centuries, making freely available for everyone to reuse (see our upcoming post, “How to Protosketch”). We are also reusing our own experience with these systems. We are practiced at quickly installing, configuring, and in some cases, programming, powerful systems.
 
 ## Conclusion
 
-If you are a leading a project, ask for a protosketch. If you are a
-developer, learn to protosketch. Create imagination-sparking moments, *in
-the meeting*. Give your team the freedom to play — with ideas, code and
-data. Minimize risk to your project and the American taxpayer by quickly
-testing ideas with the end-user in a vivid, clickable form. Develop and
-evaluate hypotheses on the fly. Protosketch to delight your team, your boss,
-and your customers.  
+If you are leading a project, ask for a protosketch. If you are a developer, learn to protosketch. Create imagination-sparking moments, *in the meeting*. Give your team the freedom to play — with ideas, code and data. Minimize risk to your project and the American taxpayer by quickly testing ideas with the end-user in a vivid, clickable form. Develop and evaluate hypotheses on the fly. Protosketch to delight your team, your boss, and your customers.

--- a/_posts/2015-03-13-how-to-protosketch.md
+++ b/_posts/2015-03-13-how-to-protosketch.md
@@ -3,7 +3,6 @@ title: How to protosketch
 date: '2015-03-13'
 layout: post
 image: /assets/blog/2014/12/protosketch.jpg
-
 tags:
 - collaboration tools
 - agile

--- a/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
+++ b/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
@@ -7,7 +7,6 @@ image: /assets/blog/govtechhack/IMG_4015.JPG
 tags: 
 - events
 - hackathons
-- outreach
 - open source
 
 authors:

--- a/_posts/2015-04-21-hackathons-not-just-for-folks-who-code.md
+++ b/_posts/2015-04-21-hackathons-not-just-for-folks-who-code.md
@@ -7,7 +7,6 @@ authors:
 tags:
 - hackathons
 - events
-- outreach
 - how we work
 - tools you can use
 

--- a/_posts/2015-05-12-announcing-the-calc-tool.md
+++ b/_posts/2015-05-12-announcing-the-calc-tool.md
@@ -6,7 +6,7 @@ authors:
 - brethauer
 tags:
 - procurement
-- gsa
+- general services administration
 - acquisition services
 - calc
 - agency work

--- a/_posts/2015-05-18-myusa.md
+++ b/_posts/2015-05-18-myusa.md
@@ -5,7 +5,6 @@ layout: post
 authors:
 - kate
 tags:
-- our projects
 - security
 - myusa
 excerpt: "If you’re a small-business owner, a veteran, or simply a person

--- a/_posts/2015-06-02-taking-the-pulse-of-the-federal-governments-web-presence.md
+++ b/_posts/2015-06-02-taking-the-pulse-of-the-federal-governments-web-presence.md
@@ -9,7 +9,6 @@ authors:
 - jtindel
 tags:
 - pulse.cio.gov
-- analytics
 - https
 - security
 - best practices

--- a/_posts/2015-06-11-18f-at-national-civic-hacking-day.md
+++ b/_posts/2015-06-11-18f-at-national-civic-hacking-day.md
@@ -10,7 +10,6 @@ authors:
 tags:
 - events
 - hackathons
-- outreach
 
 excerpt: "Last weekend, thousands of civic hackers from across the country came
 together for the National Day of Civic Hacking to better their communities. We love this kind of stuff, and couldn't help but get involved."

--- a/_posts/2015-07-16-introduction-to-https-webinar.md
+++ b/_posts/2015-07-16-introduction-to-https-webinar.md
@@ -7,7 +7,6 @@ authors:
 - gray
 tags:
 - https
-- partners in government
 - security
 - tools you can use
 - video

--- a/_posts/2015-09-01-govconnect-launch.md
+++ b/_posts/2015-09-01-govconnect-launch.md
@@ -6,157 +6,53 @@ authors:
 - bradnunnally
 - sarah
 tags:
-- our projects
 - agency work
-- partners in government
 
 excerpt: "We recently began our partnership with the Office of Personnel Management (OPM) on the GovConnect initiative, which helps agencies create a culture of excellence based on collaboration and teamwork."
 description: "We recently began our partnership with the Office of Personnel Management (OPM) on the GovConnect initiative, which helps agencies create a culture of excellence based on collaboration and teamwork."
 image:
 ---
 
-We recently began our partnership with the Office of Personnel
-Management (OPM) on the [GovConnect
-initiative](http://www.fedtechmagazine.com/article/2014/10/govconnect-makes-employee-passion-projects-reality),
-which helps agencies create a culture of excellence based on
-collaboration and teamwork.
+We recently began our partnership with the Office of Personnel Management (OPM) on the [GovConnect initiative](http://www.fedtechmagazine.com/article/2014/10/govconnect-makes-employee-passion-projects-reality), which helps agencies create a culture of excellence based on collaboration and teamwork.
 
-To develop federal talent that can work and learn across boundaries, we
-need new practices and technologies. GovConnect helps agencies test and
-scale these approaches so we can build a 21st-century system that will
-better respond to demands and handle cross-agency program and policy
-challenges. It will do all this without the unnecessary limitation of
-organizational silos by implementing a new model of a mobile, agile,
-innovative, and skilled federal workforce. The OPM team, which includes
-staff trained by the OPM Innovation Lab and Stanford’s d.school, will
-develop this model in collaboration with other agencies.
+To develop federal talent that can work and learn across boundaries, we need new practices and technologies. GovConnect helps agencies test and scale these approaches so we can build a 21st-century system that will better respond to demands and handle cross-agency program and policy challenges. It will do all this without the unnecessary limitation of organizational silos by implementing a new model of a mobile, agile, innovative, and skilled federal workforce. The OPM team, which includes staff trained by the OPM Innovation Lab and Stanford’s d.school, will develop this model in collaboration with other agencies.
 
-18F signed onto this initiative to innovate the federal workforce, a
-goal that complements the General Services Administration’s belief that
-long-term success requires a strong, diverse, and optimized workforce.
+18F signed onto this initiative to innovate the federal workforce, a goal that complements the General Services Administration’s belief that long-term success requires a strong, diverse, and optimized workforce.
 
-We’re most well known for delivering digital services, which sometimes
-leads people to believe our team is composed purely of technologists who
-write code. However, some of our toughest challenges are understanding
-the problems facing our agency partners and the people they seek to
-positively impact. Thoroughly researching a problem can lead to new
-approaches or the identification of existing solutions that can be
-scaled or augmented with technology. Like OPM’s Innovation Lab, we
-investigate problems with a human-centered design approach, starting
-each project with a “discovery” phase to deeply understand how people
-work, the challenges they face, and what their needs are.
+We’re most well known for delivering digital services, which sometimes leads people to believe our team is composed purely of technologists who write code. However, some of our toughest challenges are understanding the problems facing our agency partners and the people they seek to positively impact. Thoroughly researching a problem can lead to new approaches or the identification of existing solutions that can be scaled or augmented with technology. Like OPM’s Innovation Lab, we investigate problems with a human-centered design approach, starting each project with a “discovery” phase to deeply understand how people work, the challenges they face, and what their needs are.
 
-The discovery phase includes a mix of face-to-face interviews, remote
-collaboration, shadowing, and participatory workshops intended to engage
-the user with the design problem. We do all this in collaboration with
-our agency partners. Throughout discovery, design, and development, we
-work to validate our assumptions by always including the people who will
-use the services. We’re excited to work with OPM, which has been an
-active leader of the federal “design thinking” community with their
-Innovation Lab program.
+The discovery phase includes a mix of face-to-face interviews, remote collaboration, shadowing, and participatory workshops intended to engage the user with the design problem. We do all this in collaboration with our agency partners. Throughout discovery, design, and development, we work to validate our assumptions by always including the people who will use the services. We’re excited to work with OPM, which has been an active leader of the federal “design thinking” community with their Innovation Lab program.
 
-The GovConnect initiative is a fascinating laboratory for research into
-the challenges of developing and attracting talent in the federal
-workforce. Our current government model was designed for a different
-kind of work and predates current technology and management practices.
-GovConnect is applying human-centered design methods to reframe the
-experience of working and learning in the federal government.
+The GovConnect initiative is a fascinating laboratory for research into the challenges of developing and attracting talent in the federal workforce. Our current government model was designed for a different kind of work and predates current technology and management practices. GovConnect is applying human-centered design methods to reframe the experience of working and learning in the federal government.
 
 ## The story so far
 
-One goal of
-[President Obama’s second-term management agenda](https://www.whitehouse.gov/blog/2013/07/08/smarter-more-innovative-government-american-people)
-is to improve the effectiveness of the federal workforce - a workforce
-that makes up almost 3 million civilian employees across the world.
-Reaching this goal will increase employee engagement, raise
-productivity, and potentially attract a new generation of public
-servants.
+One goal of [President Obama’s second-term management agenda](https://www.whitehouse.gov/blog/2013/07/08/smarter-more-innovative-government-american-people) is to improve the effectiveness of the federal workforce - a workforce that makes up almost 3 million civilian employees across the world. Reaching this goal will increase employee engagement, raise productivity, and potentially attract a new generation of public servants.
 
-Several successful initiatives provided early proof of a new
-collaborative model of workforce development: [Open Opportunities](http://www.digitalgov.gov/join-digitalgov/open-opportunities-in-digitalgov/)
-(developed by GSA’s Office of Citizen Services and Innovative
-Technologies),
-the Environmental Protection Agency’s (EPA) [Skills
-Marketplace](http://www.fedmanager.com/news/2063-epa-professional-development),
-the White House’s [Innovation
-Toolkit](https://www.whitehouse.gov/blog/2014/12/02/designing-citizen-science-and-crowdsourcing-toolkit-federal-government),
-and the Department of Housing and Urban Development's [Innovation
-Time](http://www.washingtonpost.com/politics/federal_government/engaging-new-employees-to-improve-huds-workplace-and-operations/2013/06/24/8d442838-dd20-11e2-bd83-e99e43c336ed_story.html).
-Each of these efforts seek to tap the passion, energy, and ingenuity of
-federal employees and allow people to develop their professional skills
-by tackling problems that face federal agencies.
+Several successful initiatives provided early proof of a new collaborative model of workforce development: [Open Opportunities](http://www.digitalgov.gov/join-digitalgov/open-opportunities-in-digitalgov/) (developed by GSA’s Office of Citizen Services and Innovative Technologies), the Environmental Protection Agency’s (EPA) [Skills Marketplace](http://www.fedmanager.com/news/2063-epa-professional-development), the White House’s [Innovation Toolkit](https://www.whitehouse.gov/blog/2014/12/02/designing-citizen-science-and-crowdsourcing-toolkit-federal-government), and the Department of Housing and Urban Development's [Innovation Time](http://www.washingtonpost.com/politics/federal_government/engaging-new-employees-to-improve-huds-workplace-and-operations/2013/06/24/8d442838-dd20-11e2-bd83-e99e43c336ed_story.html). Each of these efforts seek to tap the passion, energy, and ingenuity of federal employees and allow people to develop their professional skills by tackling problems that face federal agencies.
 
-Thanks to the success of these initiatives and the passion of our
-partners at the Office of Personnel Management (OPM), GovConnect was
-born. GovConnect is an agile workforce initiative sponsored by OPM and
-co-led by EPA to encourage agencies to think differently about work, one
-that develops and connects the federal workforce, encourages innovation,
-and helps develop critical skills and build professional networks across
-the government to where and when they’re needed. GovConnect is a network
-of existing and new programs that seek to achieve this goal.
+Thanks to the success of these initiatives and the passion of our partners at the Office of Personnel Management (OPM), GovConnect was born. GovConnect is an agile workforce initiative sponsored by OPM and co-led by EPA to encourage agencies to think differently about work, one that develops and connects the federal workforce, encourages innovation, and helps develop critical skills and build professional networks across the government to where and when they’re needed. GovConnect is a network of existing and new programs that seek to achieve this goal.
 
 ## GovConnect phase one
 
-In April 2014, OPM's [call for
-participation](https://www.chcoc.gov/content/govconnect-expo-follow-identifying-volunteer-pilot-agencies)
-led to the selection of a cohort of pilot agencies to explore activating
-their own workforce through new approaches to work. Based on interviews
-with existing programs, the GovConnect team identified three models:
+In April 2014, OPM's [call for participation](https://www.chcoc.gov/content/govconnect-expo-follow-identifying-volunteer-pilot-agencies) led to the selection of a cohort of pilot agencies to explore activating their own workforce through new approaches to work. Based on interviews with existing programs, the GovConnect team identified three models:
 
-**GovProject** — Employees can develop professional skills and expertise
-on a part-time basis (for example, up to 20 percent time) to support
-project opportunities within the employee’s agency or in another
-government agency. This model would also support the rapid deployment of
-cross-agency tiger teams to respond to complex problems or
-time-sensitive needs.
+**GovProject** — Employees can develop professional skills and expertise on a part-time basis (for example, up to 20 percent time) to support project opportunities within the employee’s agency or in another government agency. This model would also support the rapid deployment of cross-agency tiger teams to respond to complex problems or time-sensitive needs.
 
-**GovStart** — Employees can work on innovative initiatives on a
-part-time basis (for example, up to 20 percent time) and develop
-professional networks within and across agencies. These micro-projects
-are grassroots employee driven as opposed to management driven.
+**GovStart** — Employees can work on innovative initiatives on a part-time basis (for example, up to 20 percent time) and develop professional networks within and across agencies. These micro-projects are grassroots employee driven as opposed to management driven.
 
-**GovCloud** — Employees are hired by one agency and are detailed out to
-agencies on a project-by-project basis to address critical skills gaps.
-GovCloud employees may work on one project at a time or work on multiple
-projects at once.
+**GovCloud** — Employees are hired by one agency and are detailed out to agencies on a project-by-project basis to address critical skills gaps. GovCloud employees may work on one project at a time or work on multiple projects at once.
 
-For the past year, pilot agencies have made progress on diverse
-initiatives. A GovConnect pilot does not require technology to get
-started and could be as simple as a conference room with whiteboards and
-sticky notes, or be driven by Google Forms and email, or include
-postings on a pre-existing WordPress blog or SharePoint site.
+For the past year, pilot agencies have made progress on diverse initiatives. A GovConnect pilot does not require technology to get started and could be as simple as a conference room with whiteboards and sticky notes, or be driven by Google Forms and email, or include postings on a pre-existing WordPress blog or SharePoint site.
 
-In addition, some mentor programs have flourished. EPA’s Skills
-Marketplace has become established within the EPA as an effective
-resource for managers. Open Opportunities has grown dramatically and is
-now open to all federal employees.
+In addition, some mentor programs have flourished. EPA’s Skills Marketplace has become established within the EPA as an effective resource for managers. Open Opportunities has grown dramatically and is now open to all federal employees.
 
-18F has developed the Midas software platform that fuels the Open
-Opportunities program. We believe that many of the successful pilots
-could be scaled with software and will use the research to improve the
-Midas platform. However, the GovConnect primary researcher will work
-separately from the Midas team and 18F is open to learning from their
-research.
+18F has developed the Midas software platform that fuels the Open Opportunities program. We believe that many of the successful pilots could be scaled with software and will use the research to improve the Midas platform. However, the GovConnect primary researcher will work separately from the Midas team and 18F is open to learning from their research.
 
 ## What will 18F do?
 
-18F researchers have already started connecting with pilot mentors,
-pilot agencies, and private sector and nonprofit firms. The goal of this
-research is to learn what patterns of success, and failure, might exist
-and what have been the growing pains of successful initiatives. Initial
-research will be conducted in the form of one-on-one interviews, as well
-as reviewing metrics and other research already conducted by the
-GovConnect teams. By working directly with agencies who are developing
-pilots, have launched successful programs, or who have run into barriers
-to adoption, 18F will take a human-centered approach to developing the
-next step in the GovConnect solution.
+18F researchers have already started connecting with pilot mentors, pilot agencies, and private sector and nonprofit firms. The goal of this research is to learn what patterns of success, and failure, might exist and what have been the growing pains of successful initiatives. Initial research will be conducted in the form of one-on-one interviews, as well as reviewing metrics and other research already conducted by the GovConnect teams. By working directly with agencies who are developing pilots, have launched successful programs, or who have run into barriers to adoption, 18F will take a human-centered approach to developing the next step in the GovConnect solution.
 
-The outcome of this discovery phase will be the production of a Starter
-Kit with proven techniques from other agencies, including non-technical,
-real-world approaches as well as technical solutions that can help
-programs scale.
+The outcome of this discovery phase will be the production of a Starter Kit with proven techniques from other agencies, including non-technical, real-world approaches as well as technical solutions that can help programs scale.
 
-If you’d like to learn more about this research, or if you have
-information to share from potential initiatives of your own, feel free
-to contact us at
-[18f-govconnect@gsa.gov](mailto:18f-govconnect@gsa.gov).
+If you’d like to learn more about this research, or if you have information to share from potential initiatives of your own, feel free to contact us at [18f-govconnect@gsa.gov](mailto:18f-govconnect@gsa.gov).

--- a/_posts/2015-09-09-how-a-two-day-spring-moved-an-agency-twenty-years-forward.md
+++ b/_posts/2015-09-09-how-a-two-day-spring-moved-an-agency-twenty-years-forward.md
@@ -13,79 +13,44 @@ tags:
 - workshop
 - culture change
 - transformation services
+- department of labor
 
-
-excerpt: "At 18F Consulting, we experiment with ways to empower agencies to build cost-efficient, excellent
-digital solutions. Recently we partnered with the Department of Labor’s
-Wage and Hour Division to run a two day “Design/Dev Agile Sprint” to help them modernize their Field Operations Handbook."
-description: "At 18F Consulting, we experiment with ways to empower agencies to build cost-efficient, excellent
-digital solutions. Recently we partnered with the Department of Labor’s
-Wage and Hour Division to run a two day “Design/Dev Agile Sprint” to help them modernize their Field Operations Handbook."
+excerpt: "At 18F Consulting, we experiment with ways to empower agencies to build cost-efficient, excellent digital solutions. Recently we partnered with the Department of Labor’s Wage and Hour Division to run a two day “Design/Dev Agile Sprint” to help them modernize their Field Operations Handbook."
+description: "At 18F Consulting, we experiment with ways to empower agencies to build cost-efficient, excellent digital solutions. Recently we partnered with the Department of Labor’s Wage and Hour Division to run a two day “Design/Dev Agile Sprint” to help them modernize their Field Operations Handbook."
 image: /assets/blog/labor-handbook/foh-screenshot.jpg
 redirect_from:
 - /2015/09/09/how-a-two-day-spring-moved-an-agency-twenty-years-forward/
 ---
 
-At 18F Consulting, we experiment with [ways to empower agencies
-]({{ site.baseurl }}/consulting/)to build cost-efficient, excellent
-digital solutions. Recently we partnered with the Department of Labor’s
-Wage and Hour Division (WHD) to run a two day “Design/Dev Agile Sprint.”
+At 18F Consulting, we experiment with [ways to empower agencies ]({{ site.baseurl }}/consulting/)to build cost-efficient, excellent digital solutions. Recently we partnered with the Department of Labor’s Wage and Hour Division (WHD) to run a two day “Design/Dev Agile Sprint.”
 
 ## Background: Investigators in Wage and Hour Division
 
-The Department of Labor’s Wage and Hour Division is responsible for
-enforcing a wide variety of federal labor laws, including those
-requiring the minimum wage, overtime, child labor protections, and
-family and medical leave laws. Over 1,000 investigators, working out of
-local offices nationwide, and often literally in the field, investigate
-employers to determine compliance with these laws. To gather the
-information they need, they travel to a wide variety of businesses,
-including farms, restaurants, hotels, retail shops, construction sites,
-hospitals, and many others.
+The Department of Labor’s Wage and Hour Division is responsible for enforcing a wide variety of federal labor laws, including those requiring the minimum wage, overtime, child labor protections, and family and medical leave laws. Over 1,000 investigators, working out of local offices nationwide, and often literally in the field, investigate employers to determine compliance with these laws. To gather the information they need, they travel to a wide variety of businesses, including farms, restaurants, hotels, retail shops, construction sites, hospitals, and many others.
 
-While conducting investigations, Labor employees often turn to the Field
-Operations Handbook (what they call the FOH) for guidance. The handbook
-is an operations manual that provides interpretations of the law,
-procedures for conducting investigations, and general administrative
-guidance. It reflects policies established through changes in
-legislation, regulations, significant court decisions, and the decisions
-and opinions of the WHD Administrator. The handbook is a critical tool
-for WHD staff.
+While conducting investigations, Labor employees often turn to the Field Operations Handbook (what they call the FOH) for guidance. The handbook is an operations manual that provides interpretations of the law, procedures for conducting investigations, and general administrative guidance. It reflects policies established through changes in legislation, regulations, significant court decisions, and the decisions and opinions of the WHD Administrator. The handbook is a critical tool for WHD staff.
 
 ---
 
-<p style="text-align:center;"><strong>How might we help DOL’s Wage Hour Division move forward with a quick win that would demonstrate what modernization can mean in a
-meaningful, iterative way?</strong></p>
+<p style="text-align:center;"><strong>How might we help DOL’s Wage Hour Division move forward with a quick win that would demonstrate what modernization can mean in a meaningful, iterative way?</strong></p>
 
 ---
 
 
 ![Two investigators and an 18F user researcher who is shadowing them]({{site.baseurl}}/assets/blog/labor-handbook/field-team.jpg)
-*Two investigators (left and right) and an 18F user researcher (center)
-who is shadowing them to understand how investigators use paper and
-digital methods to accomplish their job.*
+*Two investigators (left and right) and an 18F user researcher (center) who is shadowing them to understand how investigators use paper and digital methods to accomplish their job.*
 
 ## The current landscape: Publishing in the 21st century
 
-The handbook consists of four five-inch-thick binders containing printed
-and photocopied pages. These binders are replicated and distributed
-across numerous regional and local offices. The handbook also exists as
-online PDFs, where each chapter or subsection is published as its own
-PDF. With these two options, investigators don’t have an easy way to
-quickly access and search for much-needed information that helps them
-complete investigations, particularly when they’re working out in the
-field.
+The handbook consists of four five-inch-thick binders containing printed and photocopied pages. These binders are replicated and distributed across numerous regional and local offices. The handbook also exists as online PDFs, where each chapter or subsection is published as its own PDF. With these two options, investigators don’t have an easy way to quickly access and search for much-needed information that helps them complete investigations, particularly when they’re working out in the field.
 
 ![Three large binders of handbook materials]({{site.baseurl}}/assets/blog/labor-handbook/handbook.jpg)
 
 ## The challenge: How to move this project forward?
 
-The division's modernization team wanted to bring the handbook into the
-21st century by placing it online and providing robust search
-capabilities. This was not a radical idea.
+The division's modernization team wanted to bring the handbook into the 21st century by placing it online and providing robust search capabilities. This was not a radical idea.
 
-Departments across the federal government often operate under three
-constraints that can make these projects a challenge:
+Departments across the federal government often operate under three constraints that can make these projects a challenge:
 
 -   Lack of internal design and development staff dedicated to prototype or solve problems.
 
@@ -93,14 +58,7 @@ constraints that can make these projects a challenge:
 
 -   Internal teams which may lack the time, tech literacy, or processes in place to support change. How do you support change you don’t quite understand?
 
-18F Consulting is already working with the division's modernization team
-on a much larger effort — the incremental modernization of an aging
-management and investigation system. While that was underway, we
-wondered, “How might we help the division move forward with a quick win
-that would demonstrate what modernization can mean in a meaningful,
-iterative way?” With the guidance of Tom Giancola, a WHD investigator,
-and other WHD stakeholders, we chose to build a proof of concept for
-modernizing the handbook.
+18F Consulting is already working with the division's modernization team on a much larger effort — the incremental modernization of an aging management and investigation system. While that was underway, we wondered, “How might we help the division move forward with a quick win that would demonstrate what modernization can mean in a meaningful, iterative way?” With the guidance of Tom Giancola, a WHD investigator, and other WHD stakeholders, we chose to build a proof of concept for modernizing the handbook.
 
 At 18F Consulting, **“Prove by doing” is our motto.**
 
@@ -126,9 +84,7 @@ In this two day sprint, about eight of us gathered to:
 
 ## Tuesday morning: Kick off!
 
-We facilitated a two-hour kick-off meeting (sometimes called an
-Inception). It got the group aligned around the problem and to agree on
-a plan moving forward.
+We facilitated a two-hour kick-off meeting (sometimes called an Inception). It got the group aligned around the problem and to agree on a plan moving forward.
 
 ![The 18F and Labor team writes notes up on a large white board]({{site.baseurl}}/assets/blog/labor-handbook/group-1.jpg)
 *Kick off (Inception)*
@@ -147,21 +103,13 @@ During this Inception we:
 
 ## Tuesday afternoon: Start to build
 
-The designer, developers, product owner, and investigators (our primary
-users) hunkered down in a work room to make the first-ever, living,
-modern digital version of the Field Operations Handbook (FOH)!
+The designer, developers, product owner, and investigators (our primary users) hunkered down in a work room to make the first-ever, living, modern digital version of the Field Operations Handbook (FOH)!
 
-We created an ad hoc project board to track: Backlog, Current, In
-Testing/Review, Finished. We used sticky notes to write [user
-stories](http://en.wikipedia.org/wiki/User_story) and the wall of our
-workspace to place the sticky note in the correct column as it
-progressed. This helped the group understand our priorities for the two
-days we had and to know at any time the work in progress.
+We created an ad hoc project board to track: Backlog, Current, In Testing/Review, Finished. We used sticky notes to write [user stories](http://en.wikipedia.org/wiki/User_story) and the wall of our workspace to place the sticky note in the correct column as it progressed. This helped the group understand our priorities for the two days we had and to know at any time the work in progress.
 
 We used this common user story format:
 
-As a \_\_\_\_\_\_\_\_\_\_, I want \_\_\_\_\_\_\_\_\_\_\_\_, so that
-\_\_\_\_\_\_\_\_\_\_\_\_\_.
+As a \_\_\_\_\_\_\_\_\_\_, I want \_\_\_\_\_\_\_\_\_\_\_\_, so that \_\_\_\_\_\_\_\_\_\_\_\_\_.
 
 Examples of our user stories:
 
@@ -176,18 +124,9 @@ Examples of our user stories:
 -   As an investigator, I want the FOH to be easy to read because past methods have been hard to read. *(provide good version 1 typography and design of this online resource)*
 
 ![Developers, investigators, and product owners work together on day 2. The project's progress boards are taped to the windows.]({{site.baseurl}}/assets/blog/labor-handbook/group-2.jpg)
-*Day 2 of the team working out of the 18F common space. Developers on
-the left. Investigators (users) and product owners talking about needs
-on the right. Taped to the windows are the progress boards (Backlog,
-Current, Done).*
+*Day 2 of the team working out of the 18F common space. Developers on the left. Investigators (users) and product owners talking about needs on the right. Taped to the windows are the progress boards (Backlog, Current, Done).*
 
-Tom, the product owner had already used optical character recognition
-(OCR) software to convert 100s of PDFs into MS Word documents. Microsoft
-styles and headings were applied to the content to begin to structure
-the data. (Aside: this is a perfect example of using the tools you know
-best to move a project forward!) With that in hand, our developer
-validated the technical feasibility of converting those Word documents
-to HTML pages that could be searched using Elasticsearch.
+Tom, the product owner had already used optical character recognition (OCR) software to convert 100s of PDFs into MS Word documents. Microsoft styles and headings were applied to the content to begin to structure the data. (Aside: this is a perfect example of using the tools you know best to move a project forward!) With that in hand, our developer validated the technical feasibility of converting those Word documents to HTML pages that could be searched using Elasticsearch.
 
 By the end of Tuesday we had:
 
@@ -201,22 +140,9 @@ By the end of Tuesday we had:
 
 ### Build
 
-Coming into the sprint, we understood that one of the major constraints
-is that the handbook is created and maintained using Microsoft Word.
-Minimizing the effect on workflow was therefore a key part of any
-proposed technical solution. Fortunately, there are several open-source,
-publicly available tools that allow for automated conversion from Word
-files (.docx) into web-friendly files (.html), including
-[pandoc](http://pandoc.org/). So, first, we wrote a script that uses pandoc to automatically convert the Word files to HTML files.
+Coming into the sprint, we understood that one of the major constraints is that the handbook is created and maintained using Microsoft Word. Minimizing the effect on workflow was therefore a key part of any proposed technical solution. Fortunately, there are several open-source, publicly available tools that allow for automated conversion from Word files (.docx) into web-friendly files (.html), including [pandoc](http://pandoc.org/). So, first, we wrote a script that uses pandoc to automatically convert the Word files to HTML files.
 
-Then, to get the HTML files to be more usable, we wrote a second script
-that extracts the content from the HTML file, does some high-level
-parsing, creates a Table of Contents, establishes JSON objects for each
-part of the Chapter (along with associated metadata), loads the JSON
-objects into an Elasticsearch service, and rewrites each HTML file to
-include links to other government sources and internal links. Finally,
-the files and search results were served using NGINX as the application
-server (later, this was rewritten to work with Apache).
+Then, to get the HTML files to be more usable, we wrote a second script that extracts the content from the HTML file, does some high-level parsing, creates a Table of Contents, establishes JSON objects for each part of the Chapter (along with associated metadata), loads the JSON objects into an Elasticsearch service, and rewrites each HTML file to include links to other government sources and internal links. Finally, the files and search results were served using NGINX as the application server (later, this was rewritten to work with Apache).
 
 ---
 
@@ -226,54 +152,21 @@ server (later, this was rewritten to work with Apache).
 
 ### Design
 
-One of the great things about a cross-functional team in the same room
-for a sprint is you can use faster design tools. Instead of creating
-pixel perfect “mockups” of how navigation might work, or how a page
-might visually feel, we did quick pen sketches on paper, a rough color
-scheme in Illustrator and then went right into design and developer
-pairing. We discussed problems and opportunities on the spot and were
-empowered to move forward with our ideas.
+One of the great things about a cross-functional team in the same room for a sprint is you can use faster design tools. Instead of creating pixel perfect “mockups” of how navigation might work, or how a page might visually feel, we did quick pen sketches on paper, a rough color scheme in Illustrator and then went right into design and developer pairing. We discussed problems and opportunities on the spot and were empowered to move forward with our ideas.
 
 ### Feedback
 
-Actual investigators made this sprint a success. Working with them over
-the two days, we determined the best interface copy that would be clear
-and actionable to their peers. Seconds after code was pushed to the
-staging site, we observed how they used search and understood the search
-results pages. Feedback was immediately incorporated.
+Actual investigators made this sprint a success. Working with them over the two days, we determined the best interface copy that would be clear and actionable to their peers. Seconds after code was pushed to the staging site, we observed how they used search and understood the search results pages. Feedback was immediately incorporated.
 
 ![Screenshots of the prototype for an online version of the handbook.]({{site.baseurl}}/assets/blog/labor-handbook/foh-screenshot.jpg)
-*Two days later we had a working prototype showing browsable chapters
-and a search results page.*
+*Two days later we had a working prototype showing browsable chapters and a search results page.*
 
 ## What’s next?
 
-For many of us in the design and software development profession,
-building a working prototype is not a big deal. For the dedicated civil
-servants in the federal government, it can be. Over these two days we
-demonstrated that with the right support and the right people in the
-room, ideas can be tested, iterated upon, and realized without months of
-requirements gathering, large waterfall contractual agreements, and
-other impediments.
+For many of us in the design and software development profession, building a working prototype is not a big deal. For the dedicated civil servants in the federal government, it can be. Over these two days we demonstrated that with the right support and the right people in the room, ideas can be tested, iterated upon, and realized without months of requirements gathering, large waterfall contractual agreements, and other impediments.
 
-This prototype, built over a two-day sprint, is still an internal proof
-of concept for the people responsible for improving the FOH. For
-important legal reasons, they are dedicated to ensuring the
-confidential, internal-facing guidelines are developed in a secure, yet
-accessible way. Our prototype used the public-facing portion of their
-guidelines to reduce that risk. In the next few months, they will pilot
-this with a few regions while they work on securing a development
-environment that can house the more useful internal-facing documents
-(helping government do that better is another story for another day).
-Meanwhile, for all future discussions, they have a working prototype,
-created with internal stakeholders in the room who helped build it!
+This prototype, built over a two-day sprint, is still an internal proof of concept for the people responsible for improving the FOH. For important legal reasons, they are dedicated to ensuring the confidential, internal-facing guidelines are developed in a secure, yet accessible way. Our prototype used the public-facing portion of their guidelines to reduce that risk. In the next few months, they will pilot this with a few regions while they work on securing a development environment that can house the more useful internal-facing documents (helping government do that better is another story for another day). Meanwhile, for all future discussions, they have a working prototype, created with internal stakeholders in the room who helped build it!
 
-18F and GSA are committed to being proactive federal partners and
-providing operational excellence wherever we can. By working
-hand-in-hand with the WHD team, we’ve been able to show them what’s
-possible, and have given them the basic knowledge to ask the right
-questions to help them develop solutions in a cost-effective,
-user-centered way.
+18F and GSA are committed to being proactive federal partners and providing operational excellence wherever we can. By working hand-in-hand with the WHD team, we’ve been able to show them what’s possible, and have given them the basic knowledge to ask the right questions to help them develop solutions in a cost-effective, user-centered way.
 
-If your agency has a project you’d like us to look at, please contact
-18F Consulting at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).
+If your agency has a project you’d like us to look at, please contact 18F Consulting at [inquiries18F@gsa.gov](mailto:inquiries18F@gsa.gov).

--- a/_posts/2015-09-22-usa-gov-launches-vote-usa-gov-to-help-citizens-register-and-connect-with-states.md
+++ b/_posts/2015-09-22-usa-gov-launches-vote-usa-gov-to-help-citizens-register-and-connect-with-states.md
@@ -3,8 +3,8 @@ title: USA.gov launches vote.USA.gov to help citizens register and connect with 
 authors:
 - sarahcrane
 tags:
-- partners in government
 - presidential innovation fellows
+- vote.usa.gov
 excerpt: One of the most important rights of American citizens is the right to vote. It is the foundation of our democracy, and in many ways, the basis of our government. This is why the team at USA.gov is excited to announce the launch of vote.USA.gov.
 description: Every American citizen has a right to vote but many don't know how to register. Vote.usa.gov is a website to help citizens register to vote in their state.
 image: /assets/blog/vote-usa-gov/vote.jpg

--- a/_posts/2015-09-28-web-design-standards.md
+++ b/_posts/2015-09-28-web-design-standards.md
@@ -7,8 +7,6 @@ authors:
 - maya
 - colinmacarthur
 tags:
-
-- our projects
 - web design standards
 - u.s. digital service
 - open source

--- a/_posts/2015-10-07-digital-economy-practice.md
+++ b/_posts/2015-10-07-digital-economy-practice.md
@@ -7,7 +7,6 @@ authors:
 tags:
 - transformation services
 - best practices
-- digital economy practice
 
 excerpt: "We’ve come to realize that there may be opportunities to achieve high impact in targeted areas by aligning our subject expertise with our digital expertise. To test our hypothesis, we’re launching an alpha version of our first policy vertical (or niche market) within 18F Consulting: the Digital Economy Practice."
 image: /assets/blog/digital-economy-practice/dep-graphic2.jpg

--- a/_posts/2015-10-20-digital-analytics-program-anniversary.md
+++ b/_posts/2015-10-20-digital-analytics-program-anniversary.md
@@ -10,8 +10,6 @@ tags:
 - pulse.cio.gov
 - agency work
 - digitalgov community
-- partners in government
-
 
 excerpt: "Launched just three years ago, the Digital Analytics Program (DAP) continues to drive the 2012 Digital Government Strategy’s mission to improve the citizen experience by streamlining the collection and analysis of digital analytics data on a federal government-wide scale. Today, 45 agencies — including all CFO Act agencies — have implemented the common code across more than 4,000 public-facing websites, counting 1.5 BILLION pageviews each month."
 description: "Launched just three years ago, the Digital Analytics Program (DAP) continues to drive the 2012 Digital Government Strategy’s mission to improve the citizen experience by streamlining the collection and analysis of digital analytics data on a federal government-wide scale. Today, 45 agencies — including all CFO Act agencies — have implemented the common code across more than 4,000 public-facing websites, counting 1.5 BILLION pageviews each month."
@@ -20,37 +18,15 @@ image: /assets/blog/pulse/analytics.png
 
 *This post was originally published on the [DigitalGov blog](https://www.digitalgov.gov/2015/10/20/5-factors-for-building-a-successful-government-wide-digital-analytics-program/). Marina Fox is the Digital Analytics Program Manager and Gwynne Kostin is the Director of the Digital Services Innovation Center. 18F has worked with the Digital Analytics Program to help build [analytics.usa.gov](https://analytics.usa.gov/) and [pulse.cio.gov](https://pulse.cio.gov/).*  
 
-Launched just three years ago, the [Digital Analytics Program
-(DAP)](http://www.digitalgov.gov/services/dap/) continues to drive the
-[2012 Digital Government
-Strategy’s](https://www.whitehouse.gov/sites/default/files/omb/egov/digital-government/digital-government.html#measure-performance)
-mission to improve the citizen experience by streamlining the collection
-and analysis of digital analytics data on a federal government-wide
-scale.
+Launched just three years ago, the [Digital Analytics Program (DAP)](http://www.digitalgov.gov/services/dap/) continues to drive the [2012 Digital Government Strategy’s](https://www.whitehouse.gov/sites/default/files/omb/egov/digital-government/digital-government.html#measure-performance) mission to improve the citizen experience by streamlining the collection and analysis of digital analytics data on a federal government-wide scale.
 
-[The DAP officially launched on October 15, 2012](http://gsablogs.gsa.gov/dsic/2012/10/05/digital-analytics-program-helps-agencies-measure-web-performance/)
-with a release of its first version of the government-wide Web analytics
-code. The first agency to implement DAP was the Department of Interior,
-on doi.gov. Today, 45 agencies — including all CFO Act agencies — have
-implemented the common code across more than 4,000 public-facing
-websites, counting 1.5 BILLION pageviews each month.
+[The DAP officially launched on October 15, 2012](http://gsablogs.gsa.gov/dsic/2012/10/05/digital-analytics-program-helps-agencies-measure-web-performance/) with a release of its first version of the government-wide Web analytics code. The first agency to implement DAP was the Department of Interior, on doi.gov. Today, 45 agencies — including all CFO Act agencies — have implemented the common code across more than 4,000 public-facing websites, counting 1.5 BILLION pageviews each month.
 
-The DAP has become a giant of a digital analytics implementation [on a
-federal-wide scale](http://pulse.cio.gov), bringing an unprecedented
-wealth of insight on the federal web space usage to agencies and the
-[public](http://analytics.usa.gov).
+The DAP has become a giant of a digital analytics implementation [on a federal-wide scale](http://pulse.cio.gov), bringing an unprecedented wealth of insight on the federal web space usage to agencies and the [public](http://analytics.usa.gov).
 
-With the Web analytics implementation under its belt, the DAP team is
-working to add a government-wide web [customer satisfaction survey
-tool](https://www.digitalgov.gov/services/dap/digital-analytics-program-dap-gov-wide-customer-satisfaction-survey-tool-guidance/)
-to help agencies better serve the online public. Over time, DAP will be
-the hub for the tools and training needed to propel data-driven
-decisions across the federal digital space.
+With the Web analytics implementation under its belt, the DAP team is working to add a government-wide web [customer satisfaction survey tool](https://www.digitalgov.gov/services/dap/digital-analytics-program-dap-gov-wide-customer-satisfaction-survey-tool-guidance/) to help agencies better serve the online public. Over time, DAP will be the hub for the tools and training needed to propel data-driven decisions across the federal digital space.
 
-What makes DAP a success? There are many reasons. We share five here to
-both celebrate the collaboration among agencies working to deliver the
-digital government promise to the public and as a mini-playbook for your
-own program implementations.
+What makes DAP a success? There are many reasons. We share five here to both celebrate the collaboration among agencies working to deliver the digital government promise to the public and as a mini-playbook for your own program implementations.
 
 ## The big five
 
@@ -58,172 +34,57 @@ own program implementations.
 
 #### Talk to your customers
 
-It takes a village to raise a child, and it takes a government to
-implement a government-wide program of any kind. Managing change is not
-easy, especially an organizational culture change. In the case of DAP,
-asking agencies to place a piece of code on their websites for
-federal-wide tracking initially raised eyebrows and questions. Trust had
-to be earned one user, one website at a time, so the DAP staff dedicated
-hundreds of hours speaking to the agencies, answering questions,
-addressing concerns, and providing assurance with the program.
+It takes a village to raise a child, and it takes a government to implement a government-wide program of any kind. Managing change is not easy, especially an organizational culture change. In the case of DAP, asking agencies to place a piece of code on their websites for federal-wide tracking initially raised eyebrows and questions. Trust had to be earned one user, one website at a time, so the DAP staff dedicated hundreds of hours speaking to the agencies, answering questions, addressing concerns, and providing assurance with the program.
 
-As DAP grew, we created a dedicated helpdesk to provide on-going support
-to users not just for general Q & A, but in-depth analytical and
-reporting support. [Creating custom reporting
-templates](http://www.digitalgov.gov/2015/08/06/need-actionable-analytics-reports-heres-help/)
-and helping users find relevant metrics as they try to answer business
-questions became the bulk of what the DAP helpdesk has done for the
-agencies.
+As DAP grew, we created a dedicated helpdesk to provide on-going support to users not just for general Q & A, but in-depth analytical and reporting support. [Creating custom reporting templates](http://www.digitalgov.gov/2015/08/06/need-actionable-analytics-reports-heres-help/) and helping users find relevant metrics as they try to answer business questions became the bulk of what the DAP helpdesk has done for the agencies.
 
-DAP also hosts regular monthly office hours by phone to provide program
-updates and answer any questions from our users.
+DAP also hosts regular monthly office hours by phone to provide program updates and answer any questions from our users.
 
 #### Engage your customers and get their help
 
-Encourage self-help. For any program, as the number of users grows, user
-training becomes a critical element. With limited resources to spare, we
-tapped into GSA’s [Open
-Opportunities](https://openopps.digitalgov.gov/) program to bring in
-other agencies’ Web analytics experts to train the DAP users on how to
-use the tool. This not only allowed us to expand the training program
-from just Webinars to quarterly in-person trainings with live streaming
-for remote participants, but further helped with DAP agency adoption and
-acceptance as the DAP instructors came from other agencies.
+Encourage self-help. For any program, as the number of users grows, user training becomes a critical element. With limited resources to spare, we tapped into GSA’s [Open Opportunities](https://openopps.digitalgov.gov/) program to bring in other agencies’ Web analytics experts to train the DAP users on how to use the tool. This not only allowed us to expand the training program from just Webinars to quarterly in-person trainings with live streaming for remote participants, but further helped with DAP agency adoption and acceptance as the DAP instructors came from other agencies.
 
 #### Give your customers a voice
 
-If you want your customers to talk about your product or service (and
-use it!), you have to give them a forum. The best way for us to hear
-from customers on a daily basis is via a collaboration network. We set
-up a [DAP User Online
-Forum](https://www.yammer.com/dapusergrouponlineforum), where users can
-collaborate, post questions, answer question from other users and add
-issues and ideas. The online forum is monitored and moderated daily.
+If you want your customers to talk about your product or service (and use it!), you have to give them a forum. The best way for us to hear from customers on a daily basis is via a collaboration network. We set up a [DAP User Online Forum](https://www.yammer.com/dapusergrouponlineforum), where users can collaborate, post questions, answer question from other users and add issues and ideas. The online forum is monitored and moderated daily.
 
-Yet, not everyone is outspoken, and some prefer to give feedback
-anonymously. To get those voices, DAP launched a quarterly Pulse Check
-survey with just two questions: 1) How happy are you with DAP? and 2)
-What can we do to make it better? We get more specific, timely responses
-to complement our annual customer satisfaction surveys.
+Yet, not everyone is outspoken, and some prefer to give feedback anonymously. To get those voices, DAP launched a quarterly Pulse Check survey with just two questions: 1) How happy are you with DAP? and 2) What can we do to make it better? We get more specific, timely responses to complement our annual customer satisfaction surveys.
 
 #### Establish a community of experts
 
-Don’t create in a silo. Eventually, programs have to get a buy-in from
-customers anyway, so why delay? Convening power users or experts and
-involving them in the creation and development of products or services
-leads to a better product and increases program ownership. With that in
-mind, DAP created a DAP Experts Community, pulling a group of digital
-analytics and technical experts from across the government. The DAP
-Experts Community is a great asset to the program as they consistently
-[challenge DAP to improve](http://www.digitalgov.gov/2015/08/26/analytics-pitfall-avoid-this-common-implementation-mistake/)
-and enhance data collection and analysis.
+Don’t create in a silo. Eventually, programs have to get a buy-in from customers anyway, so why delay? Convening power users or experts and involving them in the creation and development of products or services leads to a better product and increases program ownership. With that in mind, DAP created a DAP Experts Community, pulling a group of digital analytics and technical experts from across the government. The DAP Experts Community is a great asset to the program as they consistently [challenge DAP to improve](http://www.digitalgov.gov/2015/08/26/analytics-pitfall-avoid-this-common-implementation-mistake/) and enhance data collection and analysis.
 
 ### 2. Walk the walk: Empower agencies with examples on how to make data-driven decisions
 
-Talking about great data is great. However, applying the great data to
-make informed decisions is what it’s all about. While users understand
-the value and importance of Big Data in general, and DAP in particular,
-*using* the data and *applying* it to drive decisions can be
-overwhelming. “Where do I begin?” is a common question we get when
-agencies first on-board with DAP.
+Talking about great data is great. However, applying the great data to make informed decisions is what it’s all about. While users understand the value and importance of Big Data in general, and DAP in particular, *using* the data and *applying* it to drive decisions can be overwhelming. “Where do I begin?” is a common question we get when agencies first on-board with DAP.
 
-At DAP, we’ve always felt passionate about sharing lessons learned and
-demonstrating how data can be used to drive decisions. So, we write
-topic-based blogs, [trend
-analyses](http://www.digitalgov.gov/2015/10/15/gov-analytics-breakdown-1-browsers-chrome-takes-the-cake/), [benchmark](http://www.digitalgov.gov/services/dap/dap-digital-metrics-guidance-and-best-practices/)
-recommendations, [metrics guidance](http://www.digitalgov.gov/2014/06/19/the-golden-metric/),
-[methods for analyzing data](http://www.digitalgov.gov/2015/04/16/using-a-hypothesis-driven-approach-in-analyzing-and-making-sense-of-your-website-traffic-data/)
-to support agencies in integrating the use of the data into their daily
-routine. The best examples, though, come from agencies themselves,
-demonstrating how they’ve used DAP data to drive decisions, in
-[real-world](http://www.digitalgov.gov/2013/11/06/nps-gov-use-of-digital-analytics-program-beyond-the-numbers/)
-or [out-of-this world](http://www.digitalgov.gov/2013/09/17/digital-analytics-program-goes-to-the-moon/)
-scenarios.
+At DAP, we’ve always felt passionate about sharing lessons learned and demonstrating how data can be used to drive decisions. So, we write topic-based blogs, [trend analyses](http://www.digitalgov.gov/2015/10/15/gov-analytics-breakdown-1-browsers-chrome-takes-the-cake/), [benchmark](http://www.digitalgov.gov/services/dap/dap-digital-metrics-guidance-and-best-practices/) recommendations, [metrics guidance](http://www.digitalgov.gov/2014/06/19/the-golden-metric/), [methods for analyzing data](http://www.digitalgov.gov/2015/04/16/using-a-hypothesis-driven-approach-in-analyzing-and-making-sense-of-your-website-traffic-data/) to support agencies in integrating the use of the data into their daily routine. The best examples, though, come from agencies themselves, demonstrating how they’ve used DAP data to drive decisions, in [real-world](http://www.digitalgov.gov/2013/11/06/nps-gov-use-of-digital-analytics-program-beyond-the-numbers/) or [out-of-this world](http://www.digitalgov.gov/2013/09/17/digital-analytics-program-goes-to-the-moon/) scenarios.
 
 ### 3. Innovate on the fly
 
-We like to say that we’ve been flying the “plane” as we’re building it.
-To keep up with the unprecedented challenge to make a government-wide
-analytics code work across thousands of websites, the code solution must
-be innovative, creative, scalable, and
-[secure](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/).
-To achieve that, we can never stop innovating. It’s second nature.
+We like to say that we’ve been flying the “plane” as we’re building it. To keep up with the unprecedented challenge to make a government-wide analytics code work across thousands of websites, the code solution must be innovative, creative, scalable, and [secure](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/). To achieve that, we can never stop innovating. It’s second nature.
 
-Making the code “work” is not enough. The code must collect insightful
-and actionable data for all of the participating agencies agency, and
-that comes with just the right amount of customization. To ensure that
-agencies have a choice with respect to hosting the DAP solution, we
-offer [multiple code hosting
-options](http://www.digitalgov.gov/services/dap/analytics-tool-instructions/).
+Making the code “work” is not enough. The code must collect insightful and actionable data for all of the participating agencies agency, and that comes with just the right amount of customization. To ensure that agencies have a choice with respect to hosting the DAP solution, we offer [multiple code hosting options](http://www.digitalgov.gov/services/dap/analytics-tool-instructions/).
 
-Given the unprecedented scale of the program, we knew that we’d need
-outside experts to keep the solution ahead of the game. We created a
-public repository on [GitHub
-](https://github.com/digital-analytics-program/gov-wide-code)with each
-DAP web analytics code version. We invite continuous feedback from
-external technical and data experts to weigh in with suggestions and
-feedback.
+Given the unprecedented scale of the program, we knew that we’d need outside experts to keep the solution ahead of the game. We created a public repository on [GitHub ](https://github.com/digital-analytics-program/gov-wide-code)with each DAP web analytics code version. We invite continuous feedback from external technical and data experts to weigh in with suggestions and feedback.
 
 ### 4. Make data accessible inside and outside the government
 
-When DAP first came to life, users were only allowed to view their own
-agency’s website data. (Even that was ground-breaking as most had only
-seen the data for their own site and never with full access to reporting
-across the enterprise.) But, that was just a start.
+When DAP first came to life, users were only allowed to view their own agency’s website data. (Even that was ground-breaking as most had only seen the data for their own site and never with full access to reporting across the enterprise.) But, that was just a start.
 
-Just shy of DAP’s second birthday, access to **all** DAP data
-government-wide was rolled out to every participating DAP agency user.
-That meant every DAP user had access not only to their specific agency’s
-data, but all of the participating agencies’ views, as well as the full
-government-wide rollup. In the [memo to
-agencies](http://www.digitalgov.gov/services/dap/guidance-for-dap-gov-wide-data/),
-then U.S. Federal Chief Information Officer Steven VanRoekel stated,
-“opening the DAP government-wide data will let participating agencies
-see other agency’s public-facing website analytics, gain valuable
-knowledge about shared customers, benchmark against similar agencies,
-and, most importantly, engage in collaboration and exchange lessons
-learned.”
+Just shy of DAP’s second birthday, access to **all** DAP data government-wide was rolled out to every participating DAP agency user. That meant every DAP user had access not only to their specific agency’s data, but all of the participating agencies’ views, as well as the full government-wide rollup. In the [memo to agencies](http://www.digitalgov.gov/services/dap/guidance-for-dap-gov-wide-data/), then U.S. Federal Chief Information Officer Steven VanRoekel stated, “opening the DAP government-wide data will let participating agencies see other agency’s public-facing website analytics, gain valuable knowledge about shared customers, benchmark against similar agencies, and, most importantly, engage in collaboration and exchange lessons learned.”
 
-Finally, in March of this year, [in partnership with
-18F](https://18f.gsa.gov/2015/03/19/how-we-built-analytics-usa-gov/),
-the DAP-based [Public Dashboard](https://www.whitehouse.gov/blog/2015/03/19/turning-government-data-better-public-service)
-[came to life](http://mashable.com/2015/03/19/white-house-open-source-analytics/#oEcsiB97JqqD),
-letting the world in, for the first time, to see the top 20 popular
-pages across the federal government public web space. The public
-response was
-[overwhelming](http://www.marketwatch.com/story/americans-really-want-to-know-wheres-my-tax-refund-2015-03-19)
-and set the stage for additional innovation, collaboration, and
-partnership between federal government and the public.
+Finally, in March of this year, [in partnership with 18F](https://18f.gsa.gov/2015/03/19/how-we-built-analytics-usa-gov/), the DAP-based [Public Dashboard](https://www.whitehouse.gov/blog/2015/03/19/turning-government-data-better-public-service) [came to life](http://mashable.com/2015/03/19/white-house-open-source-analytics/#oEcsiB97JqqD), letting the world in, for the first time, to see the top 20 popular pages across the federal government public web space. The public response was [overwhelming](http://www.marketwatch.com/story/americans-really-want-to-know-wheres-my-tax-refund-2015-03-19) and set the stage for additional innovation, collaboration, and partnership between federal government and the public.
 
 ### 5. Data quality and integrity above all
 
-Data management and governance lie at the heart of the DAP program.
-Frankly, at the end of the day, none of the above factors matter if the
-data quality is questionable.
+Data management and governance lie at the heart of the DAP program. Frankly, at the end of the day, none of the above factors matter if the data quality is questionable.
 
-At DAP, data is monitored closely on an hourly basis with the help of
-automated alerts to pick up significant changes and perform diagnostics.
-In addition, to ensure that the data is processed and standardized
-before it is available for reporting, we apply a set of data
-[standardization
-rules](https://github.com/digital-analytics-program/gov-wide-code/issues/10)
-against all of the collected data. As DAP continues to evolve, the role
-of the DAP Experts Community will continue to expand.
+At DAP, data is monitored closely on an hourly basis with the help of automated alerts to pick up significant changes and perform diagnostics. In addition, to ensure that the data is processed and standardized before it is available for reporting, we apply a set of data [standardization rules](https://github.com/digital-analytics-program/gov-wide-code/issues/10) against all of the collected data. As DAP continues to evolve, the role of the DAP Experts Community will continue to expand.
 
-Data quality doesn’t stop with DAP Experts. Every government user of DAP
-data also has responsibilities, abiding by a [set of
-rules](https://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-7)
-to protect the integrity of the data upon receiving access to it.
+Data quality doesn’t stop with DAP Experts. Every government user of DAP data also has responsibilities, abiding by a [set of rules](https://www.digitalgov.gov/services/dap/common-questions-about-dap-faq/#part-7) to protect the integrity of the data upon receiving access to it.
 
 It’s a journey
 --------------
 
-DAP data is a gold mine for research and analysis for improving the
-effectiveness, efficiency and relevancy of information and services
-provided on government websites. Implementing a program of this scope
-across agency mission and budget lines helps government to focus on the
-reason for being DAP — that is to provide the best digital services to
-the public. We’ve worked hard to focus on what can make a big
-government-wide program a success. It’s starts with small steps,
-bringing on helpers and focusing on the end goals. Yes, it’s a journey,
-and government is up for it!
+DAP data is a gold mine for research and analysis for improving the effectiveness, efficiency and relevancy of information and services provided on government websites. Implementing a program of this scope across agency mission and budget lines helps government to focus on the reason for being DAP — that is to provide the best digital services to the public. We’ve worked hard to focus on what can make a big government-wide program a success. It’s starts with small steps, bringing on helpers and focusing on the end goals. Yes, it’s a journey, and government is up for it!

--- a/_posts/2015-11-10-boston-is-using-gsa-calc-tool.md
+++ b/_posts/2015-11-10-boston-is-using-gsa-calc-tool.md
@@ -5,7 +5,6 @@ authors:
 - melody
 tags:
 - procurement
-- partners in government
 - acquisition services
 - tools you can use
 - calc
@@ -15,55 +14,27 @@ image: /assets/blog/calc-announcement/calc_demo.gif
 hero: false
 ---
 
-In May, 18F and [GSA’s Professional Services
-Category](http://www.gsa.gov/portal/category/108339) launched CALC, a [powerful
-labor category and pricing research
-tool](https://calc.gsa.gov/) to help the federal
-contracting community make smarter, faster buying decisions.
+In May, 18F and [GSA’s Professional Services Category](http://www.gsa.gov/portal/category/108339) launched CALC, a [powerful labor category and pricing research tool](https://calc.gsa.gov/) to help the federal contracting community make smarter, faster buying decisions.
 
-CALC allows contracting officers to conduct market research and price
-analysis for professional labor categories across a database of contract
-awarded prices for 48,000 labor categories from more than 5,000 recent
-GSA contracts.
+CALC allows contracting officers to conduct market research and price analysis for professional labor categories across a database of contract awarded prices for 48,000 labor categories from more than 5,000 recent GSA contracts.
 
-We hoped the tool would save federal contracting officers time and
-money. Turns out, it’s also saving cities time and money. In August,
-Jascha Franklin-Hodge, the Chief Information Officer for the City of
-Boston, tweeted:
+We hoped the tool would save federal contracting officers time and money. Turns out, it’s also saving cities time and money. In August, Jascha Franklin-Hodge, the Chief Information Officer for the City of Boston, tweeted:
 
 <blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">We&#39;re using <a href="https://t.co/3sG2I5yPp5">https://t.co/3sG2I5yPp5</a> from <a href="https://twitter.com/18F">@18F</a> to save money when we buy tech here at <a href="https://twitter.com/DoITBoston">@DoITBoston</a>. Thanks for making this great service!</p>&mdash; Jascha FranklinHodge (@jfh) <a href="https://twitter.com/jfh/status/628590338538647552">August 4, 2015</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-We reached out to Jascha, who says Boston is using CALC as a way to vet
-pricing they receive in response to a request for proposals.
+We reached out to Jascha, who says Boston is using CALC as a way to vet pricing they receive in response to a request for proposals.
 
-“We can compare multiple respondents against each other, but it's hard
-for us to know how their proposed pricing aligns with what's being
-charged to other government agencies,” he says. “CALC give us a way to
-verify that we're getting reasonable rates and [allows us to] push back
-if we're not.”
+“We can compare multiple respondents against each other, but it's hard for us to know how their proposed pricing aligns with what's being charged to other government agencies,” he says. “CALC give us a way to verify that we're getting reasonable rates and [allows us to] push back if we're not.”
 
-The tool, he says, offers city government contracting officers a way to
-get a broader perspective on the market.
+The tool, he says, offers city government contracting officers a way to get a broader perspective on the market.
 
-“One of the challenges cities face in tech procurement is that you're
-making decisions based solely on information provided by vendors.
-CALC...can help ensure decisions are fully informed,” he says.
+“One of the challenges cities face in tech procurement is that you're making decisions based solely on information provided by vendors. CALC...can help ensure decisions are fully informed,” he says.
 
 ![The CALC tool in action]({{site.baseurl}}/assets/blog/calc-announcement/calc_demo.gif)
 
-CALC helps contracting officers determine the range of pricing — at the
-highest level — for a specific labor category. For example, a search for
-“Senior Engineer” will return comparable labor categories and their
-rates, which can be further narrowed by filtering for associated
-criteria such as years of experience, education level, etc.
+CALC helps contracting officers determine the range of pricing — at the highest level — for a specific labor category. For example, a search for “Senior Engineer” will return comparable labor categories and their rates, which can be further narrowed by filtering for associated criteria such as years of experience, education level, etc.
 
-This comparison is an important piece of information that contracting
-officers can use to inform their decision about which contracts should
-receive Requests for Quotations, and in turn ensure the government is
-spending taxpayers dollars wisely and in the most efficient way.
+This comparison is an important piece of information that contracting officers can use to inform their decision about which contracts should receive Requests for Quotations, and in turn ensure the government is spending taxpayers dollars wisely and in the most efficient way.
 
-To get involved in shaping and advancing this tool (and other
-procurement-related tools), please get in touch with us at
-[calc-18f@gsa.gov](mailto:calc-18f@gsa.gov). And if you’re using the CALC
-tool for your city or state, please let us know at [18f@gsa.gov](mailto:18f@gsa.gov). We’d love to feature you on the blog.
+To get involved in shaping and advancing this tool (and other procurement-related tools), please get in touch with us at [calc-18f@gsa.gov](mailto:calc-18f@gsa.gov). And if you’re using the CALC tool for your city or state, please let us know at [18f@gsa.gov](mailto:18f@gsa.gov). We’d love to feature you on the blog.

--- a/_posts/2015-11-17-gsa-gov-refreshed-with-eye-toward-mobile-users.md
+++ b/_posts/2015-11-17-gsa-gov-refreshed-with-eye-toward-mobile-users.md
@@ -5,7 +5,7 @@ layout: post
 authors:
 - jeffwoodworth
 tags:
-- gsa
+- general services administration
 - design
 - web design standards
 excerpt: "GSA unveiled a refreshed gsa.gov website yesterday with a more crisp design layout, improved usability, and features geared more toward mobile users."

--- a/_posts/2015-12-02-analytics-usa-gov-new-features-more-data.md
+++ b/_posts/2015-12-02-analytics-usa-gov-new-features-more-data.md
@@ -11,7 +11,6 @@ authors:
 tags:
 - how we work
 - analytics.usa.gov
-- analytics
 - open data
 - open government
 

--- a/_posts/2015-12-03-power-of-mindset-normatives-matthew-milan.md
+++ b/_posts/2015-12-03-power-of-mindset-normatives-matthew-milan.md
@@ -7,7 +7,6 @@ tags:
 - how we work
 - design
 - speaker series
-- outreach
 
 excerpt: "Matthew Milan, founder of and design leader at software design firm Normative, visited 18F’s main office to share his insights into the importance of the shared mindset and how your team can develop its own. Here are some of his takeaways."
 description: "Matthew Milan, founder of and design leader at software design firm Normative, visited 18F’s main office to share his insights into the importance of the shared mindset and how your team can develop its own. Here are some of his takeaways."

--- a/_posts/2015-12-08-learning-how-to-build-a-better-front-door-for-the-federal-government.md
+++ b/_posts/2015-12-08-learning-how-to-build-a-better-front-door-for-the-federal-government.md
@@ -6,7 +6,6 @@ authors:
 - carolyn
 - michelle-chronister
 tags:
-- our projects
 - user research
 - federal front door
 - transformation services

--- a/_posts/2015-12-11-how-we-test-18f-gsa-gov.md
+++ b/_posts/2015-12-11-how-we-test-18f-gsa-gov.md
@@ -4,7 +4,7 @@ date: 2015-12-11
 authors:
 - boone
 tags:
-- automated testing
+- testing
 - how we work
 - 18f.gsa.gov
 - communication tools and practices

--- a/_posts/2015-12-22-uk-digital-service-visits-us-to-begin-series-of-exchanges.md
+++ b/_posts/2015-12-22-uk-digital-service-visits-us-to-begin-series-of-exchanges.md
@@ -5,7 +5,6 @@ authors:
 - jhunter
 tags:
 - digital services movement
-- outreach
 - how we work
 
 excerpt: "Across the pond, the motto of the United Kingdom's Government Digital Service (GDS) is “the strategy is delivery.” Over here, we say “delivery is the strategy,” but we’re both focused on the same thing: Fostering positive change across government by shipping quality digital solutions."

--- a/_posts/2016-01-06-tips-for-adapting-analytics-usa-gov.md
+++ b/_posts/2016-01-06-tips-for-adapting-analytics-usa-gov.md
@@ -7,8 +7,7 @@ authors:
 tags:
 - open government
 - analytics.usa.gov
-- analytics
-- partners in government
+- interview
 - tools you can use
 
 excerpt: "The city of Philadelphia, the city of Boulder, and the Tennessee Department of Environment and Conservation have all adapted analytics.usa.gov for their own use. We recently talked to them about how they adapted the platform and what advice they’d have for others who'd like to do the same."
@@ -18,257 +17,78 @@ redirect_from:
 -  /2016/01/05/tips-for-adapting-analytics-usa-gov/
 ---
 
-When [we launched analytics.usa.gov](https://18f.gsa.gov/2015/03/19/how-we-built-analytics-usa-gov/)
-with the [Digital Analytics
-Program](https://www.digitalgov.gov/services/dap/), the [U.S. Digital
-Service](https://www.whitehouse.gov/digital/united-states-digital-service), and the White House last March, we
-purposefully made it very easy to adapt and wrote language on the
-website to let people know they could use the code without restriction:
+When [we launched analytics.usa.gov](https://18f.gsa.gov/2015/03/19/how-we-built-analytics-usa-gov/) with the [Digital Analytics Program](https://www.digitalgov.gov/services/dap/), the [U.S. Digital Service](https://www.whitehouse.gov/digital/united-states-digital-service), and the White House last March, we purposefully made it very easy to adapt and wrote language on the website to let people know they could use the code without restriction:
 
-> This open source project is in the public domain, which means that
-> this website and its data are free for you to use without restriction.
-> You can find the [code for this website](https://github.com/GSA/analytics.usa.gov) and
-> the [code behind the data collection](https://github.com/18F/analytics-reporter) on
-> GitHub.
+> This open source project is in the public domain, which means that this website and its data are free for you to use without restriction. You can find the [code for this website](https://github.com/GSA/analytics.usa.gov) and the [code behind the data collection](https://github.com/18F/analytics-reporter) on GitHub.
 
-And a few governments have done just that: the [city of
-Philadelphia](http://analytics.phila.gov/), the [city of
-Boulder](https://bouldercolorado.gov/stats), and the [Tennessee Department of
-Environment and Conservation](http://analytics.tdec.tn.gov/).
+And a few governments have done just that: the [city of Philadelphia](http://analytics.phila.gov/), the [city of Boulder](https://bouldercolorado.gov/stats), and the [Tennessee Department of Environment and Conservation](http://analytics.tdec.tn.gov/).
 
-I reached out to **Lauren Ancona**, the Senior Data Scientist for the
-City of Philadelphia’s Office of Innovation and Technology (OIT); **Ron
-Pringle**, a Senior PHP Application Programmer Analyst for the City of
-Boulder; and **Cody Rockwood**, a project manager in the Information
-Systems Division of Tennessee’s Department of Environment and
-Conservation, to see how they adapted the platform for their respective
-organizations and what advice they’d have for others who would like to
-do the same.
+I reached out to **Lauren Ancona**, the Senior Data Scientist for the City of Philadelphia’s Office of Innovation and Technology (OIT); **Ron Pringle**, a Senior PHP Application Programmer Analyst for the City of Boulder; and **Cody Rockwood**, a project manager in the Information Systems Division of Tennessee’s Department of Environment and Conservation, to see how they adapted the platform for their respective organizations and what advice they’d have for others who would like to do the same.
 
-**MK: We saw your tweets about adapting the analytics dashboard to
-create one for your respective organizations. How did you hear about the
-dashboard and what did you do to adapt it?**
+**MK: We saw your tweets about adapting the analytics dashboard to create one for your respective organizations. How did you hear about the dashboard and what did you do to adapt it?**
 
-**LA:** My previous career as a marketer involved heavy work with
-analytics, so I’d actually been “stalking" the project during its
-development phase on GitHub for several months. Once it launched, I got
-in touch with the maintainers with some questions about the analytics
-configuration. They were very supportive and actually merged some of my
-feedback, and eventually ended up letting me come on as a project
-maintainer for the [analytics-reporter
-repo](https://github.com/18F/analytics-reporter). That, frankly, blew my mind: a
-federal agency is incorporating feedback from a local government using
-their tool on an ongoing basis. We were able to bring up a few simple
-tweaks that made it easier to adapt.
+**LA:** My previous career as a marketer involved heavy work with analytics, so I’d actually been “stalking" the project during its development phase on GitHub for several months. Once it launched, I got in touch with the maintainers with some questions about the analytics configuration. They were very supportive and actually merged some of my feedback, and eventually ended up letting me come on as a project maintainer for the [analytics-reporter repo](https://github.com/18F/analytics-reporter). That, frankly, blew my mind: a federal agency is incorporating feedback from a local government using their tool on an ongoing basis. We were able to bring up a few simple tweaks that made it easier to adapt.
 
-**RP:** I heard about the analytics dashboard from a number of sources
-almost simultaneously. I follow a lot of 18F and Code for America folks
-on Twitter so I’m sure I saw it tweeted about there. I was also working
-with Becky Boone, our Code for America Senior Fellow at the time, on
-some analytics-related work. She brought it to my attention as well.
+**RP:** I heard about the analytics dashboard from a number of sources almost simultaneously. I follow a lot of 18F and Code for America folks on Twitter so I’m sure I saw it tweeted about there. I was also working with Becky Boone, our Code for America Senior Fellow at the time, on some analytics-related work. She brought it to my attention as well.
 
-Working with Becky, we tried out a number of different dashboard
-solutions, including Code for America’s real time dashboard. Even though
-we got that up and running fairly quickly, I still felt there was value
-in integrating or emulating the 18F dashboard as part of our custom CMS,
-Xpress, that we co-developed with another Colorado city. I took some
-time over the summer to go through the federal dashboard code on GitHub.
-Because Xpress is PHP-based and modular, ultimately I decided to emulate
-the dashboard in PHP as a module specifically for Xpress. I rolled the
-work into a major upgrade already planned for late summer and we pushed
-it live in early fall of 2015.
+Working with Becky, we tried out a number of different dashboard solutions, including Code for America’s real time dashboard. Even though we got that up and running fairly quickly, I still felt there was value in integrating or emulating the 18F dashboard as part of our custom CMS, Xpress, that we co-developed with another Colorado city. I took some time over the summer to go through the federal dashboard code on GitHub. Because Xpress is PHP-based and modular, ultimately I decided to emulate the dashboard in PHP as a module specifically for Xpress. I rolled the work into a major upgrade already planned for late summer and we pushed it live in early fall of 2015.
 
-**CR:** Analytics.usa.gov came across in one of our feeds. The discovery
-was well timed, as my team had been working with D3.js building
-infographics on our intranet. We were looking for ways we could do more.
-We decided pursuing this project would be a great way to provide the
-department with a new tool.
+**CR:** Analytics.usa.gov came across in one of our feeds. The discovery was well timed, as my team had been working with D3.js building infographics on our intranet. We were looking for ways we could do more. We decided pursuing this project would be a great way to provide the department with a new tool.
 
-We spent 3 weeks pulling the project together, finding our way through
-D3.js, and learning to build intelligent graphs. From there, it was just
-getting the reporter running on our server and refining the interface.
-The whole thing was a “guerrilla" type project where we created it and
-deployed it under the radar. Then we said “Look what we built!" Our
-department leadership loved it.
+We spent 3 weeks pulling the project together, finding our way through D3.js, and learning to build intelligent graphs. From there, it was just getting the reporter running on our server and refining the interface. The whole thing was a “guerrilla" type project where we created it and deployed it under the radar. Then we said “Look what we built!" Our department leadership loved it.
 
-**MK: What are you using your dashboard for? What has the response
-been?**
+**MK: What are you using your dashboard for? What has the response been?**
 
-**LA:** We’re using it in much the same way the federal government is; a
-place where anyone curious about the way city content is being used, how
-often, and what kinds of technology they’re using (in aggregate). In my
-department (OIT), we frequently refer to it when discussing things like
-supporting legacy browsers or device types.
+**LA:** We’re using it in much the same way the federal government is; a place where anyone curious about the way city content is being used, how often, and what kinds of technology they’re using (in aggregate). In my department (OIT), we frequently refer to it when discussing things like supporting legacy browsers or device types.
 
-**RP:** The initial rollout of the dashboard was for internal use only.
-We made a stats page available to Xpress content managers to help them
-make better data-driven decisions about the content they’re curating on
-the City of Boulder website.
+**RP:** The initial rollout of the dashboard was for internal use only. We made a stats page available to Xpress content managers to help them make better data-driven decisions about the content they’re curating on the City of Boulder website.
 
-We’d always intended to make it public as well, so after some code
-refinement, we pushed out the public version about a month later. Since
-then, we’ve added a lot more to the content manager dashboard. It now
-allows stats by category and includes metrics on social media, search,
-content manager usage and more. Again, this is to help content managers
-make better decisions about content based on data. Putting this directly
-into the administrative section of the CMS makes this information
-available exactly at the place they’re most likely to use it. We’ve
-gotten very positive feedback from our content managers. We plan on
-pushing most of these new features to the public dashboard as well.
+We’d always intended to make it public as well, so after some code refinement, we pushed out the public version about a month later. Since then, we’ve added a lot more to the content manager dashboard. It now allows stats by category and includes metrics on social media, search, content manager usage and more. Again, this is to help content managers make better decisions about content based on data. Putting this directly into the administrative section of the CMS makes this information available exactly at the place they’re most likely to use it. We’ve gotten very positive feedback from our content managers. We plan on pushing most of these new features to the public dashboard as well.
 
-**CR:** The goal for Tennessee State Government is to become more
-“efficient and effective." One of the ways we’re doing that is to make
-more data-driven decisions. Before this product launched, we were
-already sending out monthly reports for our analytics. By providing this
-on-demand dashboard, we put more power in the hands of our colleagues
-working in our regulatory divisions. This can help our department better
-understand how our users are interacting with us on a day-to-day basis.
-That will lead to us making better decisions.
+**CR:** The goal for Tennessee State Government is to become more “efficient and effective." One of the ways we’re doing that is to make more data-driven decisions. Before this product launched, we were already sending out monthly reports for our analytics. By providing this on-demand dashboard, we put more power in the hands of our colleagues working in our regulatory divisions. This can help our department better understand how our users are interacting with us on a day-to-day basis. That will lead to us making better decisions.
 
-The response to the launch has been great. Our department has increased
-use of our web statistics since we started tracking them 3 years ago.
+The response to the launch has been great. Our department has increased use of our web statistics since we started tracking them 3 years ago.
 
-With this dashboard at their fingertips, they’re anxious to see more.
-We’re discussing other possibilities as well. We’ve already had requests
-to be able to narrow data or do custom “on-demand" searches. We’re
-hopeful we’ll be able to extend the functionality to include these
-requests soon.
+With this dashboard at their fingertips, they’re anxious to see more. We’re discussing other possibilities as well. We’ve already had requests to be able to narrow data or do custom “on-demand" searches. We’re hopeful we’ll be able to extend the functionality to include these requests soon.
 
-**MK: Do you have any advice for other state or local governments who
-might want to adapt the platform?**
+**MK: Do you have any advice for other state or local governments who might want to adapt the platform?**
 
-**LA:** The front- and back-end pieces are fairly straightforward for
-even a junior developer to deploy — if there is one on staff. I was not
-a developer, but managed to cobble our version together with lots of
-support from Eric Mill at 18F and several of my coworkers. Luckily, one
-of the first things our
-[alpha.phila.gov](http://alpha.phila.gov/) team built was a
-[pattern portfolio](http://cityofphiladelphia.github.io/patterns/),
-which made my life *much* easier when adapting the appearance to match
-our other work.
+**LA:** The front- and back-end pieces are fairly straightforward for even a junior developer to deploy — if there is one on staff. I was not a developer, but managed to cobble our version together with lots of support from Eric Mill at 18F and several of my coworkers. Luckily, one of the first things our [alpha.phila.gov](http://alpha.phila.gov/) team built was a [pattern portfolio](http://cityofphiladelphia.github.io/patterns/), which made my life *much* easier when adapting the appearance to match our other work.
 
-But more important than how you might adapt the platform for your
-government is *having cohesive analytics data to put in it.* For the
-most part, the government use-case is pretty consistent across the board
-— a configuration that works for one is likely to work almost anywhere.
-We’re working on [documenting and sharing
-ours](https://github.com/laurenancona/unified-analytics).
+But more important than how you might adapt the platform for your government is *having cohesive analytics data to put in it.* For the most part, the government use-case is pretty consistent across the board — a configuration that works for one is likely to work almost anywhere. We’re working on [documenting and sharing ours](https://github.com/laurenancona/unified-analytics).
 
-**RP:** Just do it! This was essentially a skunkworks project for us. We
-floated the idea at one of our monthly content manager meetings and got
-positive vibes from that but otherwise there was no mandate to do this.
-If you can, adapt the existing code. It makes more sense to piggyback
-off of someone else’s work when you can. Google has a great online API
-tester that allows you to test out any additional API calls you want to
-make as well. It helped me a lot when we decided to expand usage to
-other stats.
+**RP:** Just do it! This was essentially a skunkworks project for us. We floated the idea at one of our monthly content manager meetings and got positive vibes from that but otherwise there was no mandate to do this. If you can, adapt the existing code. It makes more sense to piggyback off of someone else’s work when you can. Google has a great online API tester that allows you to test out any additional API calls you want to make as well. It helped me a lot when we decided to expand usage to other stats.
 
-And finally, keep it simple and iterate. We ended up using Charts.js
-instead of D3 because what we needed to display was pretty simple. It
-kept the project light. We also cache the data just like the 18F
-dashboard because it reduces load on the API calls and because we plan
-on adding the data to our open data catalog. The cached CSVs will serve
-as the source for the open data entries as well.
+And finally, keep it simple and iterate. We ended up using Charts.js instead of D3 because what we needed to display was pretty simple. It kept the project light. We also cache the data just like the 18F dashboard because it reduces load on the API calls and because we plan on adding the data to our open data catalog. The cached CSVs will serve as the source for the open data entries as well.
 
-**CR:** My main advice, is just go for it. 18F has done a fantastic job
-with documentation and using open-source technology to help make this
-platform come together.
+**CR:** My main advice, is just go for it. 18F has done a fantastic job with documentation and using open-source technology to help make this platform come together.
 
-The benefits of this project have more than warranted spending the time
-implementing it. For TDEC, providing this information has helped open up
-the door to better conversations around how and why we spend our efforts
-supporting our customers via our various digital services.
+The benefits of this project have more than warranted spending the time implementing it. For TDEC, providing this information has helped open up the door to better conversations around how and why we spend our efforts supporting our customers via our various digital services.
 
 **MK: Is there anything 18F could do to improve the platform?**
 
-**LA:** A 1-click deploy from GitHub to a PaaS like Heroku (where ours
-is currently hosted) or a Docker container — there was an abandoned PR
-where someone was working on this — (or perhaps
-[cloud.gov](http://cloud.gov/) in the future?) — would make the
-process simpler, I imagine. You can do this now, in fact — if you
-already understand the technology at work. But I think there are just a
-few tiny gaps we could close that would make it even easier.
+**LA:** A 1-click deploy from GitHub to a PaaS like Heroku (where ours is currently hosted) or a Docker container — there was an abandoned PR where someone was working on this — (or perhaps [cloud.gov](http://cloud.gov/) in the future?) — would make the process simpler, I imagine. You can do this now, in fact — if you already understand the technology at work. But I think there are just a few tiny gaps we could close that would make it even easier.
 
-**RP:** More, better documentation. I’ve found that most developers make
-a lot of assumptions about baseline knowledge of anyone attempting to
-adapt or emulate their work. Because the dashboard strikes me as
-something even non-technical people might want to try to implement,
-better documentation is always going to help.
+**RP:** More, better documentation. I’ve found that most developers make a lot of assumptions about baseline knowledge of anyone attempting to adapt or emulate their work. Because the dashboard strikes me as something even non-technical people might want to try to implement, better documentation is always going to help.
 
-**CR**: Outside of extending existing functionality, the platform and
-documentation are great.
+**CR**: Outside of extending existing functionality, the platform and documentation are great.
 
-We’re looking at trying to extend some of the reporting functionality.
-Being able to filter stats according specific pages (or groups of pages)
-would be hugely beneficial for divisions within TDEC. I’m sure that need
-is not unique. Additional or customizable reporting would be incredible.
+We’re looking at trying to extend some of the reporting functionality. Being able to filter stats according specific pages (or groups of pages) would be hugely beneficial for divisions within TDEC. I’m sure that need is not unique. Additional or customizable reporting would be incredible.
 
 **MK: Anything else you want to add?**
 
-**LA:** I understand how hard it is to find time to think about
-implementing web analytics when you’re probably dealing with
-emergencies, old hardware, older software, lack of support or
-understanding of the potential for better service this kind of
-information can bring. And just getting the tracking code installed
-across many (sometimes siloed) sites is a challenge. So I'm packaging up
-[a version of our
-configuration](https://github.com/laurenancona/unified-analytics) and
-reporting tools that any city or state government could use.
+**LA:** I understand how hard it is to find time to think about implementing web analytics when you’re probably dealing with emergencies, old hardware, older software, lack of support or understanding of the potential for better service this kind of information can bring. And just getting the tracking code installed across many (sometimes siloed) sites is a challenge. So I'm packaging up [a version of our configuration](https://github.com/laurenancona/unified-analytics) and reporting tools that any city or state government could use.
 
-There are three basic components to any web analytics implementation:
-configuration, collection, and reporting. This setup gives a solid
-foundation for all three using a single snippet of code that is
-installed on each page of every site to be included in tracking.
+There are three basic components to any web analytics implementation: configuration, collection, and reporting. This setup gives a solid foundation for all three using a single snippet of code that is installed on each page of every site to be included in tracking. It leverages a tracking “container" model that comes preconfigured to capture the standard Google Analytics measurements and adds more detail: PDF and other document downloads, frustrated users, JavaScript Errors, and even a little module to collect feedback.
 
-It leverages a tracking “container" model that comes preconfigured to
-capture the standard Google Analytics measurements and adds more detail:
-PDF and other document downloads, frustrated users, JavaScript Errors,
-and even a little module to collect feedback.
+On the other end, we’ve written custom report configurations to get that extra detail back out of Google Analytics and into the hands of departments and agencies that can use it to drive things like content decisions. I’m still working on the documentation, but the [Google Analytics Embed API](https://developers.google.com/analytics/devguides/reporting/embed/v1/?hl=en) makes something like this possible. [You can log in](https://github.com/CityOfPhiladelphia/phila-dashboards) — it’s a work in progress — it will only show you data for Google Analytics accounts *you* have access to — and doesn’t store any data. (Aside: this is the last piece I’m working on — an unbranded version to accompany the release of the container configuration. In the meantime, I’ve built [preconfigured links to reports](https://github.com/laurenancona/unified-analytics/blob/gh-pages/reporting.md) in the standard Google Analytics reporting interface).
 
-On the other end, we’ve written custom report configurations to get that
-extra detail back out of Google Analytics and into the hands of
-departments and agencies that can use it to drive things like content
-decisions. I’m still working on the documentation, but the [Google
-Analytics Embed
-API](https://developers.google.com/analytics/devguides/reporting/embed/v1/?hl=en)
-makes something like this possible. [You can log
-in](https://github.com/CityOfPhiladelphia/phila-dashboards) — it’s a
-work in progress — it will only show you data for Google Analytics
-accounts *you* have access to — and doesn’t store any data. (Aside: this
-is the last piece I’m working on — an unbranded version to accompany the
-release of the container configuration. In the meantime, I’ve built
-[preconfigured links to
-reports](https://github.com/laurenancona/unified-analytics/blob/gh-pages/reporting.md)
-in the standard Google Analytics reporting interface).
+**RP:** Thanks for sharing! While we were already working our way down a similar path, having a working example and being able to look at the code behind it really helped coalesce our ideas and work quickly to make it happen. It also helped us to have the federal dashboard to show as an example before we wrote a single piece of code. People got it, and were supportive, which made my job of coding it a lot easier.
 
-**RP:** Thanks for sharing! While we were already working our way down a
-similar path, having a working example and being able to look at the
-code behind it really helped coalesce our ideas and work quickly to make
-it happen. It also helped us to have the federal dashboard to show as an
-example before we wrote a single piece of code. People got it, and were
-supportive, which made my job of coding it a lot easier.
+**CR:** The work you are doing is inspiring. Steering tech and improving how the government implements it is no small task. By creating these resources you’re paving the paths allowing entities like TDEC to react and change faster.
 
-**CR:** The work you are doing is inspiring. Steering tech and improving
-how the government implements it is no small task. By creating these
-resources you’re paving the paths allowing entities like TDEC to react
-and change faster.
+You’re also providing a real world example of how modern workplace provisions (like remote workers, flexible schedules, etc), agile practices and modern technology can improve government. If government has any hope to emerge from “behind the curve” we have to break down the status-quo. We need modern work environments and to use some of the practices commonly considered only for the “start-up” world. We have to make working for the government “sexy.”
 
-You’re also providing a real world example of how modern workplace
-provisions (like remote workers, flexible schedules, etc), agile
-practices and modern technology can improve government. If government
-has any hope to emerge from “behind the curve” we have to break down the
-status-quo. We need modern work environments and to use some of the
-practices commonly considered only for the “start-up” world. We have to
-make working for the government “sexy.”
+Otherwise, we’ll never be able to recruit the young upcoming talent and needed resources to accelerate or sustain long-term improvement. By implementing and vetting these practices, technologies and projects, then openly sharing your lessons learned, 18F is providing fuel for people like myself to use. I can point to your methods as real proof that these things can succeed in government when discussing it with executive management.
 
-Otherwise, we’ll never be able to recruit the young upcoming talent and
-needed resources to accelerate or sustain long-term improvement.
-
-By implementing and vetting these practices, technologies and projects,
-then openly sharing your lessons learned, 18F is providing fuel for
-people like myself to use. I can point to your methods as real proof
-that these things can succeed in government when discussing it with
-executive management.
-
-TL;DR: Keep pushing! 18F is affecting more than federal programs and we
-NEED your success to push forward.
+TL;DR: Keep pushing! 18F is affecting more than federal programs and we NEED your success to push forward.

--- a/_posts/2016-01-21-what-we-can-learn-from-the-interiors-social-feeds.md
+++ b/_posts/2016-01-21-what-we-can-learn-from-the-interiors-social-feeds.md
@@ -4,7 +4,7 @@ date: 2016-01-21
 authors:
 - melody
 tags:
-- partners in government
+- interview
 - communication tools and practices
 
 excerpt: "One of my favorite projects is the U.S. Department of the Interior&#39;s work on social media. I recently asked Rebecca Matulka, the senior digital media strategist for Interior what she’s learned while running an online community that helps Interior achieve its larger strategic goals."
@@ -15,152 +15,60 @@ hero: false
 <blockquote class="instagram-media" data-instgrm-version="6" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:658px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:8px;"> <div style=" background:#F8F8F8; line-height:0; margin-top:40px; padding:50.0% 0; text-align:center; width:100%;"> <div style=" background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAsCAMAAAApWqozAAAAGFBMVEUiIiI9PT0eHh4gIB4hIBkcHBwcHBwcHBydr+JQAAAACHRSTlMABA4YHyQsM5jtaMwAAADfSURBVDjL7ZVBEgMhCAQBAf//42xcNbpAqakcM0ftUmFAAIBE81IqBJdS3lS6zs3bIpB9WED3YYXFPmHRfT8sgyrCP1x8uEUxLMzNWElFOYCV6mHWWwMzdPEKHlhLw7NWJqkHc4uIZphavDzA2JPzUDsBZziNae2S6owH8xPmX8G7zzgKEOPUoYHvGz1TBCxMkd3kwNVbU0gKHkx+iZILf77IofhrY1nYFnB/lQPb79drWOyJVa/DAvg9B/rLB4cC+Nqgdz/TvBbBnr6GBReqn/nRmDgaQEej7WhonozjF+Y2I/fZou/qAAAAAElFTkSuQmCC); display:block; height:44px; margin:0 auto -44px; position:relative; top:-22px; width:44px;"></div></div><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/_-fx45Au4w/" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A photo posted by U.S. Department of the Interior (@usinterior)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2016-01-01T00:35:27+00:00">Dec 31, 2015 at 4:35pm PST</time></p></div></blockquote>
 <script async defer src="//platform.instagram.com/en_US/embeds.js"></script><br />
 
-We frequently look to other government agencies for inspiration and
-guidance while building our own projects or thinking about how to
-communicate their value. One of my favorite projects is the U.S.
-Department of the Interior’s work on social media. Their [Instagram
-feed](https://www.instagram.com/usinterior/) boasts almost 900,000 followers
-and features stunning landscapes inside America’s national parks. Their
-[Twitter account](https://twitter.com/Interior) has half a
-million followers and quickly replies to queries.
+We frequently look to other government agencies for inspiration and guidance while building our own projects or thinking about how to communicate their value. One of my favorite projects is the U.S. Department of the Interior’s work on social media. Their [Instagram feed](https://www.instagram.com/usinterior/) boasts almost 900,000 followers and features stunning landscapes inside America’s national parks. Their [Twitter account](https://twitter.com/Interior) has half a million followers and quickly replies to queries.
 
-What I like about these accounts, aside from the stunning imagery, is
-how adept Interior is at sharing their policy-related content in between
-the photos of volcanoes and snow-covered mountains. People are just as
-likely to find out about [climate change](https://twitter.com/Interior/status/667053537365504000) or
-supporting America’s [small businesses](https://twitter.com/SecretaryJewell/status/670663658343702532) as they
-are to catch a [beautiful sunset](https://twitter.com/Interior/status/670387539757395968) at Glacier
-National Park.
+What I like about these accounts, aside from the stunning imagery, is how adept Interior is at sharing their policy-related content in between the photos of volcanoes and snow-covered mountains. People are just as likely to find out about [climate change](https://twitter.com/Interior/status/667053537365504000) or supporting America’s [small businesses](https://twitter.com/SecretaryJewell/status/670663658343702532) as they are to catch a [beautiful sunset](https://twitter.com/Interior/status/670387539757395968) at Glacier National Park.
 
-Both the Instagram account and the Twitter feed are managed by Rebecca
-Matulka, the senior digital media strategist for Interior. I asked
-Rebecca if she wouldn’t mind sharing what she’s learned while running an
-online community that helps Interior achieve its larger strategic goals.
+Both the Instagram account and the Twitter feed are managed by Rebecca Matulka, the senior digital media strategist for Interior. I asked Rebecca if she wouldn’t mind sharing what she’s learned while running an online community that helps Interior achieve its larger strategic goals.
 
 **MK: What do you do in the federal government?**
 
-**RM:** I'm the senior digital media strategist for the Interior
-Department. I manage Interior's social media accounts — that's
-everything from Instagram, Twitter and Vine to Tumblr, Facebook and
-Snapchat. I develop the strategy for these accounts, create content and
-evaluate the success of the accounts.
+**RM:** I'm the senior digital media strategist for the Interior Department. I manage Interior's social media accounts — that's everything from Instagram, Twitter and Vine to Tumblr, Facebook and Snapchat. I develop the strategy for these accounts, create content and evaluate the success of the accounts.
 
-**MK: You run one of the most popular Instagram accounts for the federal
-government. Could you describe your workflow for selecting images for
-the Interior Department’s Instagram and then posting them?**
+**MK: You run one of the most popular Instagram accounts for the federal government. Could you describe your workflow for selecting images for the Interior Department’s Instagram and then posting them?**
 
-**RM:** A lot of work goes into finding great photos for Interior's
-Instagram account. We try to share pictures of what it currently looks
-like on the ground at national parks and other public lands.
+**RM:** A lot of work goes into finding great photos for Interior's Instagram account. We try to share pictures of what it currently looks like on the ground at national parks and other public lands.
 
-At the same time, we try to balance the different types of photos
-(sunrise, night sky, wildlife, etc.), geographic location and type of
-public lands. We not only want to showcase well-known national parks but
-also hidden gems like Aroostook National Wildlife Refuge in Maine or St.
-Anthony Sand Dunes in Idaho.
+At the same time, we try to balance the different types of photos (sunrise, night sky, wildlife, etc.), geographic location and type of public lands. We not only want to showcase well-known national parks but also hidden gems like Aroostook National Wildlife Refuge in Maine or St. Anthony Sand Dunes in Idaho.
 
-Once we've found a great photo, we make sure to get permission to share
-it on our accounts (especially if it's from a visitor). For the
-captions, we make sure to include interesting facts about the location
-or stories from the photographer about what it took to capture the
-photo. We like to vary the format and length, so that the captions
-aren't all the same.
+Once we've found a great photo, we make sure to get permission to share it on our accounts (especially if it's from a visitor). For the captions, we make sure to include interesting facts about the location or stories from the photographer about what it took to capture the photo. We like to vary the format and length, so that the captions aren't all the same.
 
-We typically share two photos a day during the workweek (around 11:30
-a.m. ET and 6:45 p.m. ET) and one a day on the weekends. Before posting,
-we use Mappr to change the geolocation of the photos to ensure we are
-geotagging the right place.
+We typically share two photos a day during the workweek (around 11:30 a.m. ET and 6:45 p.m. ET) and one a day on the weekends. Before posting, we use Mappr to change the geolocation of the photos to ensure we are geotagging the right place.
 
-**MK: What kind of feedback do you get from people and how do you
-respond? I know you’ve responded to me directly on Twitter, which was
-unexpectedly awesome.**
+**MK: What kind of feedback do you get from people and how do you respond? I know you’ve responded to me directly on Twitter, which was unexpectedly awesome.**
 
-**RM:** So many people have great connections to public lands — these
-are places they've visited with family and friends, or are on their
-bucket list. We've also heard from people that look forward to our daily
-photos because it's their moment of zen for the day.
+**RM:** So many people have great connections to public lands — these are places they've visited with family and friends, or are on their bucket list. We've also heard from people that look forward to our daily photos because it's their moment of zen for the day.
 
-The majority of the comments are people tagging their friends and
-talking about their trips to the place we've featured. But when someone
-asks us a question, we always try to respond. If we don't know the
-answer, we reach out to people on the ground to get it for them. We also
-like to respond when people share their photos or stories about visiting
-places — it's all about acknowledging that we saw their tweet and we
-appreciate that they're spreading the word about all the amazing public
-lands that Interior protects.
+The majority of the comments are people tagging their friends and talking about their trips to the place we've featured. But when someone asks us a question, we always try to respond. If we don't know the answer, we reach out to people on the ground to get it for them. We also like to respond when people share their photos or stories about visiting places — it's all about acknowledging that we saw their tweet and we appreciate that they're spreading the word about all the amazing public lands that Interior protects.
 
-When people provide us feedback, we let them know we've heard, and try
-to incorporate it into feed posts. This allows us to turn what might
-have been negative feedback into a positive response. [This
-conversation](https://twitter.com/Interior/status/588775170137059328) on Twitter is a great example
-of this type of result:
+When people provide us feedback, we let them know we've heard, and try to incorporate it into feed posts. This allows us to turn what might have been negative feedback into a positive response. [This conversation](https://twitter.com/Interior/status/588775170137059328) on Twitter is a great example of this type of result:
 
-**MK: How does working with the public in this way help the Interior
-Department when it wants to share information about policy decisions?**
+**MK: How does working with the public in this way help the Interior Department when it wants to share information about policy decisions?**
 
-**RM:** Interior is known for it's stunning landscapes and cute wildlife
-photos, but the Department's mission includes more than just those
-things. It's the photos that draw people to our accounts and allows us
-to share all the other great work the Department is doing. The result is
-our policy-related content reaches a much larger audience than most
-other federal government agencies.
+**RM:** Interior is known for it's stunning landscapes and cute wildlife photos, but the Department's mission includes more than just those things. It's the photos that draw people to our accounts and allows us to share all the other great work the Department is doing. The result is our policy-related content reaches a much larger audience than most other federal government agencies.
 
 **MK: Where do you look for inspiration, offline and online?**
 
-**RM:** National Geographic is a big inspiration for me — I'd love to
-see Interior's Instagram account be at that level someday. I also look
-to BuzzFeed and the Huffington Post.
+**RM:** National Geographic is a big inspiration for me — I'd love to see Interior's Instagram account be at that level someday. I also look to BuzzFeed and the Huffington Post.
 
-Personally, I like to unplug to recharge my creative juices. I love to
-cook and spend time outside with family, friends and my dog. I also
-enjoy curling up with a book. Photo captions are just as important as
-the image itself, and I want to make sure our captions don't become
-formulaic. In reading other people's writing, it gives me new ideas of
-how to develop Interior's photo captions.
+Personally, I like to unplug to recharge my creative juices. I love to cook and spend time outside with family, friends and my dog. I also enjoy curling up with a book. Photo captions are just as important as the image itself, and I want to make sure our captions don't become formulaic. In reading other people's writing, it gives me new ideas of how to develop Interior's photo captions.
 
 **MK: How do you share what you’ve learned with other people?**
 
-**RM:** It can be hard to share what we've learned because right now a
-lot of it is anecdotal. We'd like to get to a place where we have hard
-data to backup the decisions we make on social media.
+**RM:** It can be hard to share what we've learned because right now a lot of it is anecdotal. We'd like to get to a place where we have hard data to backup the decisions we make on social media.
 
-Internally, we are trying to set up processes that not only allow us to
-share our best practices, but also let the social media leads at the
-different Bureaus that Interior manages share their successes. We all
-have something we can learn from each other.
+Internally, we are trying to set up processes that not only allow us to share our best practices, but also let the social media leads at the different Bureaus that Interior manages share their successes. We all have something we can learn from each other.
 
 **MK: What’s the best part of your job?**
 
-**RM:** The best part of my job is seeing the positive responses from
-the public about places we highlight. People love to share their story
-about memories from childhood trips to Grand Teton or how they
-honeymooned at Yosemite. Interior protects America's special places so
-that past and future generations can enjoy them. It's really great to
-see this connection.
+**RM:** The best part of my job is seeing the positive responses from the public about places we highlight. People love to share their story about memories from childhood trips to Grand Teton or how they honeymooned at Yosemite. Interior protects America's special places so that past and future generations can enjoy them. It's really great to see this connection.
 
-**MK: What’s one thing that you’ve learned that might help others
-working in the federal government?**
+**MK: What’s one thing that you’ve learned that might help others working in the federal government?**
 
-**RM:** Always keep experimenting. Just because it's always been done
-that way or it didn't worked in the past, doesn't mean that is still the
-case. Social media is always changing, and we need to keep reevaluating
-what we are doing to ensure that we are providing taxpayers with the
-best service possible.
+**RM:** Always keep experimenting. Just because it's always been done that way or it didn't worked in the past, doesn't mean that is still the case. Social media is always changing, and we need to keep reevaluating what we are doing to ensure that we are providing taxpayers with the best service possible.
 
-**MK: It’s probably hard to pick, but can you share a favorite photo or
-story from the stream?**
+**MK: It’s probably hard to pick, but can you share a favorite photo or story from the stream?**
 
-It's definitely hard to pick a single favorite, but I really [love this
-photo of burrowing
-owls](https://instagram.com/p/00ROWxgu8c/?taken-by=usinterior) from
-Bear River Migratory Bird Refuge. It's from a population study, right
-before they were released. I love looking at all the owls' different
-expressions and trying to figure out what they are thinking — I can't
-help but laugh.
+It's definitely hard to pick a single favorite, but I really [love this photo of burrowing owls](https://instagram.com/p/00ROWxgu8c/?taken-by=usinterior) from Bear River Migratory Bird Refuge. It's from a population study, right before they were released. I love looking at all the owls' different expressions and trying to figure out what they are thinking — I can't help but laugh.
 
-I also really like [this tranquil
-photo](https://instagram.com/p/5qC4kegu8p/?taken-by=usinterior) from
-Glacier. It's our most popular photo of all time on our social media
-accounts. I thought it was beautiful, but it's not the normal type of
-photo we share. I was really surprised at the response — I like it
-because it's a reminder to try new things.
+I also really like [this tranquil photo](https://instagram.com/p/5qC4kegu8p/?taken-by=usinterior) from Glacier. It's our most popular photo of all time on our social media accounts. I thought it was beautiful, but it's not the normal type of photo we share. I was really surprised at the response — I like it because it's a reminder to try new things.

--- a/_posts/2016-02-02-new-us-digital-registry-authenticates-official-public-service-accounts.md
+++ b/_posts/2016-02-02-new-us-digital-registry-authenticates-official-public-service-accounts.md
@@ -6,56 +6,27 @@ authors:
 tags:
 - api
 - digitalgov community
-- partners in government
 
-excerpt: "We’d
-like to introduce to you a new API-generating repository for official
-third-party sites, social media platforms, and mobile apps in the United
-States federal government that can help you do that and remove
-bureaucratic and technological barriers between users and digital public
-services."
-description: "We’d
-like to introduce to you a new API-generating repository for official
-third-party sites, social media platforms, and mobile apps in the United
-States federal government that can help you do that and remove
-bureaucratic and technological barriers between users and digital public
-services."
+excerpt: "We’d like to introduce to you a new API-generating repository for official third-party sites, social media platforms, and mobile apps in the United States federal government that can help you do that and remove bureaucratic and technological barriers between users and digital public services."
+description: "We’d like to introduce to you a new API-generating repository for official third-party sites, social media platforms, and mobile apps in the United States federal government that can help you do that and remove bureaucratic and technological barriers between users and digital public services."
 image:
 ---
 
 *[Originally posted on Medium](https://medium.com/@GeneralServicesAdministration/new-u-s-digital-registry-authenticates-official-public-service-accounts-1f8120d67976#.upjpyxsbo) by Justin Herman, U.S. Social Media lead at [DigitalGov](http://www.digitalgov.gov/).*
 
-Whether for voter registration, health services, or questions about
-taxes, trusting what and who you engage with online is critical. We’d
-like to introduce to you a new API-generating repository for official
-third-party sites, social media platforms, and mobile apps in the federal government that can help you do that and remove
-bureaucratic and technological barriers between users and digital public
-services.
+Whether for voter registration, health services, or questions about taxes, trusting what and who you engage with online is critical. We’d like to introduce to you a new API-generating repository for official third-party sites, social media platforms, and mobile apps in the federal government that can help you do that and remove bureaucratic and technological barriers between users and digital public services.
 
-It’s called [the U.S. Digital
-Registry](https://www.digitalgov.gov/services/u-s-digital-registry/),
-and we hope you’ll join us in using it to develop a new generation of
-services that:
+It’s called [the U.S. Digital Registry](https://www.digitalgov.gov/services/u-s-digital-registry/), and we hope you’ll join us in using it to develop a new generation of services that:
 
 -   Delivers authenticated information to users across platforms, languages, and topics
 -   Supports cyber-security by deterring fake accounts that spread misinformation and steal personal data
 -   Improves performance reporting, data analysis, and accessibility of public services
 
-Official government websites are easy to recognize because they end in
-domain names like .gov and .mil. Increasingly, however, citizens choose
-to access their services, ask questions, and participate through
-third-party platforms like Facebook, Yelp, Twitter, and GitHub.
+Official government websites are easy to recognize because they end in domain names like .gov and .mil. Increasingly, however, citizens choose to access their services, ask questions, and participate through third-party platforms like Facebook, Yelp, Twitter, and GitHub.
 
+While some of those platforms authenticate public services in order to maintain trust between their users and the information they rely on, it’s not enough. We know there is a long way to go down a road that is ever changing.
 
-While some of those platforms authenticate public services in order to
-maintain trust between their users and the information they rely on,
-it’s not enough. We know there is a long way to go down a road that is
-ever changing.
-
-The rise of third-party platforms in delivering modern public services
-required us to rise beside them with greater means of maintaining
-accountability over official government accounts, and make it as easy to
-follow all public services as it was to find one.
+The rise of third-party platforms in delivering modern public services required us to rise beside them with greater means of maintaining accountability over official government accounts, and make it as easy to follow all public services as it was to find one.
 
 Here’s how it works:
 
@@ -75,60 +46,28 @@ platforms, languages, or by tags.
 companies, or public services on how future iterations of the U.S.
 Digital Registry can improve and expand.
 
-Let’s say you want to create a new Emergency Broadcast System for the
-digital age that delivers only authentic, official disaster relief
-information regardless of what agency or sub-agency it comes from
-without having to hunt across platforms — in Spanish?
+Let’s say you want to create a new Emergency Broadcast System for the digital age that delivers only authentic, official disaster relief information regardless of what agency or sub-agency it comes from without having to hunt across platforms — in Spanish?
 
 Or how about curating an inventory of open source code?
 
-What could an [analytics.usa.gov](https://analytics.usa.gov/) for all
-our digital engagement look like?
+What could an [analytics.usa.gov](https://analytics.usa.gov/) for all our digital engagement look like?
 
-What if you have a question on your veteran health benefits or federal
-student loans, but the account you’re engaging with doesn’t have that
-“little blue check mark”?
+What if you have a question on your veteran health benefits or federal student loans, but the account you’re engaging with doesn’t have that “little blue check mark”?
 
-Citizens shouldn’t have to hunt for the critical information they need
-across bureaucratic silos and emerging platforms, or second guess if the
-person who is engaging with them on the other side of the connection is
-who they say they are. The U.S. Digital Registry provides the data
-foundation you can use in order to help make these problems a thing of
-the past.
+Citizens shouldn’t have to hunt for the critical information they need across bureaucratic silos and emerging platforms, or second guess if the person who is engaging with them on the other side of the connection is who they say they are. The U.S. Digital Registry provides the data foundation you can use in order to help make these problems a thing of the past.
 
-Agencies are currently engaged in a verification sprint to increase the
-number of accounts in the U.S. Digital Registry from almost 3,000 to
-more than 6,000 by Leap Day.
+Agencies are currently engaged in a verification sprint to increase the number of accounts in the U.S. Digital Registry from almost 3,000 to more than 6,000 by Leap Day.
 
-Hundreds of managers across government are authenticating their profiles
-and enriching the data for each individual account by March 31.
+Hundreds of managers across government are authenticating their profiles and enriching the data for each individual account by March 31.
 
-We’ll continue adding new platforms and capabilities to the registry
-based on your feedback — including recommendations for collaborative
-tags and UX testing of the API.
+We’ll continue adding new platforms and capabilities to the registry based on your feedback — including recommendations for collaborative tags and UX testing of the API.
 
-In the meantime, we encourage state, local, and international public
-services bodies to [share in the open source code](https://github.com/ctacdev/social-media-registry) of the U.S.
-Digital Registry and create your own repositories so we can explore new fields of integrated, location-based services.
+In the meantime, we encourage state, local, and international public services bodies to [share in the open source code](https://github.com/ctacdev/social-media-registry) of the U.S. Digital Registry and create your own repositories so we can explore new fields of integrated, location-based services.
 
 Mashups with this would be awesome. For the people.
 
-We also encourage all third-party platforms [with Terms of Service with
-the
-government](http://www.digitalgov.gov/resources/negotiated-terms-of-service-agreements/)
-to use the registry to conclusively authenticate public service
-accounts. Not all platforms are in the registry in this first iteration,
-but we’ll get there.
+We also encourage all third-party platforms [with Terms of Service with the government](http://www.digitalgov.gov/resources/negotiated-terms-of-service-agreements/) to use the registry to conclusively authenticate public service accounts. Not all platforms are in the registry in this first iteration, but we’ll get there.
 
-The new U.S. Digital Registry combines the former Federal Social Media
-Registry and Mobile Apps Registry with a path forward to further expand
-the scope and provides a seachange in open data capabilities. We’re
-already meeting with organizations ready to use the registry API, and
-we’re determined to develop it into an expanding and evolving service
-that combines an easy-to-use tool with the active participation of
-hundreds of government technologists, innovative private-sector
-developers, news organizations, researchers, and anyone who wants
-reliable access to the public information they need.
+The new U.S. Digital Registry combines the former Federal Social Media Registry and Mobile Apps Registry with a path forward to further expand the scope and provides a seachange in open data capabilities. We’re already meeting with organizations ready to use the registry API, and we’re determined to develop it into an expanding and evolving service that combines an easy-to-use tool with the active participation of hundreds of government technologists, innovative private-sector developers, news organizations, researchers, and anyone who wants reliable access to the public information they need.
 
-So if you could make any public service easier to access with it, where
-would you start?
+So if you could make any public service easier to access with it, where would you start?

--- a/_posts/2016-02-18-analytics.usa.gov-agency-specific-dashboards.md
+++ b/_posts/2016-02-18-analytics.usa.gov-agency-specific-dashboards.md
@@ -10,22 +10,17 @@ authors:
 - juliawinn
 tags:
 - analytics.usa.gov
-- analytics
 excerpt: "We’ve added agency-specific dashboards to analytics.usa.gov! Starting today, you’ll see a dropdown from the main analytics.usa.gov page that allows you to view the same dashboard, but filtered for websites that are administered by one of 10 specific agencies."
 description: "We’ve added agency-specific dashboards to analytics.usa.gov! Starting today, you’ll see a dropdown from the main analytics.usa.gov page that allows you to view the same dashboard, but filtered for websites that are administered by one of 10 specific agencies."
 image: /assets/blog/dap/analytics-commerce.jpg
 hero: false
 ---
 
-We’ve added agency-specific dashboards to
-[analytics.usa.gov](https://analytics.usa.gov/)!
+We’ve added agency-specific dashboards to [analytics.usa.gov](https://analytics.usa.gov/)!
 
 ![The analytics dashboard for the Department of Commerce]({{site.baseurl}}/assets/blog/dap/analytics-commerce.jpg)
 
-Starting today, you’ll see a dropdown from the main
-[analytics.usa.gov](https://analytics.usa.gov/) page that allows you
-to view the same dashboard, but filtered for websites that are
-administered by one of 10 specific agencies:
+Starting today, you’ll see a dropdown from the main [analytics.usa.gov](https://analytics.usa.gov/) page that allows you to view the same dashboard, but filtered for websites that are administered by one of 10 specific agencies:
 
 -   [Department of Commerce](https://analytics.usa.gov/commerce/)
 -   [Department of Education](https://analytics.usa.gov/education/)
@@ -41,64 +36,26 @@ administered by one of 10 specific agencies:
 What do these pages show me?
 ----------------------------
 
-These dashboard pages allow for greater insight into how the public
-interacts with specific agency websites as a complement to the
-aggregated view available at analytics.usa.gov. In many cases, the
-information we see as a government-wide percentage does not perfectly
-mirror an individual agency’s data. For example, at time of writing this
-post, the domestic vs. foreign traffic on the whole of participating
-Digital Analytics Program (DAP) sites is about 90% to 10%, respectively.
-But the Veteran’s Administration specifically has a 98% to 2% ratio,
-while NASA has a 67% to 33% domestic to foreign visits ratio.
+These dashboard pages allow for greater insight into how the public interacts with specific agency websites as a complement to the aggregated view available at analytics.usa.gov. In many cases, the information we see as a government-wide percentage does not perfectly mirror an individual agency’s data. For example, at time of writing this post, the domestic vs. foreign traffic on the whole of participating Digital Analytics Program (DAP) sites is about 90% to 10%, respectively. But the Veteran’s Administration specifically has a 98% to 2% ratio, while NASA has a 67% to 33% domestic to foreign visits ratio.
 
 ![Comparison of traffic broken down by country for NASA and the VA]({{site.baseurl}}/assets/blog/dap/traffic-by-country.jpg)
 
-The pages also allow you to see things like the most popular downloads
-at an agency-level. During tax season, the IRS contributes the majority
-of downloads in the “Top Downloads” section on analytics.usa.gov, which
-is logical since it is tax season. With agency dashboards, you can
-observe downloads at the agency level.
+The pages also allow you to see things like the most popular downloads at an agency-level. During tax season, the IRS contributes the majority of downloads in the “Top Downloads” section on analytics.usa.gov, which is logical since it is tax season. With agency dashboards, you can observe downloads at the agency level.
 
 Why these agencies? Are there more to come?
 -------------------------------------------
 
-The agencies included in this initial “batch” of dashboards volunteered
-to be part of the first release. They are not representative of total
-participation in DAP, which is currently at 45 agencies. In the future,
-we hope to continue to expand the number of agency-specific pages. If
-you’d like to see a dashboard for your agency, contact us at
-[dap@support.digitalgov.gov](mailto:dap@support.digitalgov.gov).
+The agencies included in this initial “batch” of dashboards volunteered to be part of the first release. They are not representative of total participation in DAP, which is currently at 45 agencies. In the future, we hope to continue to expand the number of agency-specific pages. If you’d like to see a dashboard for your agency, contact us at [dap@support.digitalgov.gov](mailto:dap@support.digitalgov.gov).
 
 Are the dashboards representative of all agency websites?
 ---------------------------------------------------------
 
-In most cases, no. The dashboards reflect only websites that participate
-in the Digital Analytics Program. You can see which sites are included
-in the data set for each agency by downloading the “Visits to all
-Domains in the Last 30 Days” .csv file from the “Download the Data”
-section. You can also get an idea of the level of participation of an
-agency at [pulse.cio.gov](https://pulse.cio.gov/analytics/agencies/).
-If you work on a federal website that you’d like to have participate in
-DAP, email us at
-[dap@support.digitalgov.gov](mailto:dap@support.digitalgov.gov).
+In most cases, no. The dashboards reflect only websites that participate in the Digital Analytics Program. You can see which sites are included in the data set for each agency by downloading the “Visits to all Domains in the Last 30 Days” .csv file from the “Download the Data” section. You can also get an idea of the level of participation of an agency at [pulse.cio.gov](https://pulse.cio.gov/analytics/agencies/). If you work on a federal website that you’d like to have participate in DAP, email us at [dap@support.digitalgov.gov](mailto:dap@support.digitalgov.gov).
 
-We think this level of data is valuable to gain a more clear
-understanding of the kinds of interaction the public has with the
-various different parts of the federal government, and what is important
-to them. We hope you feel the same!
+We think this level of data is valuable to gain a more clear understanding of the kinds of interaction the public has with the various different parts of the federal government, and what is important to them. We hope you feel the same!
 
-*Tim Lowden leads the Digital Analytics Program, which powers
-analytics.usa.gov. Gabriel Ramirez, Gray Brooks, Eric Mill, Colin Craig,
-and Julia Winn are Innovation Specialists at 18F.*
+*Tim Lowden leads the Digital Analytics Program, which powers analytics.usa.gov. Gabriel Ramirez, Gray Brooks, Eric Mill, Colin Craig, and Julia Winn are Innovation Specialists at 18F.*
 
-*The [Digital
-Analytics Program](http://www.digitalgov.gov/services/dap/) currently
-tracks analytics data on over 4,000 U.S. federal government websites
-across 45 agencies. To learn more or to find out how your agency/website
-can participate in the program, please [email
-us](mailto:dap@support.digitalgov.gov).*
+*The [Digital Analytics Program](http://www.digitalgov.gov/services/dap/) currently tracks analytics data on over 4,000 U.S. federal government websites across 45 agencies. To learn more or to find out how your agency/website can participate in the program, please [email us](mailto:dap@support.digitalgov.gov).*
 
-*The work on
-[analytics.usa.gov](https://analytics.usa.gov/) is all open-source,
-and can be found in our [GitHub
-repo](https://github.com/18F/analytics.usa.gov).*
+*The work on [analytics.usa.gov](https://analytics.usa.gov/) is all open-source, and can be found in our [GitHub repo](https://github.com/18F/analytics.usa.gov).*

--- a/_posts/2016-03-03-five-questions-for-the-nasa-chief-historian.md
+++ b/_posts/2016-03-03-five-questions-for-the-nasa-chief-historian.md
@@ -5,7 +5,7 @@ authors:
 - kate
 tags:
 - speaker series
-- partners in government
+- interview
 excerpt: "Dr. Bill Barry — NASA’s Chief Historian since 2010 — will soon be visiting 18F to talk about the history of NASA’s logo. Here, read his insights on why “the meatball” is so popular, his advice to young folks considering careers in aeronautics, and more."
 description: "Dr. Bill Barry — NASA’s Chief Historian since 2010 — will soon be visiting 18F to talk about the history of NASA’s logo. Here, read his insights on why “the meatball” is so popular, his advice to young folks considering careers in aeronautics, and more."
 image: /assets/blog/nasa-historian/space.jpg

--- a/_posts/2016-03-08-san-diego-summit-opens-doors-to-technology-partnerships.md
+++ b/_posts/2016-03-08-san-diego-summit-opens-doors-to-technology-partnerships.md
@@ -5,7 +5,7 @@ authors:
 - andrewmcmahon
 tags:
 - events
-- gsa
+- general services administration
 excerpt: "On March 18, the U.S. General Services Administration (GSA) will co-host the San Diego Summit on Emerging Digital Technology and Government as part of our work to bring new, emerging technology to the federal government."
 description: "On March 18, the U.S. General Services Administration (GSA) will co-host the San Diego Summit on Emerging Digital Technology and Government as part of our work to bring new, emerging technology to the federal government."
 image: /assets/blog/events/san-diego.jpg

--- a/_posts/2016-03-28-interesting-things-we-learned-from-examining-traffic-patterns-on-analytics-usa-gov.md
+++ b/_posts/2016-03-28-interesting-things-we-learned-from-examining-traffic-patterns-on-analytics-usa-gov.md
@@ -6,7 +6,6 @@ authors:
 - melody
 tags:
 - analytics.usa.gov
-- analytics
 excerpt: "Ten federal agencies now have public dashboards and datasets for their web traffic on analytics.usa.gov. The dashboards show insights into how the public interacts with specific agency websites."
 description: "Ten federal agencies now have public dashboards and datasets for their web traffic on analytics.usa.gov. The dashboards show insights into how the public interacts with specific agency websites."
 image: /assets/blog/dap/epa-analytics.jpg
@@ -14,9 +13,7 @@ image: /assets/blog/dap/epa-analytics.jpg
 
 [![A screenshot of the Environmental Protection Agency's dashboard on analytics.usa.gov]({{site.baseurl}}/assets/blog/dap/epa-analytics.jpg)](https://analytics.usa.gov/environmental-protection-agency/)
 
-Ten federal agencies [now have public dashboards and
-datasets](https://18f.gsa.gov/2016/02/18/analytics.usa.gov-agency-specific-dashboards/)
-for their web traffic on analytics.usa.gov. The dashboards show insights into how the public interacts with specific agency websites.
+Ten federal agencies [now have public dashboards and datasets](https://18f.gsa.gov/2016/02/18/analytics.usa.gov-agency-specific-dashboards/) for their web traffic on analytics.usa.gov. The dashboards show insights into how the public interacts with specific agency websites.
 
 Using the new dashboards, you can discover things like:
 
@@ -26,20 +23,8 @@ Using the new dashboards, you can discover things like:
 -   Most people who visit the Department of Education’s site [head to a page on student aid](https://analytics.usa.gov/education/).
 -   Over 500 people [downloaded a trip planner](http://www.nps.gov/yell/planyourvisit/upload/16Trip_planner_FINAL_web.pdf) to visit Yellowstone National Park.
 
-The data provides a window into how people are interacting with the
-government and specific agency websites online. In addition to federal
-agencies, cities and states are [now adapting analytics.usa.gov for
-their own
-use](https://18f.gsa.gov/2016/01/06/tips-for-adapting-analytics-usa-gov/).
+The data provides a window into how people are interacting with the government and specific agency websites online. In addition to federal agencies, cities and states are [now adapting analytics.usa.gov for their own use](https://18f.gsa.gov/2016/01/06/tips-for-adapting-analytics-usa-gov/).
 
-The data is also available if you’d like to see trends across operating
-systems or web browsers, or see what topics people find interesting.
+The data is also available if you’d like to see trends across operating systems or web browsers, or see what topics people find interesting.
 
-The [Digital Analytics
-Program](http://www.digitalgov.gov/services/dap/) currently tracks
-analytics data on over 4,000 U.S. federal government websites across 45
-agencies. To learn more or to find out how your agency or website can
-participate in the program, please email the [Digital Analytics
-Program](mailto:dap@support.digitalgov.gov). The work on [analytics.usa.gov](https://analytics.usa.gov/) is all
-open-source, and can be found in our [GitHub
-repo](https://github.com/18F/analytics.usa.gov).
+The [Digital Analytics Program](http://www.digitalgov.gov/services/dap/) currently tracks analytics data on over 4,000 U.S. federal government websites across 45 agencies. To learn more or to find out how your agency or website can participate in the program, please email the [Digital Analytics Program](mailto:dap@support.digitalgov.gov). The work on [analytics.usa.gov](https://analytics.usa.gov/) is all open-source, and can be found in our [GitHub repo](https://github.com/18F/analytics.usa.gov).

--- a/_posts/2016-04-01-what-10-weeks-at-18f-taught-me.md
+++ b/_posts/2016-04-01-what-10-weeks-at-18f-taught-me.md
@@ -5,7 +5,7 @@ authors:
 - cat-langel
 tags:
 - culture
-- gsa
+- general services administration
 - communicart
 excerpt: "Calling 18F home for the past two months has given me the opportunity to
 grow in countless ways. I’ve pushed myself in ways I wasn’t expecting."

--- a/_posts/2016-04-05-three-teams-using-the-draft-us-web-design-standards-talk-about-their-experiences.md
+++ b/_posts/2016-04-05-three-teams-using-the-draft-us-web-design-standards-talk-about-their-experiences.md
@@ -4,7 +4,6 @@ date: 2016-04-05
 authors:
 - melody
 tags:
-- our projects
 - web design standards
 - u.s. digital service
 - open source

--- a/_posts/2016-04-26-thinking-about-the-future-of-the-post-office-an-interview-with-amanda-weaver.md
+++ b/_posts/2016-04-26-thinking-about-the-future-of-the-post-office-an-interview-with-amanda-weaver.md
@@ -4,303 +4,109 @@ date: 2016-04-26
 authors:
 - melody
 tags:
-- partners in government
+- interview
 description: “Amanda Weaver&rsquo;s team at the U.S. Postal Service Office of Inspector General  operates like a government think-tank. They write white papers on everything from 3D printing to the Internet of Postal Things. We talked to Amanda about the futuristic things her office is dreaming up for the post office of the future.”
 excerpt: “Amanda Weaver&rsquo;s team at the U.S. Postal Service Office of Inspector General  operates like a government think-tank. They write white papers on everything from 3D printing to the Internet of Postal Things. We talked to Amanda about the futuristic things her office is dreaming up for the post office of the future.”
 image: /assets/blog/partners-in-government/internet-of-postal-things.jpg
 ---
 
-Imagine receiving a text message every time a new letter was placed in
-your mailbox, or your city receiving a notification when there was a new
-pothole in your neighborhood — courtesy of a sensor that had been placed
-on your neighborhood mail truck.
+Imagine receiving a text message every time a new letter was placed in your mailbox, or your city receiving a notification when there was a new pothole in your neighborhood — courtesy of a sensor that had been placed on your neighborhood mail truck.
 
-These are the types of things that Amanda Weaver and her colleagues
-think up at the Risk Analysis Research Center (RARC) at the U.S. Postal
-Service Office of Inspector General’s Office. Her team operates like a
-government think-tank, writing white papers on everything from [3D
-printing](https://www.uspsoig.gov/document/update-3d-printing-and-postal-service)
-to the [Internet of Postal
-Things](https://www.uspsoig.gov/document/internet-postal-things) to
-ways that [post offices could provide financial services for
-underserved
-populations](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-14-007_0.pdf).
-They basically think about what a post office could be and how it could
-operate — and then research and write up reports that are relevant to
-the Postal Service.
+These are the types of things that Amanda Weaver and her colleagues think up at the Risk Analysis Research Center (RARC) at the U.S. Postal Service Office of Inspector General’s Office. Her team operates like a government think-tank, writing white papers on everything from [3D printing](https://www.uspsoig.gov/document/update-3d-printing-and-postal-service) to the [Internet of Postal Things](https://www.uspsoig.gov/document/internet-postal-things) to ways that [post offices could provide financial services for underserved populations](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-14-007_0.pdf). They basically think about what a post office could be and how it could operate — and then research and write up reports that are relevant to the Postal Service.
 
-We reached out to Amanda after learning about her work to see if she
-would tell us more about what the RARC thinks about and does on a daily
-basis.
+We reached out to Amanda after learning about her work to see if she would tell us more about what the RARC thinks about and does on a daily basis.
 
-**Melody Kramer: You work with a research group at the Postal Service’s
-Office of Inspector General. Can you describe some of the projects your
-team works on and what you’ve published?**
+**Melody Kramer: You work with a research group at the Postal Service’s Office of Inspector General. Can you describe some of the projects your team works on and what you’ve published?**
 
-**Amanda Weaver:** We are a small research group generating strategic
-ideas for the efficiency of USPS. We work on different and interesting
-research topics — and have a diversified portfolio focusing on several
-major themes.
+**Amanda Weaver:** We are a small research group generating strategic ideas for the efficiency of USPS. We work on different and interesting research topics — and have a diversified portfolio focusing on several major themes.
 
-I’m going to list some of our current projects and things we’re thinking
-about:
+I’m going to list some of our current projects and things we’re thinking about:
 
-**Enhancing the value of mail to digital natives.** We see these digital
-natives as the future. By 2017, they will be 40 percent of the U.S.
-population with the most economic purchasing power. We’re taking a
-two-pronged approach to this:
+**Enhancing the value of mail to digital natives.** We see these digital natives as the future. By 2017, they will be 40 percent of the U.S. population with the most economic purchasing power. We’re taking a two-pronged approach to this:
 
-First, we’re trying to [understand their revealed
-preferences](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-15-012.pdf)
-using the latest scientific techniques from neuroscience. Second, we’re
-focused on innovations within the mail itself. How can we use the latest
-technology to make the physical mail piece more digitally interactive
-and thus more appealing to the digital natives?
+First, we’re trying to [understand their revealed preferences](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-15-012.pdf) using the latest scientific techniques from neuroscience. Second, we’re focused on innovations within the mail itself. How can we use the latest technology to make the physical mail piece more digitally interactive and thus more appealing to the digital natives?
 
 [![A map of potential pieces of the internet of postal things]({{site.baseurl}}/assets/blog/partners-in-government/internet-of-postal-things.jpg)](https://www.uspsoig.gov/document/internet-postal-things)
 *A page from the [report on the Internet of Postal Things](https://www.uspsoig.gov/document/internet-postal-things)*
 
-**The Internet of Postal Things.** We’re imagining [how the rich
-infrastructure of the Postal Service could be
-used](https://www.uspsoig.gov/document/internet-postal-things) if it
-were outfitted with sensors and interconnected with each other as well
-as the internet. This would create useful information to make the postal
-system smarter, and allow it to collect really useful information to the
-localities as a byproduct — think about sensors that could measure road
-conditions, the strength of mobile signals, or monitor air quality. We
-are currently expanding on this concept in another paper to explain how
-the Internet of Postal Things could aid in the efforts of “Smart
-Cities.”
+**The Internet of Postal Things.** We’re imagining [how the rich infrastructure of the Postal Service could be used](https://www.uspsoig.gov/document/internet-postal-things) if it were outfitted with sensors and interconnected with each other as well as the internet. This would create useful information to make the postal system smarter, and allow it to collect really useful information to the localities as a byproduct — think about sensors that could measure road conditions, the strength of mobile signals, or monitor air quality. We are currently expanding on this concept in another paper to explain how the Internet of Postal Things could aid in the efforts of “Smart Cities.”
 
-**Keeping up with new technology.** We also keep up and report on what’s
-happening in the parcel market in terms of new technologies (robots,
-algorithms, driverless cars, drones, etc.), and new entrants with new
-business models (startups like Postmates, Shyp, Deliv; regional
-carriers; retailers delivering their own goods like Amazon; and the
-traditional players like FedEx and UPS).
+**Keeping up with new technology.** We also keep up and report on what’s happening in the parcel market in terms of new technologies (robots, algorithms, driverless cars, drones, etc.), and new entrants with new business models (startups like Postmates, Shyp, Deliv; regional carriers; retailers delivering their own goods like Amazon; and the traditional players like FedEx and UPS).
 
-**Monitoring innovation.** To expand our research, we’ve recently
-started an effort to more closely monitor innovation and startups in
-Silicon Valley and other tech hubs. We reach out to people and companies
-there to meet and talk about their work.
+**Monitoring innovation.** To expand our research, we’ve recently started an effort to more closely monitor innovation and startups in Silicon Valley and other tech hubs. We reach out to people and companies there to meet and talk about their work.
 
-<br/>
-**MK: I’m really interested by the idea of the Internet of Postal
-Things. I know your office has written** [**a white
-paper**](https://www.uspsoig.gov/document/internet-postal-things)
-**about this topic. You mention more than a dozen possible applications
-— I’m wondering if you could talk a little bit about how the distributed
-infrastructure of the post office supports this kind of innovation, and
-the possibilities that the post office could provide based on having
-this distributed workforce.**
+**MK: I’m really interested by the idea of the Internet of Postal Things. I know your office has written** [**a white paper**](https://www.uspsoig.gov/document/internet-postal-things) **about this topic. You mention more than a dozen possible applications — I’m wondering if you could talk a little bit about how the distributed infrastructure of the post office supports this kind of innovation, and the possibilities that the post office could provide based on having this distributed workforce.**
 
-**AW:** It comes down to ubiquity, frequency, and regularity. The Postal
-Service is everywhere: it works seven days a week and on a predictable
-regular schedule. Combine this with leveraging sensors on an
-infrastructure of over 500,000 employees, 31,000 post offices, and
-214,000 vehicles and there are huge possibilities with the Internet of
-Things. I’m going to highlight some really interesting applications:
+**AW:** It comes down to ubiquity, frequency, and regularity. The Postal Service is everywhere: it works seven days a week and on a predictable regular schedule. Combine this with leveraging sensors on an infrastructure of over 500,000 employees, 31,000 post offices, and 214,000 vehicles and there are huge possibilities with the Internet of Things. I’m going to highlight some really interesting applications:
 
-**The "You've Got Mail" moment**. We’ve thought about how sensors in
-mail boxes could send you a text message the second mail is delivered to
-your mailbox. This could make the mail moment more exciting (Think about
-the red numbers on Facebook that show you have a message. We could
-create a similar experience for physical mail.)
+**The "You've Got Mail" moment**. We’ve thought about how sensors in mail boxes could send you a text message the second mail is delivered to your mailbox. This could make the mail moment more exciting (Think about the red numbers on Facebook that show you have a message. We could create a similar experience for physical mail.)
 
-**Sensors on postal vehicles to measure and report road conditions**.
-Mail trucks travel down every street every day anyway. If we put sensors
-on mail trucks, we could provide valuable data about road conditions,
-potholes etc. without the need for cities, counties, or state-level
-Departments of Transportation to send people out to do it.
+**Sensors on postal vehicles to measure and report road conditions**. Mail trucks travel down every street every day anyway. If we put sensors on mail trucks, we could provide valuable data about road conditions, potholes etc. without the need for cities, counties, or state-level Departments of Transportation to send people out to do it.
 
-**Sensors to report mobile signals.** Postal trucks could also be
-equipped with sensors that test the strength of a mobile signal in every
-part of the country. This data could be valuable to companies that
-provide broadband internet to let them know where their signals are weak
-or non-existent.
+**Sensors to report mobile signals.** Postal trucks could also be equipped with sensors that test the strength of a mobile signal in every part of the country. This data could be valuable to companies that provide broadband internet to let them know where their signals are weak or non-existent.
 
-<br/>
-**MK: Jumping to a different white paper I read: How might** [**3D
-printing**](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-14-011_if_it_prints_it_ships_3d_printing_and_the_postal_service_0.pdf)
-**(pdf) disrupt logistics, and how is the post office thinking about
-that? I’m especially curious about those last mile regions: where they
-are and what innovations are out there to support shortening supply
-chains?**
+**MK: Jumping to a different white paper I read: How might** [**3D printing**](https://www.uspsoig.gov/sites/default/files/document-library-files/2015/rarc-wp-14-011_if_it_prints_it_ships_3d_printing_and_the_postal_service_0.pdf) **(pdf) disrupt logistics, and how is the post office thinking about that? I’m especially curious about those last mile regions: where they are and what innovations are out there to support shortening supply chains?**
 
-**AW:** What's great about 3D printing is that it enables rapid
-prototyping and mass customization leading to more manufacturing of
-lightweight items locally. This is our strength, i.e. delivering stuff
-locally and the delivery of lightweight parcels. So the Postal Service
-would be ideal for delivering 3D-printed light objects and even the raw
-material to all those local small manufacturers (the so-called Makers).
-We think there is a $500 million opportunity in new parcels.
+**AW:** What's great about 3D printing is that it enables rapid prototyping and mass customization leading to more manufacturing of lightweight items locally. This is our strength, i.e. delivering stuff locally and the delivery of lightweight parcels. So the Postal Service would be ideal for delivering 3D-printed light objects and even the raw material to all those local small manufacturers (the so-called Makers). We think there is a $500 million opportunity in new parcels.
 
-<br/>
-**MK: What can we do as citizens who love the Postal Service to keep it
-going? Also, are there any changes coming for self-service, etc?**
+**MK: What can we do as citizens who love the Postal Service to keep it going? Also, are there any changes coming for self-service, etc?**
 
-**AW:** Self-service kiosks require an initial investment that is
-probably very high. I don’t see there being a massive roll-out of them
-in every post office. But, I do think there is interest in having more
-of them in offices where it makes sense.
+**AW:** Self-service kiosks require an initial investment that is probably very high. I don’t see there being a massive roll-out of them in every post office. But, I do think there is interest in having more of them in offices where it makes sense.
 
-As people, in my opinion, I think the important thing to understand is
-how much of a role regulation plays in how the Postal Service must
-conduct business. The Postal Service faces regulatory hurdles that no
-private-sector firm would ever have to deal with. It’s expected to
-generate its own income, yet it’s stifled by legislation that doesn’t
-allow it to offer new products and services, participate in mergers and
-acquisitions, or move as quickly as a private corporation. I think
-knowing the impact legislation plays in the future of the Postal Service
-is critical to understanding the way forward. 
+As people, in my opinion, I think the important thing to understand is how much of a role regulation plays in how the Postal Service must conduct business. The Postal Service faces regulatory hurdles that no private-sector firm would ever have to deal with. It’s expected to generate its own income, yet it’s stifled by legislation that doesn’t allow it to offer new products and services, participate in mergers and acquisitions, or move as quickly as a private corporation. I think knowing the impact legislation plays in the future of the Postal Service is critical to understanding the way forward. 
 
-<br/>
-**MK: How is the Postal Service Inspector General using current (and
-near-future) technology to change how it does business? (For example,
-are you testing with drone delivery, AI-routing for delivery efficiency,
-etc.?)**
+**MK: How is the Postal Service Inspector General using current (and near-future) technology to change how it does business? (For example, are you testing with drone delivery, AI-routing for delivery efficiency, etc.?)**
 
-**AW:** We are currently surveying technological innovations and
-disruptions in last-mile parcel delivery, including robotics, drone
-delivery, autonomous vehicles, and dynamic routing.
+**AW:** We are currently surveying technological innovations and disruptions in last-mile parcel delivery, including robotics, drone delivery, autonomous vehicles, and dynamic routing.
 
-<br/>
-**MK: We're starting to see user-facing improvements in delivery
-already, such as the recent feature for users to re-route packages in
-transit via the web. How important are these web-based customer
-improvements to the overall business of the Postal Service, and what can
-we expect in the future?**
+**MK: We're starting to see user-facing improvements in delivery already, such as the recent feature for users to re-route packages in transit via the web. How important are these web-based customer improvements to the overall business of the Postal Service, and what can we expect in the future?**
 
-**AW:** The key is to allow customers more control over their mail and
-parcels through their digital devices — anywhere, anytime, on any device
-for a customer-controlled experience. The information about a package
-could be as important as the package and sometimes more. The Postal
-Service is starting to expand on these types of services with new
-features being added to the My USPS site.
+**AW:** The key is to allow customers more control over their mail and parcels through their digital devices — anywhere, anytime, on any device for a customer-controlled experience. The information about a package could be as important as the package and sometimes more. The Postal Service is starting to expand on these types of services with new features being added to the My USPS site.
 
-<br/>
-**MK: How has same-day delivery from internet retailers impacted
-your business?**
+**MK: How has same-day delivery from internet retailers impacted your business?**
 
-**AW:** It's a competitive pressure for sure, but it’s still not clear
-if the underlying economics will support this notion beyond niche
-applications. But certainly you cannot ignore it. People want their
-online purchases ASAP or even within two hours of that purchase — and
-retailers want to cater to the instant gratification from impulsive
-purchasing. This is an area we are monitoring within our research group.
+**AW:** It's a competitive pressure for sure, but it’s still not clear if the underlying economics will support this notion beyond niche applications. But certainly you cannot ignore it. People want their online purchases ASAP or even within two hours of that purchase — and retailers want to cater to the instant gratification from impulsive purchasing. This is an area we are monitoring within our research group.
 
-<br/>
-**MK: How does the Postal Service Inspector General’s office think about
-innovation when it comes to serving rural communities? I’m assuming
-there are different needs in a rural area versus an urban one — could
-you talk a little bit about how your office thinks about the various
-needs of different post offices?**
+**MK: How does the Postal Service Inspector General’s office think about innovation when it comes to serving rural communities? I’m assuming there are different needs in a rural area versus an urban one — could you talk a little bit about how your office thinks about the various needs of different post offices?**
 
-**AW:** From a research perspective, we are very aware of the different
-needs associated with rural versus urban post offices, and we try to
-consider this with each research project. The experience is different,
-the needs of the customer are different, and the role the post office
-plays in those communities is different. I think that in considering
-what the post office of the future should be, you have to think about
-these different areas in different ways, and we’re always thinking about
-how we can’t take a “one size fits all” solution.
+**AW:** From a research perspective, we are very aware of the different needs associated with rural versus urban post offices, and we try to consider this with each research project. The experience is different, the needs of the customer are different, and the role the post office plays in those communities is different. I think that in considering what the post office of the future should be, you have to think about these different areas in different ways, and we’re always thinking about how we can’t take a “one size fits all” solution.
 
-<br/>
-**MK: I read about the** [**Post Office in your
-Pocket**](https://www.uspsoig.gov/document/retail-opportunities-us-postal-service)
-**and the idea of the post office as a community hub. Could you talk a
-little bit about those and other ideas your office is working on?**
+**MK: I read about the** [**Post Office in your Pocket**](https://www.uspsoig.gov/document/retail-opportunities-us-postal-service) **and the idea of the post office as a community hub. Could you talk a little bit about those and other ideas your office is working on?**
 
-**AW:** The Postal Service is in every community every day anyway (and
-it would be costly for others to establish presence), and our presence
-in rural areas tends to be valued not just for postal services but also
-as a community hub. You can harness tremendous economies of scope by
-offering community services such as e-government and e-health using
-postal space and infrastructure.
+**AW:** The Postal Service is in every community every day anyway (and it would be costly for others to establish presence), and our presence in rural areas tends to be valued not just for postal services but also as a community hub. You can harness tremendous economies of scope by offering community services such as e-government and e-health using postal space and infrastructure.
 
-With this in mind, we identified five areas of retail opportunity for
-the Post Office:
+With this in mind, we identified five areas of retail opportunity for the Post Office:
 
-1\. **The Community Hub** — an exploration of how the local Post Office
-can serve as a “one-stop shop” of community and government services and
-resources.
+1\. **The Community Hub** — an exploration of how the local Post Office can serve as a “one-stop shop” of community and government services and resources.
 
-2\. **The Future is Now** — a summary of ideas to address potential
-platforms, services, and products that might provide greater service to
-the public and improve the Postal Service’s outlook.
+2\. **The Future is Now** — a summary of ideas to address potential platforms, services, and products that might provide greater service to the public and improve the Postal Service’s outlook.
 
-3\. **Innovative Post Office Facilities** — creative enhancements at
-local Post Office facilities can enrich the customer experience.
+3\. **Innovative Post Office Facilities** — creative enhancements at local Post Office facilities can enrich the customer experience.
 
-4\. **Post Office in Your Pocket** — digital and mobile products and
-services to go.
+4\. **Post Office in Your Pocket** — digital and mobile products and services to go.
 
-5\. **Getting There** — fundamental restrictions, including philosophies,
-laws, and regulations to overcome.
+5\. **Getting There** — fundamental restrictions, including philosophies, laws, and regulations to overcome.
 
-These opportunities would compare with those of certain foreign postal
-organizations that are rapidly transforming into organizations that
-provide a range of business and innovative offerings and using mobile
-devices to create value for existing products and services.
+These opportunities would compare with those of certain foreign postal organizations that are rapidly transforming into organizations that provide a range of business and innovative offerings and using mobile devices to create value for existing products and services.
 
-<br/>
-**MK: I want to learn a little more about the Inspector General’s
-Office, which sits outside of the Postal Service and operates more like
-a think tank that makes recommendations for the post office.** **How
-many people do you work with? What is a typical day like for you and
-your coworkers and how does user research inform the reports that you
-produce?**
+**MK: I want to learn a little more about the Inspector General’s Office, which sits outside of the Postal Service and operates more like a think tank that makes recommendations for the post office.** **How many people do you work with? What is a typical day like for you and your coworkers and how does user research inform the reports that you produce?**
 
-**AW:** There are about 30 of us. The work environment here is great. I
-say this because of the people here — everyone really cares about the
-future of the Postal Service and talking about the research we are
-doing. It’s something we even talk about at happy hour after leaving the
-office. When I first moved to DC, before coming to the **Risk Analysis
-Research Center (RARC) in the Office of the Inspector General**, it
-seemed like everyone here took themselves SO seriously. It’s such a
-relief to be in a work environment where people care about their work
-but are down-to-earth at the same time.
+**AW:** There are about 30 of us. The work environment here is great. I say this because of the people here — everyone really cares about the future of the Postal Service and talking about the research we are doing. It’s something we even talk about at happy hour after leaving the office. When I first moved to DC, before coming to the **Risk Analysis Research Center (RARC) in the Office of the Inspector General**, it seemed like everyone here took themselves SO seriously. It’s such a relief to be in a work environment where people care about their work but are down-to-earth at the same time.
 
-Here’s a photo of one of our whiteboards, where we track complaints of
-the RARCers who bike to work everyday.
+Here’s a photo of one of our whiteboards, where we track complaints of the RARCers who bike to work everyday.
 
 ![A whiteboard with stick figures for every day o fthe week and a chart about the benefits of biking to work.]({{site.baseurl}}/assets/blog/partners-in-government/rarc.jpg)
 
-Check out these links ([1](https://www.instagram.com/rootchopper/), [2](https://www.flickr.com/photos/rootchopper/sets/72157662509216092), [3](https://rootchopper.wordpress.com/2015/12/11/the-office-bike-commuting-matrix/)) to see where others have been posted by another
-RARCer, John Pickett:
+Check out these links ([1](https://www.instagram.com/rootchopper/), [2](https://www.flickr.com/photos/rootchopper/sets/72157662509216092), [3](https://rootchopper.wordpress.com/2015/12/11/the-office-bike-commuting-matrix/)) to see where others have been posted by another RARCer, John Pickett:
 
-*(Editor's note: The Office of the Inspector General at the Postal Service is
-really serious about their biking.)*
+*(Editor's note: The Office of the Inspector General at the Postal Service is really serious about their biking.)*
 
-<br/>
-**MK: One last question: what was your path to your current role? I’m
-always fascinated by the myriad of jobs that exist in the federal
-government: How did you get to where you are today?**
+**MK: One last question: what was your path to your current role? I’m always fascinated by the myriad of jobs that exist in the federal government: How did you get to where you are today?**
 
 **AW:** Where do I begin?? When I was a little girl….just kidding!
 
-More seriously, I studied International Relations in grad school. At the
-time I was focused on foreign policy, and really wanted to work in
-government. After grad school I started applying to jobs that were
-research-focused, since research was my primary skill upon graduation. I
-attended grad school in London, and when it was over I moved back home
-while job hunting. “Home” was far from D.C., and I didn’t have much luck
-with applications not being in the area. I didn’t have the money to up
-and move to D.C. and hang out or intern until I got a full time job. So,
-I went to work for the Ritz-Carlton in New Orleans. I had worked there
-the year between undergrad and grad school.
+More seriously, I studied International Relations in grad school. At the time I was focused on foreign policy, and really wanted to work in government. After grad school I started applying to jobs that were research-focused, since research was my primary skill upon graduation. I attended grad school in London, and when it was over I moved back home while job hunting. “Home” was far from D.C., and I didn’t have much luck with applications not being in the area. I didn’t have the money to up and move to D.C. and hang out or intern until I got a full time job. So, I went to work for the Ritz-Carlton in New Orleans. I had worked there the year between undergrad and grad school.
 
-I talked to someone in sales, who told me that at the D.C. properties,
-there are diplomatic sales positions. With my background, she thought it
-would be interesting to me to work with embassies. When one of these
-positions became available, I applied and got a job in the D.C. area. I
-quickly moved out of this sales position and into a more market research
-and communications role.
+I talked to someone in sales, who told me that at the D.C. properties, there are diplomatic sales positions. With my background, she thought it would be interesting to me to work with embassies. When one of these positions became available, I applied and got a job in the D.C. area. I quickly moved out of this sales position and into a more market research and communications role.
 
-After being there for about eight months, I received an offer at RARC.
-Whoever tells you that USAJobs is a black hole for resumes may be
-telling the truth. But, in my case, it worked! I work on the Global,
-Digital, and Innovation team within RARC, so when I was applying, the
-“global” part of the description caught my eye. Once I went online and
-saw the type of research the group did, I was curious to say the least.
-May marks two years that I’ve been here.
+After being there for about eight months, I received an offer at RARC. Whoever tells you that USAJobs is a black hole for resumes may be telling the truth. But, in my case, it worked! I work on the Global, Digital, and Innovation team within RARC, so when I was applying, the “global” part of the description caught my eye. Once I went online and saw the type of research the group did, I was curious to say the least. May marks two years that I’ve been here.

--- a/_posts/2016-05-02-from-spreadsheet-to-api-to-app-a-better-contract-forecast-tool.md
+++ b/_posts/2016-05-02-from-spreadsheet-to-api-to-app-a-better-contract-forecast-tool.md
@@ -8,78 +8,37 @@ tags:
 - acquisition services
 - procurement
 - tools you can use
-- partners in government
+- general services administration
+- agency work
 excerpt: "Executive branch agencies of the federal government are required by law to tell vendors if and when they plan on making purchases. The General Services Administration (GSA) was forecasting using a crowded spreadsheet containing dozens of columns and hundreds of rows. 18F helped create a new, open-source tool to display contract forecasting opportunities."
 description: "Executive branch agencies of the federal government are required by law to tell vendors if and when they plan on making purchases. The General Services Administration (GSA) was forecasting using a crowded spreadsheet containing dozens of columns and hundreds of rows. 18F helped create a new, open-source tool to display contract forecasting opportunities."
 image: /assets/blog/osbu-forecast/forecast-tool.jpg
 ---
 
-Executive branch agencies of the federal government are required by law
-to tell vendors if and when they plan on making purchases. Everything
-from printers to elevator maintenance is “forecast” out to industry so
-that companies can anticipate when and how to compete to do business
-with the government. The General Services Administration (GSA) was
-forecasting using a crowded spreadsheet containing dozens of columns and
-hundreds of rows — all of which had to be updated manually. As part of
-Administrator Denise Turner Roth’s [Making it Easier
-initiative](http://www.gsa.gov/portal/content/252215), 18F helped
-create a new, [open-source tool](https://github.com/18f/forecast) to
-display [contract forecasting
-opportunities](https://gsaforecast.gsa.gov) and allow for keyword
-search and filtering.
+Executive branch agencies of the federal government are required by law to tell vendors if and when they plan on making purchases. Everything from printers to elevator maintenance is “forecast” out to industry so that companies can anticipate when and how to compete to do business with the government. The General Services Administration (GSA) was forecasting using a crowded spreadsheet containing dozens of columns and hundreds of rows — all of which had to be updated manually. As part of Administrator Denise Turner Roth’s [Making it Easier initiative](http://www.gsa.gov/portal/content/252215), 18F helped create a new, [open-source tool](https://github.com/18f/forecast) to display [contract forecasting opportunities](https://gsaforecast.gsa.gov) and allow for keyword search and filtering.
 
 ## Making it easier for business
 
-The [GSA Office of Small Business
-Utilization](http://www.gsa.gov/portal/category/21015) (OSBU) is
-required to compile projections of contracting opportunities that
-small, disadvantaged, and women-owned businesses may be able to
-perform. However, GSA was only publishing their own agency data — thus
-requiring businesses to go to dozens of agency web sites just to find
-forecast information for those agencies.
+The [GSA Office of Small Business Utilization](http://www.gsa.gov/portal/category/21015) (OSBU) is required to compile projections of contracting opportunities that small, disadvantaged, and women-owned businesses may be able to perform. However, GSA was only publishing their own agency data — thus requiring businesses to go to dozens of agency web sites just to find forecast information for those agencies.
 
 ![A screenshot of a OSBU's original spreadsheet]({{site.baseurl}}/assets/blog/osbu-forecast/spreadsheet.jpg)
 *OSBU's original vendor forecast featured thousands of rows of
 complex data*
 
-As 18F began development, we spoke with a variety of small businesses
-across the country to learn what information is most important to them
-when deciding to pursue federal contracts. The findings from this
-research (searching by NAICS code, filtering by location) directly
-informed the design and layout decisions we made when building the tool.
-We used the [Draft U.S. Web Design
-Standards](https://standards.usa.gov/) to ensure the site looked great
-on mobile and tablet devices.
+As 18F began development, we spoke with a variety of small businesses across the country to learn what information is most important to them when deciding to pursue federal contracts. The findings from this research (searching by NAICS code, filtering by location) directly informed the design and layout decisions we made when building the tool. We used the [Draft U.S. Web Design Standards](https://standards.usa.gov/) to ensure the site looked great on mobile and tablet devices.
 
 ## Performance improvements and iteration
 
-Ultimately, 18F used an [API](https://gsaforecast.18f.gov/api/)-first
-approach to build a lightweight, easy-to-use Django application with a
-simple backend that OSBU can use to quickly update forecasts. With easy 
-updating, vendors have up-to-date forecasting information throughout 
-the year instead of just quarterly. During research and development, 
-we also found that GSA and external users had a variety of unique use cases; 
-providing an API makes integrations with and extensions of the data possible.
+Ultimately, 18F used an [API](https://gsaforecast.18f.gov/api/)-first approach to build a lightweight, easy-to-use Django application with a simple backend that OSBU can use to quickly update forecasts. With easy updating, vendors have up-to-date forecasting information throughout the year instead of just quarterly. During research and development, we also found that GSA and external users had a variety of unique use cases; providing an API makes integrations with and extensions of the data possible.
 
-We also uploaded five additional agencies’ forecasting data into 
-the tool to allow businesses to search one time to see a larger universe of results. For vendors who
-prefer to use the spreadsheet, the tool allows users to download
-filtered spreadsheets containing their specific search results.
+We also uploaded five additional agencies’ forecasting data into the tool to allow businesses to search one time to see a larger universe of results. For vendors who prefer to use the spreadsheet, the tool allows users to download filtered spreadsheets containing their specific search results.
 
-The beta version of the site is available at
-[gsaforecast.gsa.gov](https://gsaforecast.gsa.gov) and you can read
-OSBU Director Jerome Fletcher’s announcement post about the tool [on
-the GSA
-blog](http://gsablogs.gsa.gov/gsablog/2016/03/15/new-gsa-small-business-contracting-forecast-tool-will-drive-community-economic-development/).
+The beta version of the site is available at [gsaforecast.gsa.gov](https://gsaforecast.gsa.gov) and you can read OSBU Director Jerome Fletcher’s announcement post about the tool [on the GSA blog](http://gsablogs.gsa.gov/gsablog/2016/03/15/new-gsa-small-business-contracting-forecast-tool-will-drive-community-economic-development/).
 
 ![The homepage of the new OSBU forecast tool]({{site.baseurl}}/assets/blog/osbu-forecast/forecast-tool.jpg)
 *The new GSA forecast tool is mobile optimized and allows for
 keyword searching across multiple agencies.*
 
-If you have any questions about the tool, email
-[forecasthelp@gsa.gov](mailto:forecasthelp@gsa.gov). Meanwhile, if you
-would like to stay informed about other 18F acquisition projects, sign
-up for [our acquisition email
-list](https://gsa.us9.list-manage.com/subscribe?u=6f1977de9eff4c384dc8d6527&id=e7f757afe3).
+If you have any questions about the tool, email [forecasthelp@gsa.gov](mailto:forecasthelp@gsa.gov). Meanwhile, if you would like to stay informed about other 18F acquisition projects, sign up for [our acquisition email list](https://gsa.us9.list-manage.com/subscribe?u=6f1977de9eff4c384dc8d6527&id=e7f757afe3).
 
 *Duane Rollins also contributed to this post.*

--- a/_posts/2016-05-03-delivering-the-next-generation-of-digital-government.md
+++ b/_posts/2016-05-03-delivering-the-next-generation-of-digital-government.md
@@ -4,7 +4,7 @@ date: 2016-05-03
 authors:
 - deniseroth
 tags:
-- gsa
+- general services administration
 - technology transformation service
 excerpt: "Today we take another step forward helping government develop the technology that the public and taxpayers deserve. I'm pleased to announce the creation of GSA's third service, the Technology Transformation Service."
 image:

--- a/_posts/2016-05-10-gsa-invests-in-18fs-work-with-new-service.md
+++ b/_posts/2016-05-10-gsa-invests-in-18fs-work-with-new-service.md
@@ -4,7 +4,7 @@ date: 2016-05-10
 authors:
 - aaron
 tags:
-- gsa
+- general services administration
 - 18f
 - technology transformation service
 excerpt: "The GSA has created the Technology Transformation Service as a third pillar of services for federal agencies alongside the Public Buildings Service and Federal Acquisition Service."

--- a/_posts/2016-05-11-tackling-challenges-facing-cities-in-collaboration-with-all-levels-of-government.md
+++ b/_posts/2016-05-11-tackling-challenges-facing-cities-in-collaboration-with-all-levels-of-government.md
@@ -4,74 +4,23 @@ date: 2016-05-11
 authors:
 - hillary
 tags:
-- partners in government
 - digital services movement
-- outreach
-- proactive partner
-- economic catalyst
+- events
 excerpt: "Superpublic, a first-of-its-kind innovation lab, will bring members of federal, state, and local governments together to collaborate with academia and private industry to foster innovative solutions to problems facing cities."
 description: "Superpublic, a first-of-its-kind innovation lab, will bring members of federal, state, and local governments together to collaborate with academia and private industry to foster innovative solutions to problems facing cities."
 image: /assets/blog/superpublic/50-un-plaza.jpg
 ---
 
-Last October, I had the pleasure to speak at CityLab 2015, an annual
-event that brings together city leaders and innovators to address
-problems facing metropolitan areas. There, I ran into Krista Canellakis,
-the deputy innovation officer for the City and County of San Francisco.
-Both of us were excited about a story told by [La 27e
-Région](http://www.la27eregion.fr/en/), a public policy lab in Paris,
-about a coworking and collaboration space for government folks and the
-public.
+Last October, I had the pleasure to speak at CityLab 2015, an annual event that brings together city leaders and innovators to address problems facing metropolitan areas. There, I ran into Krista Canellakis, the deputy innovation officer for the City and County of San Francisco. Both of us were excited about a story told by [La 27e Région](http://www.la27eregion.fr/en/), a public policy lab in Paris, about a coworking and collaboration space for government folks and the public.
 
-Back in San Francisco, Krista pitched the idea to Chief Innovation
-Officer Jay Nath while I mentioned it to my colleague, GSA Regional
-Administrator Andrew McMahon, and the seeds of a U.S. version were sown.
-I’m excited [that this vision is coming
-true](http://www.sfchronicle.com/business/article/Superpublic-lab-in-SF-to-focus-on-urban-problems-7423635.php?t=114144a41300af33be&cmpid=twitter-premium),
-right down the hall from our San Francisco team.
+Back in San Francisco, Krista pitched the idea to Chief Innovation Officer Jay Nath while I mentioned it to my colleague, GSA Regional Administrator Andrew McMahon, and the seeds of a U.S. version were sown. I’m excited [that this vision is coming true](http://www.sfchronicle.com/business/article/Superpublic-lab-in-SF-to-focus-on-urban-problems-7423635.php?t=114144a41300af33be&cmpid=twitter-premium), right down the hall from our San Francisco team.
 
-The General Services Administration (GSA) is partnering with the San
-Francisco Mayor’s [Office of Civic Innovation](http://innovatesf.com/)
-and the [City Innovate Foundation](http://cityinnovate.org/) to launch
-a new collaborative government workspace in the heart of San Francisco.
-The first-of-its-kind innovation lab, called
-[Superpublic](http://cityinnovate.org/superpublic/), will bring
-members of federal, state, and local governments together to collaborate
-with academia and private industry to foster innovative solutions to
-common city problems. The 5,000 sq. ft. lab will be located on the top floor
-of 50 U.N. Plaza and will host design workshops, prototype development,
-training sessions, and daily coworking.
+The General Services Administration (GSA) is partnering with the San Francisco Mayor’s [Office of Civic Innovation](http://innovatesf.com/) and the [City Innovate Foundation](http://cityinnovate.org/) to launch a new collaborative government workspace in the heart of San Francisco. The first-of-its-kind innovation lab, called [Superpublic](http://cityinnovate.org/superpublic/), will bring members of federal, state, and local governments together to collaborate with academia and private industry to foster innovative solutions to common city problems. The 5,000 sq. ft. lab will be located on the top floor of 50 U.N. Plaza and will host design workshops, prototype development, training sessions, and daily coworking.
 
-![An aerial picture of 50 U.N. Plaza]({{site.baseurl}}/assets/blog/superpublic/50-un-plaza.jpg)
-*50 U.N. Plaza, which will house Superpublic.*
+![An aerial picture of 50 U.N. Plaza]({{site.baseurl}}/assets/blog/superpublic/50-un-plaza.jpg) *50 U.N. Plaza, which will house Superpublic.*
 
-“Superpublic presents a unique opportunity to solve common problems that
-persist at all levels of government and demonstrate a model for
-collaboration that can be replicated in other cities across the United
-States,” said Denise Turner Roth, GSA Administrator. “This is a great
-example of how the General Services Administration is finding new and
-innovative ways to improve the way we work. Both as a catalyst for
-community economic development, and as a provider of modern IT
-services.”
+“Superpublic presents a unique opportunity to solve common problems that persist at all levels of government and demonstrate a model for collaboration that can be replicated in other cities across the United States,” said Denise Turner Roth, GSA Administrator. “This is a great example of how the General Services Administration is finding new and innovative ways to improve the way we work. Both as a catalyst for community economic development, and as a provider of modern IT services.”
 
-Professionals, entrepreneurs, and students working in civic innovation
-are welcome to join the full-time team of designers, developers, and
-subject matter experts that will be working out of Superpublic. The goal
-is to bring together this interdisciplinary group of experts under one
-roof to create public-private teams working on targeted projects such as
-the [“Smart City Challenge”](http://www.transportation.gov/smartcity).
-The City of San Francisco is working with the Departments of
-Transportation, Energy, and Commerce on advancing smart cities,
-specifically around mobility. U.S. Secretary of Commerce Penny Pritzker
-joined the announcement saying, “Superpublic creates a forum to bring
-together leaders in the public, private, nonprofit, and academic sectors
-to create digital solutions that address our cities’ most pressing
-issues and develop stronger partnerships in the process.”
+Professionals, entrepreneurs, and students working in civic innovation are welcome to join the full-time team of designers, developers, and subject matter experts that will be working out of Superpublic. The goal is to bring together this interdisciplinary group of experts under one roof to create public-private teams working on targeted projects such as the [“Smart City Challenge”](http://www.transportation.gov/smartcity). The City of San Francisco is working with the Departments of Transportation, Energy, and Commerce on advancing smart cities, specifically around mobility. U.S. Secretary of Commerce Penny Pritzker joined the announcement saying, “Superpublic creates a forum to bring together leaders in the public, private, nonprofit, and academic sectors to create digital solutions that address our cities’ most pressing issues and develop stronger partnerships in the process.”
 
-Superpublic San Francisco follows in the footsteps of another
-[Superpublic](http://superpublic.fr/en/) space in Paris, [Civic
-Hall](http://civichall.org/) in New York, the [Center for Civic
-Innovation](http://www.civicatlanta.org/) in Atlanta, the Civic Design
-Lab inside Oakland City Hall, and others. There are many steps still to
-come, but we’re excited about this new effort to bring the best talents
-together to improve government digital services.
+Superpublic San Francisco follows in the footsteps of another [Superpublic](http://superpublic.fr/en/) space in Paris, [Civic Hall](http://civichall.org/) in New York, the [Center for Civic Innovation](http://www.civicatlanta.org/) in Atlanta, the Civic Design Lab inside Oakland City Hall, and others. There are many steps still to come, but we’re excited about this new effort to bring the best talents together to improve government digital services.

--- a/_posts/2016-05-24-the-user-centered-redesign-of-identitytheft-gov.md
+++ b/_posts/2016-05-24-the-user-centered-redesign-of-identitytheft-gov.md
@@ -4,7 +4,8 @@ date: 2016-05-24
 authors:
 - melody
 tags:
-- partners in government
+- interview
+- content design
 - design
 - user research
 - best practices
@@ -15,12 +16,9 @@ image: /assets/blog/identity-theft/identitytheft-home.jpg
 
 ![The homepage of identitytheft.gov]({{site.baseurl}}/assets/blog/identity-theft/identitytheft-home.jpg)
 
-I first came across the redesigned IdentityTheft.gov on Reddit, of all
-places.
+I first came across the redesigned IdentityTheft.gov on Reddit, of all places.
 
-Someone had posted a link to the Federal Trade Commission’s (FTC)
-[newly redesigned site](https://www.identitytheft.gov/) and
-[wrote](https://www.reddit.com/r/personalfinance/comments/463tc0/in_case_your_identity_is_ever_compromised_i/):
+Someone had posted a link to the Federal Trade Commission’s (FTC) [newly redesigned site](https://www.identitytheft.gov/) and [wrote](https://www.reddit.com/r/personalfinance/comments/463tc0/in_case_your_identity_is_ever_compromised_i/):
 
 > I hope this never happens to any of you as the entire thing can be
 > really stressful. The identitytheft.gov website is a true breath of
@@ -30,209 +28,83 @@ Someone had posted a link to the Federal Trade Commission’s (FTC)
 > contact law enforcement, putting credit freezes, and basically
 > protecting yourself. It also explains your rights pretty well too.
 
-I visited the site, and completely agreed. Not only was
-IdentityTheft.gov well-written and easy to understand, it was also
-clearly designed with end users in mind: the site takes people through a
-series of clear, well-designed steps that ensure they’ve completed the
-necessary steps if they are the victims of identity theft.
+I visited the site, and completely agreed. Not only was IdentityTheft.gov well-written and easy to understand, it was also clearly designed with end users in mind: the site takes people through a series of clear, well-designed steps that ensure they’ve completed the necessary steps if they are the victims of identity theft.
 
-I reached out to two of the members of the team behind IdentityTheft.gov
-to learn more about the decision-making process that went into making
-content and design decisions for the site. **Jessica Skretch** is a user
-experience designer and visual information specialist at the Division of
-Consumer & Business Education at the FTC; **Nicole Fleming** is a
-consumer education specialist. They led the design and content of the
-site, respectively.
+I reached out to two of the members of the team behind IdentityTheft.gov to learn more about the decision-making process that went into making content and design decisions for the site. **Jessica Skretch** is a user experience designer and visual information specialist at the Division of Consumer & Business Education at the FTC; **Nicole Fleming** is a consumer education specialist. They led the design and content of the site, respectively.
 
-**Melody Kramer: Thanks for talking with me today! I love how
-user-friendly and intentional IdentityTheft.gov is and I was wondering
-if you could detail the research that went into making the site really easy to navigate.**
+**Melody Kramer: Thanks for talking with me today! I love how user-friendly and intentional IdentityTheft.gov is and I was wondering if you could detail the research that went into making the site really easy to navigate.**
 
-**Jessica Skretch and Nicole Fleming:** Before we began, we wanted to be
-sure that we understood our audience really well, so we:
+**Jessica Skretch and Nicole Fleming:** Before we began, we wanted to be sure that we understood our audience really well, so we:
 
 -   Conducted user interviews (We talked to 20 victims of identity theft.)
 -   Compiled and analyzed a lot of data about our audience to inform our team and create personas
 -   Used internal and external data sources (national surveys, Google analytics, customer satisfaction surveys) to inform our decisions.
 
-We also [applied plain language best practices across the
-board.](https://www.identitytheft.gov/Assistant) But probably the most
-important thing we did was define a goal for the site: “Making it easier
-for victims to report and recover from identity theft.”
+We also [applied plain language best practices across the board.](https://www.identitytheft.gov/Assistant) But probably the most important thing we did was define a goal for the site: “Making it easier for victims to report and recover from identity theft.”
 
-Our team had a strong understanding of our primary audience based on a
-long history of working with victims via the FTC’s Consumer Response
-Center as well as our research efforts. That background results in a lot
-of empathy for this audience because they’re suddenly in this stressful,
-overwhelming situation, and they want to figure out what to do. That was
-a strong motivator for making the tone of the site reassuring. We
-prioritized messages and eliminated things that were potential
-distractions.
+Our team had a strong understanding of our primary audience based on a long history of working with victims via the FTC’s Consumer Response Center as well as our research efforts. That background results in a lot of empathy for this audience because they’re suddenly in this stressful, overwhelming situation, and they want to figure out what to do. That was a strong motivator for making the tone of the site reassuring. We prioritized messages and eliminated things that were potential distractions.
 
-We intentionally and consistently fought for that primary audience and
-kept other potential distractions off the table. We could easily make a
-list of other content that would be tempting to include on a government
-website about identity theft.
+We intentionally and consistently fought for that primary audience and kept other potential distractions off the table. We could easily make a list of other content that would be tempting to include on a government website about identity theft.
 
-However, to serve our primary audience well we had to focus, and not try
-to speak to every other potential audience. We did try to
-cross-reference things like prevention information and free outreach
-materials, but we did that in a very subtle way.
+However, to serve our primary audience well we had to focus, and not try to speak to every other potential audience. We did try to cross-reference things like prevention information and free outreach materials, but we did that in a very subtle way.
 
-**MK: You use checklists on the site. How did you decide upon
-checklists and why do they work
-well?**
+**MK: You use checklists on the site. How did you decide upon checklists and why do they work well?**
 
-**JS and NF:** We introduced checklists in our previous iteration of
-identity theft guidance in 2012 — a print booklet and series of articles
-on [consumer.ftc.gov](http://consumer.ftc.gov). So using checklists to
-help users is not new for us. But I can elaborate on why we use them.
+**JS and NF:** We introduced checklists in our previous iteration of identity theft guidance in 2012 — a print booklet and series of articles on [consumer.ftc.gov](http://consumer.ftc.gov). So using checklists to help users is not new for us. But I can elaborate on why we use them.
 
 ![An example checklist from identitytheft.gov]({{site.baseurl}}/assets/blog/identity-theft/checklist.jpg)
 
-The recovery process for an identity theft victim can vary a lot and
-include many tasks. We wanted a format for people using the site that
-was easy-to-follow. We wanted to shift the situation from a person
-feeling totally overwhelmed to feeling in control and that the steps are
-doable because we’ve laid them out in a step-by-step plan. People use
-checklists all the time. They’re familiar and give people a sense of
-agency. They also show progress. It feels good to check items off the
-list.
+The recovery process for an identity theft victim can vary a lot and include many tasks. We wanted a format for people using the site that was easy-to-follow. We wanted to shift the situation from a person feeling totally overwhelmed to feeling in control and that the steps are doable because we’ve laid them out in a step-by-step plan. People use checklists all the time. They’re familiar and give people a sense of agency. They also show progress. It feels good to check items off the list.
 
-When we conducted interviews last spring, identity theft victims
-responded very positively to the newer checklist-style materials. They
-compared text-heavy versions to a “manual” and our newer materials to a
-“quick-start guide.” They said, “No one reads a manual. We all use the
-handy one-page guide.” And they said when they were in damage-control
-mode, they were looking for material that was “short and to the point,”
-not “a full education on the subject.”
+When we conducted interviews last spring, identity theft victims responded very positively to the newer checklist-style materials. They compared text-heavy versions to a “manual” and our newer materials to a “quick-start guide.” They said, “No one reads a manual. We all use the handy one-page guide.” And they said when they were in damage-control mode, they were looking for material that was “short and to the point,” not “a full education on the subject.”
 
-**MK: The language on the site is really easy to understand. How
-did you think about language and what did you do to test the language on
-the site?**
+**MK: The language on the site is really easy to understand. How did you think about language and what did you do to test the language on the site?**
 
-**JS and NF:** Identity theft victims are in an unfamiliar, stressful
-situation. They shouldn’t have to do mental backflips to understand our
-advice. Using plain language that’s familiar and easy to understand is a
-passion for both of us. It’s ideal to have both a writer and an editor
-who are committed to plain language because it’s not easy to accomplish.
-It requires looking at every single word, and asking:
+**JS and NF:** Identity theft victims are in an unfamiliar, stressful situation. They shouldn’t have to do mental backflips to understand our advice. Using plain language that’s familiar and easy to understand is a passion for both of us. It’s ideal to have both a writer and an editor who are committed to plain language because it’s not easy to accomplish. It requires looking at every single word, and asking:
 
 -   Is this word necessary?
 -   Is there a better, more familiar word that we could use?
 
-Listening to victims describe their experience helps a lot. You start to
-hear the common phrases that people use, as well as what parts of the
-process confused them and why.
+Listening to victims describe their experience helps a lot. You start to hear the common phrases that people use, as well as what parts of the process confused them and why.
 
-Our writers use tools like Google Trends and Google Analytics to see
-which word is more commonly searched on our sites and more broadly. For
-example, one of the most commonly searched phrases related to identity
-theft is “report identity theft.” So, we made sure to include that on
-the site and in all of our promotional materials about the site.
+Our writers use tools like Google Trends and Google Analytics to see which word is more commonly searched on our sites and more broadly. For example, one of the most commonly searched phrases related to identity theft is “report identity theft.” So, we made sure to include that on the site and in all of our promotional materials about the site.
 
-We also paid attention to potential areas of confusion when we did
-usability testing. Words and phrases that cause confusion often become
-obvious when you watch users thinking aloud and navigating the site. For
-example, we make a distinction between new and existing accounts because
-the recovery steps are different. It became clear during testing that
-users didn’t understand that distinction until we changed the language
-to “a fraudulent account opened by the thief” versus “fraudulent charges
-made on your existing account.”
+We also paid attention to potential areas of confusion when we did usability testing. Words and phrases that cause confusion often become obvious when you watch users thinking aloud and navigating the site. For example, we make a distinction between new and existing accounts because the recovery steps are different. It became clear during testing that users didn’t understand that distinction until we changed the language to “a fraudulent account opened by the thief” versus “fraudulent charges made on your existing account.”
 
-**MK: What has the response been since you
-relaunched?**
+**MK: What has the response been since you relaunched?**
 
-**JS and NF:** Generally very positive. We monitor user experience by
-keeping an eye on stats, our feedback form, and what’s happening on live
-chat. We get very encouraging feedback, and we also get an earful when
-someone encounters a technical issue on the site.
+**JS and NF:** Generally very positive. We monitor user experience by keeping an eye on stats, our feedback form, and what’s happening on live chat. We get very encouraging feedback, and we also get an earful when someone encounters a technical issue on the site.
 
-One feature that people have been really excited about is the ability to
-create letters to send to credit bureaus, businesses, and debt
-collectors. It takes the guesswork out of the letter writing process.
+One feature that people have been really excited about is the ability to create letters to send to credit bureaus, businesses, and debt collectors. It takes the guesswork out of the letter writing process.
 
 ![A template letter that users can send to credit reporting agencies ]({{site.baseurl}}/assets/blog/identity-theft/letter.jpg)
 
-We’ve also heard from a lot of victim advocates and local law
-enforcement, who say that they feel confident sending people to
-IdentityTheft.gov, knowing that the site will help them.
+We’ve also heard from a lot of victim advocates and local law enforcement, who say that they feel confident sending people to IdentityTheft.gov, knowing that the site will help them.
 
-**MK: I really like the bar at the top, which basically tells people
-which phase of the project they’re in. It reminds me of something I read
-in the Federal Front Door [research
-report](https://labs.usa.gov/#research-report), which is that
-people want transparency into government processes. How did you think
-about design elements and topics like transparency?**
+**MK: I really like the bar at the top, which basically tells people which phase of the project they’re in. It reminds me of something I read in the Federal Front Door [research report](https://labs.usa.gov/#research-report), which is that people want transparency into government processes. How did you think about design elements and topics like transparency?**
 
 ![A graphic element of identitytheft.gov that shows users where they are in in a series of six labeled steps]({{site.baseurl}}/assets/blog/identity-theft/steps.jpg)
 
-**JS and NF:** We tried to set proper expectations at each turn for our
-users. For example, there’s [a
-page](https://www.identitytheft.gov/Information) right before you jump
-into the detailed questions that explains that the answers will be used
-to build your Identity Theft Affidavit and your personal recovery plan.
-These are the two main tools we provide on the site to help victims
-recover from identity theft. We wanted people to know why they were
-answering questions and what they were going to get at the end of it. In
-the recovery plan, we included additional information in expandable note
-boxes, in case users didn’t understand why we were recommending certain
-steps to them.
+**JS and NF:** We tried to set proper expectations at each turn for our users. For example, there’s [a page](https://www.identitytheft.gov/Information) right before you jump into the detailed questions that explains that the answers will be used to build your Identity Theft Affidavit and your personal recovery plan. These are the two main tools we provide on the site to help victims recover from identity theft. We wanted people to know why they were answering questions and what they were going to get at the end of it. In the recovery plan, we included additional information in expandable note boxes, in case users didn’t understand why we were recommending certain steps to them.
 
-To really achieve transparency for users, we discovered that we had to
-find the right balance between giving users helpful information and not
-overwhelming them with too much information. We had to make tough
-choices about what to prioritize and what to eliminate, and we will have
-to re-evaluate those decisions as time goes by and we learn more about
-our users.
+To really achieve transparency for users, we discovered that we had to find the right balance between giving users helpful information and not overwhelming them with too much information. We had to make tough choices about what to prioritize and what to eliminate, and we will have to re-evaluate those decisions as time goes by and we learn more about our users.
 
 **MK:How did you user test this?**
 
-**JS and NF:** We did two rounds of formal usability testing, and our
-timeline allowed a few days in the middle of each round so that we could
-make some quick, responsive tweaks to the language or design based on
-what we were observing.
+**JS and NF:** We did two rounds of formal usability testing, and our timeline allowed a few days in the middle of each round so that we could make some quick, responsive tweaks to the language or design based on what we were observing.
 
-The first round was an image of the homepage followed by clickable
-prototypes. Showing the homepage design allowed us to get reactions on
-the look and feel, as well as the messaging and homepage priorities. The
-clickable prototypes gave us our first look at users walking through the
-whole experience six months before launch.
+The first round was an image of the homepage followed by clickable prototypes. Showing the homepage design allowed us to get reactions on the look and feel, as well as the messaging and homepage priorities. The clickable prototypes gave us our first look at users walking through the whole experience six months before launch.
 
-The second round of testing was a fairly robust beta site. Some areas
-were still in development, but for the most part, the meat of the site
-was working. At this point, we were able to see users really go through
-the whole process two months before launch.
+The second round of testing was a fairly robust beta site. Some areas were still in development, but for the most part, the meat of the site was working. At this point, we were able to see users really go through the whole process two months before launch.
 
-After both test cycles, we were able to make quick responsive changes to
-content and language. We also made improvements to design and
-functionality. By the second round, time and money constraints forced us
-to prioritize the most critical changes. Some takeaways from testing
-couldn’t be implemented pre-launch but were not lost. We’re still
-actively working on development and rolling out incremental
-improvements.
+After both test cycles, we were able to make quick responsive changes to content and language. We also made improvements to design and functionality. By the second round, time and money constraints forced us to prioritize the most critical changes. Some takeaways from testing couldn’t be implemented pre-launch but were not lost. We’re still actively working on development and rolling out incremental improvements.
 
-**MK: What about people who don’t have Internet access? How do they
-report identity theft?**
+**MK: What about people who don’t have Internet access? How do they report identity theft?**
 
-**JS and NF:** The FTC offers
-a toll free help line where you can call and talk to someone at
-1-877-FTC-HELP. We encourage
-people to use the site if possible because it’s available 24/7 and
-designed to assist you as you work through the recovery process (which
-has a tendency to evolve over time). IdentityTheft.gov allows you to
-update your report details, and the site will adjust your recovery plan
-accordingly. For example, if you discover a second fraudulent account,
-you can come back to the site, add it to the report, and it will
-generate the appropriate recovery steps.
+**JS and NF:** The FTC offers a toll free help line where you can call and talk to someone at 1-877-FTC-HELP. We encourage people to use the site if possible because it’s available 24/7 and designed to assist you as you work through the recovery process (which has a tendency to evolve over time). IdentityTheft.gov allows you to update your report details, and the site will adjust your recovery plan accordingly. For example, if you discover a second fraudulent account, you can come back to the site, add it to the report, and it will generate the appropriate recovery steps.
 
-**MK: Are you noticing more people using the
-website?**
+**MK: Are you noticing more people using the website?**
 
-**JS and NF:** Yes, the total
-number of identity theft reports we receive has increased and the method
-of reporting has shifted more to the website, rather than phone. We also
-have a healthy portion of reports being submitted on mobile devices,
-which wasn’t possible before.
+**JS and NF:** Yes, the total number of identity theft reports we receive has increased and the method of reporting has shifted more to the website, rather than phone. We also have a healthy portion of reports being submitted on mobile devices, which wasn’t possible before.
 
 [![Two pie charts that show the percentage of users reporting their identity theft online has grown from 39 percent before the launch to 68 percent post launch, including 15 percent on mobile devices.]({{site.baseurl}}/assets/blog/identity-theft/users.jpg)](https://labs.usa.gov/#research-report)

--- a/_posts/2016-06-07-building-better-by-building-together-with-the-federal-election-commission.md
+++ b/_posts/2016-06-07-building-better-by-building-together-with-the-federal-election-commission.md
@@ -8,7 +8,6 @@ tags:
 - fec.gov
 - how we work
 - communication tools and practices
-- partners in government
 - collaboration tools
 excerpt: "How do you work iteratively and in the open in government? How do you transform an agency’s digital presence with agile and user-centered design? We’ve learned a lot about this as we’ve worked alongside our partners at the Federal Election Commission (FEC) on beta.fec.gov, and we want to share some of those lessons here."
 image: /assets/blog/fec/fec-meeting.jpg

--- a/_posts/2016-06-17-exciting-additions-to-analytics-usa-gov.md
+++ b/_posts/2016-06-17-exciting-additions-to-analytics-usa-gov.md
@@ -5,7 +5,6 @@ authors:
 - timlowden
 tags:
 - analytics.usa.gov
-- analytics
 excerpt: "We’ve expanded analytics.usa.gov to include 15(!) more
 agency-specific dashboard pages. We now offer agency-specific analytics
 data pages for a total of 25 major federal agencies, and each one is
@@ -21,37 +20,16 @@ hero: false
 
 *Originally published on [DigitalGov.gov](http://www.digitalgov.gov/2016/06/17/exciting-additions-to-analytics-usa-gov/).*
 
-We’ve expanded [analytics.usa.gov](https://analytics.usa.gov/) to
-include 15(!) more agency-specific dashboard pages. We now offer
-agency-specific analytics data pages for a total of 25 major federal
-agencies, and each one is accessible from the dropdown menu at the top
-of the site.
+We’ve expanded [analytics.usa.gov](https://analytics.usa.gov/) to include 15(!) more agency-specific dashboard pages. We now offer agency-specific analytics data pages for a total of 25 major federal agencies, and each one is accessible from the dropdown menu at the top of the site.
 
 ![The analytics.usa.gov homepage pointing out the participating websites menu]({{ site.baseurl }}/assets/blog/dap/analytics-homepage-2016.png)
 
-Additionally, we’ve moved the downloadable datasets to their own pages,
-rather than be located on the dashboard pages themselves. The page to
-download aggregated data for all participating sites is now
-[analytics.usa.gov/data](https://analytics.usa.gov/data), and each
-agency-specific page has a [corresponding data
-page](https://analytics.usa.gov/justice/data/), as well.
+Additionally, we’ve moved the downloadable datasets to their own pages, rather than be located on the dashboard pages themselves. The page to download aggregated data for all participating sites is now [analytics.usa.gov/data](https://analytics.usa.gov/data), and each agency-specific page has a [corresponding data page](https://analytics.usa.gov/justice/data/), as well.
 
 ![Screenshot of the new standalone downloads page]({{ site.baseurl }}/assets/blog/dap/analytics-downloads-2016.png)
 
-We’re excited to offer the public this expanded view of web analytics
-data, and we hope you find it useful!
+We’re excited to offer the public this expanded view of web analytics data, and we hope you find it useful!
 
-*Tim Lowden leads the Digital Analytics Program (DAP), which powers*
-[analytics.usa.gov.](https://analytics.usa.gov/) Gray Brooks, Eric
-Mill, Heather Battaglia, and Colin Craig are at
-[18F](https://18f.gsa.gov/) and contribute to the development and
-maintenance of the site.*
+*Tim Lowden leads the Digital Analytics Program (DAP), which powers* [analytics.usa.gov.](https://analytics.usa.gov/) Gray Brooks, Eric Mill, Heather Battaglia, and Colin Craig are at [18F](https://18f.gsa.gov/) and contribute to the development and maintenance of the site.*
 
-*The DAP currently tracks analytics data on more than 4,000 U.S. federal
-government websites across 45 agencies. To learn more or to find out how
-your agency/website can participate in the program, please [email
-us](mailto:dap@support.digitalgov.gov). The work on
-[analytics.usa.gov](https://analytics.usa.gov/) is open-source, and
-can be found in our
-[Git](https://github.com/18F/analytics.usa.gov)[H](https://github.com/18F/analytics.usa.gov)[ub
-repo](https://github.com/18F/analytics.usa.gov).*
+*The DAP currently tracks analytics data on more than 4,000 U.S. federal government websites across 45 agencies. To learn more or to find out how your agency/website can participate in the program, please [email us](mailto:dap@support.digitalgov.gov). The work on [analytics.usa.gov](https://analytics.usa.gov/) is open-source, and can be found in our [GitHub repo](https://github.com/18F/analytics.usa.gov).*

--- a/_posts/2016-06-21-using-plain-language-to-bridge-the-gap-between-government-and-industry.md
+++ b/_posts/2016-06-21-using-plain-language-to-bridge-the-gap-between-government-and-industry.md
@@ -5,7 +5,7 @@ authors:
 - ryan-sibley
 tags:
 - content design
-- gsa
+- general services administration
 - procurement
 excerpt: "Recently, we partnered with the Office of Integrated Technology Services
 (ITS) here within the General Services Administration (GSA) on a

--- a/_posts/2016-07-13-technology-transformation-services-looking-for-new-commissioner.md
+++ b/_posts/2016-07-13-technology-transformation-services-looking-for-new-commissioner.md
@@ -4,7 +4,7 @@ date: 2016-07-13 15:00
 authors:
 - 18F
 tags:
-- gsa
+- general services administration
 - hiring
 - technology transformation service
 excerpt: "Now’s the time to get involved in transforming how the

--- a/_posts/2016-08-11-holly-allen-helping-engineer-a-better-18F.md
+++ b/_posts/2016-08-11-holly-allen-helping-engineer-a-better-18F.md
@@ -5,7 +5,6 @@ authors:
 - melody
 tags:
 - staff profiles
-- engineering
 - college scorecard
 excerpt: "Holly Allen came to 18F from Dreamworks Animation and the Public Library of Science. She joined 18F in pursuit of a way \"to use technology to address big societal problems.\" After hearing about the U.S. Digital Service and 18F from US Chief Technology Officer, Megan Smith, she was inspired to join."
 description: "Holly Allen came to 18F from Dreamworks Animation and the Public Library of Science. She joined 18F in pursuit of a way \"to use technology to address big societal problems.\" After hearing about the U.S. Digital Service and 18F from US Chief Technology Officer, Megan Smith, she was inspired to join."

--- a/_posts/2016-08-30-sign-up-for-the-technology-industry-day.md
+++ b/_posts/2016-08-30-sign-up-for-the-technology-industry-day.md
@@ -5,7 +5,7 @@ authors:
 - gsa-blog-team
 tags:
 - events
-- gsa
+- general services administration
 - technology transformation service
 excerpt: "On September 8, GSA is hosting its very first Technology Industry Day. Sign up to hear about how GSA is transforming technology in the federal government, see demos of products and solutions developed by TTS and, last but not least, provide feedback on how we can work better with industry. "
 image: 

--- a/_posts/2016-09-19-vendors-government-strengthen-partnership-technology-industry-day.md
+++ b/_posts/2016-09-19-vendors-government-strengthen-partnership-technology-industry-day.md
@@ -4,7 +4,7 @@ authors:
 - andre
 tags:
 - events
-- gsa
+- general services administration
 - video
 - agile bpa
 - micro-purchase platforms

--- a/_posts/2016-10-14-iterative-workplace-design-denver-federal-center.md
+++ b/_posts/2016-10-14-iterative-workplace-design-denver-federal-center.md
@@ -5,36 +5,14 @@ authors:
 tags:
 - public buildings service
 - design
-- denver federal center
-- gsa
+- general services administration
 excerpt: "Not long ago, the General Service Administration’s regional headquarters on the Denver Federal Center campus looked like a stereotypical office space; today, it is a modern workplace thanks to the iterative work of the Denver GSA’s design team."
 description: "Not long ago, the General Service Administration’s regional headquarters on the Denver Federal Center campus looked like a stereotypical office space; today, it is a modern workplace thanks to the iterative work of the Denver GSA’s design team."
 image: /assets/blog/denver/union-station.jpg
 ---
-Not long ago, the General Service Administration’s [regional headquarters
-on the Denver Federal Center campus](http://gsa.gov/portal/category/21504) looked like a stereotypical office
-space: cubicles sprawled down a long, fluorescent-lit hallway, and
-conference rooms and private offices lined the sides of the building
-with windows looking out on the foothills of the Rockies on one side,
-and downtown Denver on the other. The GSA’s two primary services, the
-[Public Buildings Service (PBS)](http://gsa.gov/portal/content/104722) and the [Federal Acquisition Service
-(FAS)](http://gsa.gov/portal/content/104850), were split with PBS in the main building, and FAS scattered
-around other buildings in the area. In 2014, the two services were
-slated to consolidate into one office space, a move that would save the
-agency money and open up valuable space for other federal agencies.
-There was only one problem: They didn’t have space to do so. “We were
-maxed out on cubicles,” said Andrew Myers, one of the leads on the
-re-design project.
+Not long ago, the General Service Administration’s [regional headquarters on the Denver Federal Center campus](http://gsa.gov/portal/category/21504) looked like a stereotypical office space: cubicles sprawled down a long, fluorescent-lit hallway, and conference rooms and private offices lined the sides of the building with windows looking out on the foothills of the Rockies on one side, and downtown Denver on the other. The GSA’s two primary services, the [Public Buildings Service (PBS)](http://gsa.gov/portal/content/104722) and the [Federal Acquisition Service (FAS)](http://gsa.gov/portal/content/104850), were split with PBS in the main building, and FAS scattered around other buildings in the area. In 2014, the two services were slated to consolidate into one office space, a move that would save the agency money and open up valuable space for other federal agencies. There was only one problem: They didn’t have space to do so. “We were maxed out on cubicles,” said Andrew Myers, one of the leads on the re-design project.
 
-Cubicles and private offices have a certain appeal to them: You can
-leave things there overnight, put up photos of your family, and keep
-your work organized on your desk. They also take up a lot of space, much
-more than most people actually need, and constrain people to working in
-the same space all the time. When Myers, his colleague Shelly Baxter,
-and the design team started thinking about how to make more space in the
-office, they started with the cube walls. “One of the designers took the
-existing furniture and came up with a pretty creative layout,” Baxter
-said.
+Cubicles and private offices have a certain appeal to them: You can leave things there overnight, put up photos of your family, and keep your work organized on your desk. They also take up a lot of space, much more than most people actually need, and constrain people to working in the same space all the time. When Myers, his colleague Shelly Baxter, and the design team started thinking about how to make more space in the office, they started with the cube walls. “One of the designers took the existing furniture and came up with a pretty creative layout,” Baxter said.
 
 <figure>
   <img src="{{site.baseurl}}{{page.image}}" alt="">
@@ -43,80 +21,39 @@ said.
 
 ## Listen and iterate
 
-When tenants tour the GSA space today, they see standing desks, huddle
-rooms with glass walls, giant windows, and open spaces where people can
-work together. The only real semi-private office space you’ll see is for
-the Regional Administrator, [Sue Damour](http://gsa.gov/portal/category/21495), and her door is almost always
-open. Getting there was a process of testing hypotheses and adjusting to
-human and policy needs.
+When tenants tour the GSA space today, they see standing desks, huddle rooms with glass walls, giant windows, and open spaces where people can work together. The only real semi-private office space you’ll see is for the Regional Administrator, [Sue Damour](http://gsa.gov/portal/category/21495), and her door is almost always open. Getting there was a process of testing hypotheses and adjusting to human and policy needs.
 
 <figure>
   <img src="{{ site.baseurl }}/assets/blog/denver/skylight.jpg" alt="">
   <figcaption>The Skylight Cafe has high tables and booth seating that facilitates collaboration and social events among the regional staff. Photo courtesy: GSA PBS Region 8 </figcaption>
 </figure>
 
-Part of GSA’s mission is to find innovative ways to [design workplaces
-that make the federal government more efficient and
-productive](http://www.gsa.gov/portal/content/134874). The Rocky
-Mountain Region houses 28 tenants on the Denver Federal Center campus.
-Myers and Baxter said they set up several workplaces in the building as
-working showrooms. Each room had different furniture and layouts and the
-staff would offer tours for their tenants to gauge their reactions and
-show them what was possible for their own offices.
+Part of GSA’s mission is to find innovative ways to [design workplaces that make the federal government more efficient and productive](http://www.gsa.gov/portal/content/134874). The Rocky Mountain Region houses 28 tenants on the Denver Federal Center campus. Myers and Baxter said they set up several workplaces in the building as working showrooms. Each room had different furniture and layouts and the staff would offer tours for their tenants to gauge their reactions and show them what was possible for their own offices.
 
 <figure>
   <img alt="A group of bench seating in the Denver GSA space" src="{{site.baseurl }}/assets/blog/denver/quiet-car.jpg">
   <figcaption>Photo courtesy: GSA PBS Region 8</figcaption>
 </figure>
 
-PBS was, in a way, exercising [play 1 from the Digital Services Playbook](https://playbook.cio.gov/#play1).
-Just like we test features here at 18F before releasing them too widely,
-they were *testing their work with real people before* disrupting their
-customers at other agencies.
+PBS was, in a way, exercising [play 1 from the Digital Services Playbook](https://playbook.cio.gov/#play1). Just like we test features here at 18F before releasing them too widely, they were *testing their work with real people before* disrupting their customers at other agencies.
 
-From these showrooms, they learned their tenants all had more employees
-to squeeze into smaller spaces than they had designed for. They also
-learned what worked and what people wanted more of. They learned they’d
-need to create a distraction-free space so people could get away from
-the noisy, high traffic parts of the building and get work done, and
-spaces to take phone calls or meet with each other without disturbing
-others. To meet these needs, they created a quiet zone and another area
-with a wide mix of phone booths and conference rooms, so whether you’re
-on the phone by yourself, or in a group of 20, there’s a place for you
-to meet.
+From these showrooms, they learned their tenants all had more employees to squeeze into smaller spaces than they had designed for. They also learned what worked and what people wanted more of. They learned they’d need to create a distraction-free space so people could get away from the noisy, high traffic parts of the building and get work done, and spaces to take phone calls or meet with each other without disturbing others. To meet these needs, they created a quiet zone and another area with a wide mix of phone booths and conference rooms, so whether you’re on the phone by yourself, or in a group of 20, there’s a place for you to meet.
 
 <figure>
   <img src="{{site.baseurl}}/assets/blog/denver/quiet-car-2.jpg" alt="">
   <figcaption>The quiet zone, all phones must be silenced and voices hushed here. Photo courtesy: GSA PBS Region 8</figcaption>
 </figure>
 
-Over time, they’ve learned subtler things about the space: “Better
-access to wifi … added electrical outlets … we enhanced white noise,”
-said Baxter, and they’ve learned a lot about how human behavior didn’t
-match their assumptions. “We’ve noticed that certain people are
-magnets,” said Myers, “if you’re a manager and you sit somewhere, for
-whatever reason, your team ends up sitting near you.” Whether that’s
-because of unspoken pressure from managers to be near their employees,
-or personal preference, it was an unexpected outcome they hadn’t really
-designed for.
+Over time, they’ve learned subtler things about the space: “Better access to wifi … added electrical outlets … we enhanced white noise,” said Baxter, and they’ve learned a lot about how human behavior didn’t match their assumptions. “We’ve noticed that certain people are magnets,” said Myers, “if you’re a manager and you sit somewhere, for whatever reason, your team ends up sitting near you.” Whether that’s because of unspoken pressure from managers to be near their employees, or personal preference, it was an unexpected outcome they hadn’t really designed for.
 
 <figure>
   <img src="{{ site.baseurl }}/assets/blog/denver/dogbones.jpg" alt="">
   <figcaption>So-called "dog bone" desks are one of many different kinds of workstations available throughout Building 41. Photo courtesy: GSA PBS Region 8</figcaption>
 </figure>
 
-It’s been a little over a year since the redesign took place, but the
-work is not complete. They continue to refine their hypotheses about how
-people use the space and occasionally make changes to accommodate their
-reality. “People are creatures of habit,” Baxter said, “and we’ve
-started to see people assume that a desk designated ‘drop in’ belongs to
-a specific individual because that person sits there whenever they’re in
-the office.”
+It’s been a little over a year since the redesign took place, but the work is not complete. They continue to refine their hypotheses about how people use the space and occasionally make changes to accommodate their reality. “People are creatures of habit,” Baxter said, “and we’ve started to see people assume that a desk designated ‘drop in’ belongs to a specific individual because that person sits there whenever they’re in the office.”
 
-Redesigning the GSA’s workplace has been an iterative effort to discover
-how people want to work, how they can be most productive, and designing
-around those needs. It’s a great example of how human-centered design
-manifests itself in spaces outside of the tech world.
+Redesigning the GSA’s workplace has been an iterative effort to discover how people want to work, how they can be most productive, and designing around those needs. It’s a great example of how human-centered design manifests itself in spaces outside of the tech world.
 
 <figure>
   <img src="{{ site.baseurl }}/assets/blog/denver/gallery-41.jpg" alt="">

--- a/_posts/2016-11-04-code-gov-the-next-milestone-federal-open-source-code.md
+++ b/_posts/2016-11-04-code-gov-the-next-milestone-federal-open-source-code.md
@@ -6,7 +6,7 @@ authors:
 tags:
 - open source
 - presidential innovation fellows
-- gsa
+- general services administration
 - code.gov
 excerpt: "Last week, U.S. Chief Information Officer Tony Scott announced the launch of code.gov, another important milestone in the federal government’s adoption of open source code. The new site provides access to more than 50 open source projects from 13 federal agencies."
 image: /assets/blog/code-gov/homepage-2016.jpg

--- a/_posts/2016-11-25-what-18f-is-thankful-for-this-thanksgiving.md
+++ b/_posts/2016-11-25-what-18f-is-thankful-for-this-thanksgiving.md
@@ -3,7 +3,6 @@ title: What 18F is thankful for this Thanksgiving
 authors:
 - boone
 tags:
-- thanksgiving
 - how we work
 - culture
 excerpt: Like all federal employees, we don't work on Thanksgiving. We do work on the day after, though, and this year we thought we'd pause to take a moment and reflect. Here are a few things that we're thankful for, what brings meaning to our lives, and what brings us to work every day.

--- a/tests/schema/tags.yml
+++ b/tests/schema/tags.yml
@@ -63,6 +63,7 @@
 - modular contracting
 - myusa
 - national technical information service
+- navy reserve
 - onboarding
 - open data
 - open government

--- a/tests/schema/tags.yml
+++ b/tests/schema/tags.yml
@@ -5,10 +5,8 @@
 - agency work
 - agile
 - agile bpa
-- analytics
 - analytics.usa.gov
 - api
-- automated testing
 - best practices
 - calc
 - cloud.gov
@@ -24,20 +22,16 @@
 - data act
 - day in the life
 - demo day
-- denver federal center
 - department of commerce
 - department of labor
 - design
 - devops
 - digital acquisition accelerator
-- digital economy practice
 - digital services movement
 - digitalgov community
 - discovery.gsa.gov
 - distributed
-- economic catalyst
 - education
-- engineering
 - environmental protection agency
 - eregulations
 - evangelism
@@ -50,7 +44,6 @@
 - foia
 - general services administration
 - gov.uk
-- gsa
 - guides
 - hackathons
 - health and human services
@@ -59,11 +52,11 @@
 - https
 - hub
 - identity
+- interview
 - jekyll
 - join us
 - lessons learned
 - machine learning
-- marketplaces
 - micro-purchase platforms
 - midas
 - modern practices
@@ -75,13 +68,9 @@
 - open government
 - open opportunities
 - open source
-- our projects
-- outreach
-- partners in government
 - peace corps
 - platforms
 - presidential innovation fellows
-- proactive partner
 - product
 - procurement
 - public buildings service
@@ -97,7 +86,6 @@
 - technical guides
 - technology transformation service
 - testing
-- thanksgiving
 - tools you can use
 - training
 - transformation services
@@ -111,5 +99,6 @@
 - user research
 - user-centered design
 - video
+- vote.usa.gov
 - web design standards
 - workshop


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/tag-cleanup.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/tag-cleanup)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/tag-cleanup/)

This PR removes a number of duplicate, inconsistently-applied, barely-used, or wildly outdated tags, per a conversation with @awfrancisco last week.

I haven't yet audited agency tags or dealt with the `procurement` vs. `acquisition services` question, but this seemed like plenty to start with.

/cc @awfrancisco 
