### PR TITLE
In page nav items

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -5,7 +5,7 @@ permalink: /about/
 layout: default-intro
 lead: We help other government agencies build, buy, and share technology products.
 banner_cta: true
-nav_items:
+subnav_items:
 -
   text: Our principles
   permalink: /about/#our-principles

--- a/_about/index.md
+++ b/_about/index.md
@@ -5,6 +5,23 @@ permalink: /about/
 layout: default-intro
 lead: We help other government agencies build, buy, and share technology products.
 banner_cta: true
+nav_items:
+-
+  text: Our principles
+  permalink: /about/#our-principles
+  in_subnav: true
+-
+  text: Our team
+  permalink: /about/#our-team
+  in_subnav: true
+-
+  text: History and funding
+  permalink: /about/#history-and-funding
+  in_subnav: true
+-
+  text: For press
+  permalink: /about/#for-press
+  in_subnav: true
 ---
 
 18F is an office within the [General Services Administration](https://www.gsa.gov/) (GSA).

--- a/_authors/jameshupp.md
+++ b/_authors/jameshupp.md
@@ -4,6 +4,6 @@ full_name: James Hupp
 first_name: James
 last_name: Hupp
 redirect_from: "/team/jameshupp/"
-published: false
+published: true
 ---
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -98,34 +98,6 @@ assigned:
         in_drawer: true
         in_footer: true
         children:
-            -
-                text: 'Our principles'
-                permalink: /about/#our-principles
-                in_menu: false
-                in_drawer: false
-                in_footer: false
-                in_subnav: true
-            -
-                text: 'Our team'
-                permalink: /about/#our-team
-                in_menu: false
-                in_drawer: false
-                in_footer: false
-                in_subnav: true
-            -
-                text: 'History and funding'
-                permalink: /about/#history-and-funding
-                in_menu: false
-                in_drawer: false
-                in_footer: false
-                in_subnav: true
-            -
-                text: 'For press'
-                permalink: /about/#for-press
-                in_menu: false
-                in_drawer: false
-                in_footer: false
-                in_subnav: true
     -
         text: Join 18F
         href: _pages/join.md

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,11 +1,7 @@
 {% assign current = page.url | downcase | split: '/' %}
 
-{% if page.nav_items %}
-  {% assign nav_items = page.nav_items %}
-{% else %}
-  {% assign nav_items = site.data.navigation %}
-  {% assign nav_items = nav_items['assigned'] %}
-{% endif %}
+{% assign nav_items = site.data.navigation %}
+{% assign nav_items = nav_items['assigned'] %}
 
 {% if include.navbar %}
   {% include navigation/navbar.html nav_items=nav_items %}
@@ -21,10 +17,12 @@
 
 
 {% if include.subnav %}
-  {% if page.nav_items %}
+  {% if page.subnav_items %}
+    {% assign subnav_items = page.subnav_items %}
+
     {% include navigation/subnav.html
        page_data=page
-       nav_items=nav_items
+       subnav_items=subnav_items
        children=true
     %}
   {% else %}

--- a/_includes/navigation/subnav.html
+++ b/_includes/navigation/subnav.html
@@ -1,4 +1,4 @@
-{% assign nav_items = include.page_data.children | default: include.nav_items %}
+{% assign subnav_items = include.page_data.children | default: include.subnav_items %}
 
 <nav class="nav-accordion nav-subnav usa-accordion" role="navigation">
   {% assign title_slug = page.title | slugify %}
@@ -9,7 +9,7 @@
   <ul id="{{ title_slug }}" class="usa-sidenav-list usa-accordion" aria-hidden="true">
     {% assign is_matching = page.url | matches_url: page_data.permalink %}
 
-  {% for item in nav_items %}
+  {% for item in subnav_items %}
     {% if item.in_subnav %}
     <li>
       {% if item.permalink %}


### PR DESCRIPTION
Fixes issue(s) #2127 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/in-page-nav.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/in-page-nav)

[:sunglasses: PREVIEW]https://federalist.18f.gov/preview/18F/18f.gsa.gov/in-page-nav/)

Changes proposed in this pull request:
- Adds the `nav_items` attribute to the About page frontmatter, as an example of how to add navigation on a localized level

/cc @coreycaitlin 
