### PR TITLE
Add agency work tag

### DIFF
--- a/_posts/2016-06-15-two-agencies-participating-in-the-digital-acquisition-accelerator-pilot.md
+++ b/_posts/2016-06-15-two-agencies-participating-in-the-digital-acquisition-accelerator-pilot.md
@@ -12,6 +12,7 @@ tags:
 - presidential innovation fellows
 - procurement
 - training
+- agency work
 excerpt: "Today, we’re thrilled to announce that the Federal Bureau of Investigation and the U.S. Department of the Treasury are the first two agencies to participate in the Digital Acquisition Accelerator Pilot."
 description: "Today, we’re thrilled to reveal that we’ve selected the Federal Bureau of Investigation and the U.S. Department of the Treasury as the first two agencies to participate in the Digital Acquisition Accelerator Pilot."
 image: /assets/blog/digital-acquisition-accelerator/daa-pilot-homepage.jpg

--- a/_posts/2016-06-21-using-plain-language-to-bridge-the-gap-between-government-and-industry.md
+++ b/_posts/2016-06-21-using-plain-language-to-bridge-the-gap-between-government-and-industry.md
@@ -7,6 +7,7 @@ tags:
 - content design
 - general services administration
 - procurement
+- agency work
 excerpt: "Recently, we partnered with the Office of Integrated Technology Services
 (ITS) here within the General Services Administration (GSA) on a
 four-month effort to develop a plain language guide, informed by

--- a/_posts/2016-10-25-three-small-steps-you-can-take-to-reboot-agile-in-your-organization.md
+++ b/_posts/2016-10-25-three-small-steps-you-can-take-to-reboot-agile-in-your-organization.md
@@ -9,6 +9,7 @@ tags:
 - department of commerce
 - national technical information service
 - workshop
+- agency work
 excerpt: "This past summer, 18F held an agile workshop for the National Technical Information Service (NTIS), part of the U.S. Department of Commerce. An agency with roots going back to World War II, NTIS is facing a future that requires a strategic realignment towards open data and services."
 image: /assets/blog/agile-workshop/3-steps-team.jpg
 ---

--- a/_posts/2017-01-05-building-effective-agile-partnership-between-government-industry.md
+++ b/_posts/2017-01-05-building-effective-agile-partnership-between-government-industry.md
@@ -6,6 +6,7 @@ tags:
 - acquisition services
 - agile bpa
 - department of labor
+- agency work
 excerpt: "The Wage and Hour Division (WHD) of the U.S. Department of Labor has been with 18F at the forefront of digital transformation and has been an outstanding early adopter. One of our latest initiatives has been an Agile Delivery Services Blanket Purchase Agreement (Agile BPA) Task Order to create the initial version of a web application tool for the Section 14(c) certificate application process."
 image: /assets/blog/dol-whd-14c/certification-application.png
 hero: false
@@ -89,7 +90,7 @@ this relationship has been so successful:
 -   **A vendor ready to work in an agile way.** AIS conducts sprint ceremonies, keeps everyone on track during stand ups, and has been flexible to the evolving needs of WHD. They’ve struck a great balance between project management work and dedicated developers focused on creating the web application tool, while also being strong supporters of usability testing.
 -   **Shared responsibility for success.** A crucial value that has led to the success of this task order is that AIS and WHD are both responsible for the success of this MVP. Without the necessary engagement and involvement within WHD, the vendor cannot succeed. Similarly, WHD cannot succeed without the technical expertise of the vendor.
 -   **An empowered product owner**. From the beginning, we emphasized the need to have one person dedicated and *empowered* to make critical decisions and direct the strategy. Our product owner, Elizabeth Striegel, has done a great job prioritizing the backlog, making key decisions on features, and getting items escalated to appropriate decision-makers throughout Labor. She has also been a great ambassador for WHD about agile methodology and demonstrating why it’s a better way to work.
--   **A stakeholder commitment to work in the open.** Our [repo has been public from day one](https://github.com/18F/dol-whd-14c), which includes our project management tasks. Furthermore, the user stories from the performance work statement were public on our [Trello board](https://trello.com/b/74MUGMpP/14-c-public-backlog) and have been used to inform each sprint during these 60 days. You can also see the outcome of work with the beta version of the [public prototype](https://dol-whd-section14c-stg.azurewebsites.net/#/). 
+-   **A stakeholder commitment to work in the open.** Our [repo has been public from day one](https://github.com/18F/dol-whd-14c), which includes our project management tasks. Furthermore, the user stories from the performance work statement were public on our [Trello board](https://trello.com/b/74MUGMpP/14-c-public-backlog) and have been used to inform each sprint during these 60 days. You can also see the outcome of work with the beta version of the [public prototype](https://dol-whd-section14c-stg.azurewebsites.net/#/).
 
 ## A new way to work
 


### PR DESCRIPTION
Changes proposed in this pull request:
- adds the `agency work` tag to a couple posts that should have it

/cc @coreycaitlin @gboone 
