### PR TITLE
remove broken dashboard links

### DIFF
--- a/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
+++ b/_posts/2015-03-17-does-18f-pass-the-bechdel-test-for-tech.md
@@ -80,7 +80,7 @@ simplify, streamline, and unify the Small Business Innovation Research
 application process.
 
 
-[*USCIS projects*](https://18f.gsa.gov/what-we-deliver/dhs-myuscis/) - We
+[*USCIS projects*](https://18f.gsa.gov/what-we-deliver/myuscis/) - We
 are helping to re-image and modernize immigration and visa processes:
 building tools that improve the applicant process, providing clear and
 simple information to the public, and creating new tools that make the
@@ -95,8 +95,7 @@ businesses search for opportunities to work with the U.S. government.
 
 ## Almost Bechdels
 
-[*Data
-Act*](https://github.com/fedspendingtransparency/fedspendingtransparency.github.io) -
+[*Data Act*](https://github.com/fedspendingtransparency/fedspendingtransparency.github.io) -
 Consulting engagement to advise on the federal spending data standards
 and corresponding pilot project mandated by the DATA Act. Kaitlin Devine
 mentions, “There isn't actually any code associated with this right now,

--- a/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
+++ b/_posts/2015-04-01-govtechhack-hacking-for-civic-improvement.md
@@ -77,7 +77,7 @@ following day. These projects included:
 -   [**eRegs**](http://cfpb.github.io/eRegulations/) — An application that makes federal regulations easier to
     find, read, and understand
 
--   [**Communicart**](https://18f.gsa.gov/dashboard/what-we-deliver/c2/) — A simplified, email-based purchasing approval tool
+-   [**Communicart**](https://18f.gsa.gov/what-we-deliver/c2/) — A simplified, email-based purchasing approval tool
     for purchase card holders authorized to buy office supplies for
     the government
 

--- a/_posts/2015-07-08-openfec-api.md
+++ b/_posts/2015-07-08-openfec-api.md
@@ -29,7 +29,7 @@ With that API, searching for candidates and committees will be easier and more i
 
 All of these features are supported by our [public API](http://api.open.fec.gov/developers) so those outside of government can directly benefit from this technology, by making or using their own apps. For example, we created an endpoint that accepts partial names in queries, so you can make your own type-ahead search.
 
-The API is the backbone of [OpenFEC](https://18f.gsa.gov/dashboard/what-we-deliver/fec-gov/) — the FEC's next digital evolution. It’s also the first public release from our partnership. Be on the lookout for a new app and an eventual site redesign. As with all our projects, looking modern isn’t just an aesthetic choice, it comes from smart design and asking actual website users what they want. Take a look at our [interactive API documentation](https://api.open.fec.gov/developers). It not only has a fresh look, but it’s driven by modern technology underneath the hood.
+The API is the backbone of OpenFEC — the FEC's next digital evolution. It’s also the first public release from our partnership. Be on the lookout for a new app and an eventual site redesign. As with all our projects, looking modern isn’t just an aesthetic choice, it comes from smart design and asking actual website users what they want. Take a look at our [interactive API documentation](https://api.open.fec.gov/developers). It not only has a fresh look, but it’s driven by modern technology underneath the hood.
 
 Releasing the API before it’s complete allows 18F and FEC to get public feedback and ensure the project will continue to grow and adjust to better serve the people.
 


### PR DESCRIPTION
Removes an old link to the dashboard, which no longer works. It doesn't seem to affect meaning/sense at all.

/cc @gboone or @awfrancisco 
