### PR TITLE
Update Readme to better link to styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 This repo houses the 18F website. We use the [Draft U.S. Web Design standards](https://standards.usa.gov/) as a front end framework. The site is built and served through [the Federalist platform](https://federalist.fr.cloud.gov/).
 
-As of March 2017, we maintain a styleguide for components used across the site at 18f.gsa.gov/styleguide.
+### Style and style guide
+
+18f.gsa.gov extends the [U.S. Web Design Standards](https://standards.usa.gov/) and [18F Brand guidelines](https://pages.18f.gov/brand/) to create a style that is professional, unique, and informative. The style guide, located at [18f.gsa.gov/styleguide/](https://18f.gsa.gov/styleguide/) documents the patterns and components used to create this theme.
+
+[View style guide](https://18f.gsa.gov/styleguide/)
 
 ### History
 


### PR DESCRIPTION
This updates the documentation in the README so that users have an easier time finding the style guide.

**New text:**

> > 18f.gsa.gov extends the [U.S. Web Design Standards](https://standards.usa.gov/) and [18F Brand guidelines](https://pages.18f.gov/brand/) to create a style that is professional, unique, and informative. The style guide, located at [18f.gsa.gov/styleguide/](https://18f.gsa.gov/styleguide/) documents the patterns and components used to create this theme.
> 
> > [View style guide](https://18f.gsa.gov/styleguide/)


[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/gemfarmer-styleguide-readme/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/gemfarmer-styleguide-readme/README.md)




/cc @gboone 
