### PR TITLE
Upgrade jekyll_oembed to v0.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :jekyll_plugins do
   gem 'jekyll_frontmatter_tests'
   gem 'jekyll_pages_api'
   gem 'jekyll_pages_api_search'
-  gem 'jekyll_oembed', '~> 0.0.2'
+  gem 'jekyll_oembed'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       listen (~> 3.0, < 3.1)
     jekyll_frontmatter_tests (0.0.13)
       jekyll (>= 2.0, < 4.0)
-    jekyll_oembed (0.0.2)
+    jekyll_oembed (0.0.3)
       jekyll (~> 3)
       ruby-oembed (~> 0)
     jekyll_pages_api (0.1.6)
@@ -204,7 +204,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll_frontmatter_tests
-  jekyll_oembed (~> 0.0.2)
+  jekyll_oembed
   jekyll_pages_api
   jekyll_pages_api_search
   jemoji


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/upgrade-jekyll_oembed.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/upgrade-jekyll_oembed)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/upgrade-jekyll_oembed/)

Changes proposed in this pull request:
- upgrades `jekyll_oembed` to `0.0.3`
- This is important because previously, private (or otherwise blocked) URLs would fail a build. `0.0.3` fails silently, which is good, in this case.

/cc @gboone 
