### PR TITLE
highlight what-we-deliver nav heading

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,6 +18,7 @@ assigned:
         text: What we deliver
         href: pages/what-we-deliver.md
         permalink: /what-we-deliver/
+        collections: ['projects']
         in_menu: true
         in_drawer: true
         in_footer: true

--- a/_layouts/project-tag-results.html
+++ b/_layouts/project-tag-results.html
@@ -6,7 +6,7 @@ header_border: true
 {% assign matching_posts = page | match_posts | sort:'date' | reverse %}
 
 <section class="breadcrumb usa-grid">
-  <a class="link-arrow-right" href="{{ site.baseurl }}/">Home</a> {% include svg/icons/arrow-right.svg %} <a class="link-arrow-right" href="{{ site.baseurl }}/how-we-work/">What we deliver</a> {% include svg/icons/arrow-right.svg %} <span class="link-arrow-right">{{ page.title }}</span>
+  <a class="link-arrow-right" href="{{ site.baseurl }}/">Home</a> {% include svg/icons/arrow-right.svg %} <a class="link-arrow-right" href="{{ site.baseurl }}/what-we-deliver/">What we deliver</a> {% include svg/icons/arrow-right.svg %} <span class="link-arrow-right">{{ page.title }}</span>
 </section>
 <section class="page-tag-results">
 


### PR DESCRIPTION
Fixes issue(s) #2276 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/active-nav.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/active-nav)

[:sunglasses: PREVIEW](https://federalist.18f.gov/preview/18F/18f.gsa.gov/active-nav/project/fec-gov/)

<img width="562" alt="screen shot 2017-02-09 at 11 24 46 am" src="https://cloud.githubusercontent.com/assets/4803473/22799377/69562ff2-eeba-11e6-8274-20ab5261a3f4.png">


Changes proposed in this pull request:
- Ensures that the `what-we-deliver` nav item is active when a user is on any of the project pages
- Changed breadcrumb link from  `how-we-work` to `what-we-deliver`

/cc @coreycaitlin 
