### PR TITLE
remove team-api

### DIFF
--- a/pages/developer.md
+++ b/pages/developer.md
@@ -33,10 +33,6 @@ The [Hub API](https://18f.gsa.gov/hub/api/) provides web services for the [18F H
 
 The [OpenFEC API](https://api.open.fec.gov/developers) is the first RESTful API for the Federal Election Commission. It aims to make campaign finance more accessible for journalists, academics, developers, and other transparency seekers.
 
-### Team API
-
-The [18F Team API](https://team-api.18f.gov/public/api/) exposes organization information that is then integrated into the other internal systems 18F uses.
-
 ## 18F Initiatives
 
 ### /Developer Program


### PR DESCRIPTION
team-api is deprecated :pour-one-out:, link on this page 404s
have not heard of any plans to revive it

Fixes issue(s) #2381.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Remove entire section referencing Team API.
-
-

/cc @relevant-people
