### PR TITLE
Update frontmatter tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
-  gem 'jekyll_frontmatter_tests'
+  gem 'jekyll_frontmatter_tests', '~> 0.1.0'
   gem 'jekyll_pages_api'
   gem 'jekyll_pages_api_search'
   gem 'jekyll_oembed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       jekyll (~> 3.3)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    jekyll_frontmatter_tests (0.0.13)
+    jekyll_frontmatter_tests (0.1.0)
       jekyll (>= 2.0, < 4.0)
     jekyll_oembed (0.0.3)
       jekyll (~> 3)
@@ -203,7 +203,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
-  jekyll_frontmatter_tests
+  jekyll_frontmatter_tests (~> 0.1.0)
   jekyll_oembed
   jekyll_pages_api
   jekyll_pages_api_search

--- a/_posts/2014-05-19-packaging-up-api-usability-testing-for-agency-re-use.md
+++ b/_posts/2014-05-19-packaging-up-api-usability-testing-for-agency-re-use.md
@@ -8,7 +8,7 @@ title: "Packaging up API usability testing for agency reuse"
 description: "Over the past year, a GSA collaboration has seen a project that offers API usability testing to federal agencies go from the pilot stage to a regular, robust series. Already, 13 agencies and programs have participated, and several more participate with every monthly session that passes. The best examples from across the government have made clear that one of the most important tasks of API producers is to regularly engage their developer community and listen to what they have to say. But just encouraging agencies to do this only goes so far."
 excerpt: "Over the past year, a GSA collaboration has seen a project that offers API usability testing to federal agencies go from the pilot stage to a regular, robust series. Already, 13 agencies and programs have participated, and several more participate with every monthly session that passes. The best examples from across the government have made clear that one of the most important tasks of API producers is to regularly engage their developer community and listen to what they have to say. But just encouraging agencies to do this only goes so far."
 
-image: 
+image:
 
 authors:
 - gray

--- a/_projects/c2.md
+++ b/_projects/c2.md
@@ -15,7 +15,7 @@ project_url: "[C2 website](https://cap.18f.gov/)"
 learn_more:
 product_clients:
 resources:
-quote: 
+quotes:
 ---
 
 Federal employees who want to make small, work-related purchases do so using a Purchase Card (or P-Card, for short). The P-Cards system was put in place to ensure proper use of taxpayers’ money, and they can only be used by specially trained employees. Until recently, all P-Card users had to manually track their purchases, which took time and effort needed for more mission-critical tasks.

--- a/tests/schema/_authors.yml
+++ b/tests/schema/_authors.yml
@@ -1,11 +1,10 @@
 ---
-name: "String"
-first_name: "String"
-last_name: "String"
-full_name: "String"
+name: String
+first_name: String
+full_name: String
 published: Boolean
 config:
-  path: '_authors'
+  path: _authors
   ignore:
   - README.md
   - ..

--- a/tests/schema/_posts.yml
+++ b/tests/schema/_posts.yml
@@ -1,5 +1,5 @@
 ---
-title: "String"
+title: String
 authors:
   type: Array
   matches: _data/author.yml
@@ -9,7 +9,7 @@ tags:
   rules: [no-dash, lowercase]
 excerpt: "String"
 config:
-  path: '_posts'
+  path: _posts
   ignore:
   - README.md
   - ..

--- a/tests/schema/_projects.yml
+++ b/tests/schema/_projects.yml
@@ -1,13 +1,10 @@
 ---
-layout: "String"
-title: "String"
-subtitle: "String"
-excerpt: "String"
+layout: String
+title: String
+subtitle: String
+excerpt: String
 tag: String
-github_repo: "String"
-project_url: "String"
-permalink: "String"
-expiration_date: String
+permalink: String
 config:
   path: _projects
   ignore:
@@ -24,7 +21,6 @@ config:
     - github_repo
     - project_url
     - learn_more
-    - agency
     - resources
     - quote
     - quote_source

--- a/tests/schema/_test_collection.yml
+++ b/tests/schema/_test_collection.yml
@@ -1,11 +1,11 @@
 ---
-name: "String"
-last_name: "String"
+name: String
+last_name: String
 team:
-  type: "String"
+  type: String
   one_of: ["Test"]
 config:
-  path: 'spec/_test_collection'
+  path: spec/_test_collection
   ignore:
   - ..
   - .

--- a/tests/schema/rules.yml
+++ b/tests/schema/rules.yml
@@ -1,4 +1,4 @@
 no-dash:
-- prohibited: ["-"]
-lowercase:
-- prohibited: ["AZ"]
+  exceptions:
+    - user-centered design
+    - micro-purchase platforms


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/jekyll_fm_redux.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/jekyll_fm_redux)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/jekyll_fm_redux/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/jekyll_fm_redux/README.md)

Changes proposed in this pull request:
- updates the `jekyll_frontmatter_tests` gem to `v0.1.0`
- updates frontmatter formatting

/cc @gboone 
