### PR TITLE
minor image and copy edits

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -32,6 +32,33 @@ assigned:
         in_footer: false
         children:
     -
+        text: About 18F
+        href: _about/index.md
+        permalink: /about/
+        collections: ['about']
+        in_menu: true
+        in_drawer: true
+        in_footer: true
+        children:
+    -
+        text: Join 18F
+        href: /_join/index.md
+        permalink: /join/
+        in_menu: false
+        in_drawer: false
+        in_footer: true
+        children:
+    -
+        text: Blog
+        href: blog/index.html
+        permalink: /blog/
+        permalink_alt: /tags/
+        collections: ['authors', 'posts']
+        in_menu: true
+        in_drawer: true
+        in_footer: true
+        children:
+    -
         text: Contact
         href: pages/contact.md
         permalink: /contact/
@@ -89,31 +116,4 @@ assigned:
                         in_drawer: false
                         in_footer: false
                         in_subnav: true
-    -
-        text: About 18F
-        href: _about/index.md
-        permalink: /about/
-        collections: ['about']
-        in_menu: true
-        in_drawer: true
-        in_footer: true
-        children:
-    -
-        text: Join 18F
-        href: /_join/index.md
-        permalink: /join/
-        in_menu: false
-        in_drawer: false
-        in_footer: true
-        children:
-    -
-        text: Blog
-        href: blog/index.html
-        permalink: /blog/
-        permalink_alt: /tags/
-        collections: ['authors', 'posts']
-        in_menu: true
-        in_drawer: true
-        in_footer: true
-        children:
 unassigned: []

--- a/_projects/calc.md
+++ b/_projects/calc.md
@@ -7,6 +7,7 @@ permalink: /what-we-deliver/calc/
 excerpt: We helped build an interactive website for searching past government contracts to find fair hourly rates.
 image:
 image_accessibility:
+image_icon: folderwithclock.svg
 tag: calc
 expiration_date:
 github_repo: https://github.com/18F/calc

--- a/_projects/eregs.md
+++ b/_projects/eregs.md
@@ -8,7 +8,7 @@ redirect_from: /project/eregulations/
 excerpt: We've worked with several agencies to adapt an open-source tool that makes regulations easier to find, read, and understand.
 image:
 image_accessibility:
-image_icon: gavel.svg
+image_icon: 
 tag: eregulations
 expiration_date:
 github_repo:

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -15,9 +15,6 @@ gridless: true
       <p>Want to see if 18F can help your agency? Email Dan Kenny on our Agency Partnerships team at <a href="mailto:inquiries18F@gsa.gov?subject=18F%20Website%20Inquiry&body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20the%20problems%20you%27re%20working%20on%2C%20or%20what%20project%20you%27re%20hoping%20to%20work%20on%20with%2018F:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%3F%0A">inquiries18F@gsa.gov</a>.</p>
     </li>
     <li class="section-info-list-item">
-      <a class="usa-button usa-button-marginless" href="mailto:inquiries18F@gsa.gov?subject=18F%20Website%20Inquiry&body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20the%20problems%20you%27re%20working%20on%2C%20or%20what%20project%20you%27re%20hoping%20to%20work%20on%20with%2018F:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%3F%0A">Get in touch</a>
-    </li>
-    <li class="section-info-list-item">
       <div class="section-info-header">Other contacts</div>
       <ul>
         <li>Media inquiries: <a href="mailto:press@gsa.gov">press@gsa.gov</a></li>
@@ -39,6 +36,8 @@ After we hear from you, we’ll set up a time to talk more, answer your question
 To learn more about how we work with agencies, see [our principles]({{ site.baseurl }}/about/#our-principles), explore our [Partnership Playbook](https://pages.18f.gov/partnership-playbook/), or learn about [how we’re funded]({{ site.baseurl }}/about/#funding-and-agreements).
 
 {% endmarkdown %}
+
+<a class="usa-button usa-button-marginless" href="mailto:inquiries18F@gsa.gov?subject=18F%20Website%20Inquiry&body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20the%20problems%20you%27re%20working%20on%2C%20or%20what%20project%20you%27re%20hoping%20to%20work%20on%20with%2018F:%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%3F%0A">Get in touch</a>
 </div>
 
 </div>

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -16,7 +16,7 @@ gridless: true
     <div class="usa-section-bottom">
       <div class="small-caps small-caps-no-margin">Projects</div>
       <h3>We’ve worked with more than 50 offices and agencies on more than 200 engagements.</h3>
-      <p>All our projects support agencies in transforming how they deliver digital services and technology products. Here are a few of the projects we’ve worked on with agencies.</p>
+      <p>All our projects support agencies in transforming how they deliver digital services and technology products. Here are a few of the projects we’ve worked on.</p>
     </div>
     <div class="usa-flex usa-flex-wrap">
       {% assign projects_list = site | find_collection: 'projects' | weighted_sort: 'project_weight', 'title' %}


### PR DESCRIPTION
This has a few edits suggested in review:

- moves the "email us" button to the main content area
- removes "with agencies" from the "what we deliver" intro, because we already said "support agencies" in the prior sentence
- switches up a few placeholder project images for variety
- change nav order so `Contact` is in the upper-right

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/edits-from-slack.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/edits-from-slack)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/edits-from-slack/)

/cc @gboone 
