### PR TITLE
Takes out the twitter share links

### DIFF
--- a/_posts/2016-02-12-happy-valentines-day-from-18F.md
+++ b/_posts/2016-02-12-happy-valentines-day-from-18F.md
@@ -24,16 +24,16 @@ These tools — and these Valentine’s Day cards — follow industry-standard w
 So spread a little love this Valentine’s Day...because nothing says “I love you” like sharing our Draft U.S. Web Design Standards cards.
 
 ![The draft web standards accordion with a valentines message exposed.]({{site.baseurl}}/assets/img/vday/accordion.png)
-**Accordion to me, you’re the best.** [Send this card to someone on Twitter!](https://twitter.com/intent/tweet?text=Happy%20Valentines%20Day%20from%20the%20Draft%20U.S.%20Web%20Design%20Standards%20team!%20{{site.url}}/card/accordion/)
+**Accordion to me, you’re the best.**
 
 ![A valentines message floating above the draft web standards logo.]({{site.baseurl}}/assets/img/vday/no-standard-way.png)
-**There’s no standard way to say I love you this Valentine’s day.** [Send this card to someone on Twitter!](https://twitter.com/intent/tweet?text=Happy%20Valentines%20Day%20from%20the%20Draft%20U.S.%20Web%20Design%20Standards%20team!%20{{site.url}}/card/no-standard-way/)
+**There’s no standard way to say I love you this Valentine’s day.**
 
 ![Valentines messages written on the draft web standards button templates.]({{site.baseurl}}/assets/img/vday/press-all-buttons.png)
-**You press all my buttons.** [Send this card to someone on Twitter!](https://twitter.com/intent/tweet?text=Happy%20Valentines%20Day%20from%20the%20Draft%20U.S.%20Web%20Design%20Standards%20team!%20{{ site.url }}/card/press-all-buttons/)
+**You press all my buttons.**
 
 ![A heart superimposed over the draft web standards grid]({{site.baseurl}}/assets/img/vday/entire-grid.png)
-**My heart would fill this entire grid.** [Send this card to someone on Twitter!](https://twitter.com/intent/tweet?text=Happy%20Valentines%20Day%20from%20the%20Draft%20U.S.%20Web%20Design%20Standards%20team!%20{{site.url}}/card/entire-grid/)
+**My heart would fill this entire grid.**
 
 ![A rose and a violet with a valentines message.]({{site.baseurl}}/assets/img/vday/roses-violets.png)
-**Roses are #E31C3D Violets are #0071BC.** [Send this card to someone on Twitter!](https://twitter.com/intent/tweet?text=Happy%20Valentines%20Day%20from%20the%20Draft%20U.S.%20Web%20Design%20Standards%20team!%20{{site.url }}/card/roses-violets/)
+**Roses are #E31C3D Violets are #0071BC.**


### PR DESCRIPTION
Since we dropped the `card` collection and the layout that generated the Twitter cards, all the links now 404. If this is something we want to support again in the future we should make an issue for it.

The way the `card` collection worked was to generate pages that could be read into Twitter effectively creating multiple custom share messages for the same blog post.

cc @18F/blog 