### PR TITLE
Adds generic call to action banner

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -4,6 +4,7 @@ path: about
 permalink: /about/
 layout: default-intro
 lead: We help other government agencies build, buy, and share technology products.
+banner_cta: true
 ---
 
 18F is an office within the [General Services Administration](https://www.gsa.gov/) (GSA).

--- a/_includes/banner-cta.html
+++ b/_includes/banner-cta.html
@@ -1,0 +1,11 @@
+<div class="usa-section background-medium">
+    <div class="usa-grid usa-flex usa-flex-baseline">
+      <div class="usa-width-one-third h3">Get in touch</div>
+      <div>
+        <p>
+          Have a project in mind? Want to see if 18F can help your agency? We’d love to talk more, answer your questions, or learn more about what you’re working on.
+        </p>
+        <a href="{{ site.baseurl }}/how-we-work/"><button class="usa-button usa-button-secondary marginless">Contact us</button></a>
+      </div>
+    </div>
+  </div>

--- a/_layouts/default-intro.html
+++ b/_layouts/default-intro.html
@@ -40,3 +40,7 @@ layout: default
     {{ content }}
   {% endif %}
 </section>
+
+{% if page.banner_cta %}
+  {% include banner-cta.html %}
+{% endif %}

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -138,10 +138,5 @@ header_border: true
     </div>
   </div>
 
-  <div class="usa-section">
-    <div class="usa-grid usa-flex usa-flex-pull-right usa-flex-baseline">
-    <h4>We work with federal agencies to approach technology projects in new ways</h4>
-    <div class="usa-width-one-third"><a href="{{ site.baseurl }}/how-we-work/"><button class="usa-button usa-button-secondary marginless">Get in touch</button></a></div>
-  </div>
-  </div>
+  {% include banner-cta.html %}
 </section>

--- a/_sass/_components/layout.scss
+++ b/_sass/_components/layout.scss
@@ -98,8 +98,16 @@
   background-color: $color-gray-lightest;
 }
 
+.background-medium {
+  background-color: $color-medium;
+}
+
 .background-dark {
   background-color: $color-dark;
+}
+
+.background-medium,
+.background-dark {
   color: $color-white;
   -webkit-font-smoothing: antialiased;
 


### PR DESCRIPTION
What I am trying to edit above: 

This adds a generic call to action banner to the site.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/page-footers.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/page-footers)

[:sunglasses: PREVIEW project](https://federalist.18f.gov/preview/18F/18f.gsa.gov/page-footers/project/fec-gov)
[:sunglasses: PREVIEW about](https://federalist.18f.gov/preview/18F/18f.gsa.gov/page-footers/about)

Changes proposed in this pull request:
- adds a `$medium` background banner that can be added to `profile-intro` layouts by adding the `banner_cta: true` to the fronmatter
- adds it by default on the project page layout

/cc @coreycaitlin 
