### PR TITLE
Restore accesslint

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+<html lang="en">
+  <head>
+    <title>404</title>
+  </head>
+</html>

--- a/404.html
+++ b/404.html
@@ -2,4 +2,7 @@
   <head>
     <title>404</title>
   </head>
+  <body>
+    <div>For AccessLint purposes only.</div>
+  </body>
 </html>

--- a/_config-accesslint.yml
+++ b/_config-accesslint.yml
@@ -1,5 +1,7 @@
 ---
 env: development
+include:
+- 404.html
 exclude:
 - ".about.yml"
 - ".cfignore"

--- a/_config-blog.yml
+++ b/_config-blog.yml
@@ -7,6 +7,7 @@ exclude:
 - ".gitignore"
 - ".gitmodules"
 - ".hound.yml"
+- 404.html
 - api-endpoints
 - bin
 - build

--- a/_config-fast-builds.yml
+++ b/_config-fast-builds.yml
@@ -14,6 +14,7 @@ exclude:
 - .gitignore
 - .gitmodules
 - .hound.yml
+- 404.html
 - api-endpoints
 - bin
 - build

--- a/_config.yml
+++ b/_config.yml
@@ -121,6 +121,7 @@ exclude:
 - .gitignore
 - .gitmodules
 - .hound.yml
+- 404.html
 - api-endpoints
 - bin
 - build

--- a/circle.yml
+++ b/circle.yml
@@ -22,5 +22,5 @@ test:
     - npm run htmlproofer
     - bundle exec rspec
     - CODECLIMATE_REPO_TOKEN=${CODECLIMATE_REPO_TOKEN} bundle exec codeclimate-test-reporter
-  # post:
-    # - ./serve-accesslint && bundle exec accesslint-ci scan http://localhost:4000/site
+  post:
+    - ./serve-accesslint && bundle exec accesslint-ci scan http://localhost:4000/site


### PR DESCRIPTION
Replaces #2321 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/restore-accesslint.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/restore-accesslint)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/restore-accesslint/)

Changes proposed in this pull request:
- adds a new page `404.html` that will only be served with the `./serve-accesslint` command
- Before this is merged I need to make sure that when Federalist serves the correct 404 page.

/cc @gboone @ckundo 
