### PR TITLE
Unlists the Product Manager postiion (it's closed)

### DIFF
--- a/_includes/open-positions.html
+++ b/_includes/open-positions.html
@@ -2,11 +2,12 @@
   {% if all_positions.size > 0 %}
     {% assign published_positions = all_positions | where: "published", true %}
     {% assign open_positions = published_positions | where: "listed", true %}
-
-<h3>Open positions</h3>
-  {% for position in open_positions %}{% unless "listed" == false %}
-<a class="usa-button" href="{{ site.baseurl }}{{ position.permalink }}">{{ position.position_title | default: position.title }}</a>{% endunless %}
-  {% endfor %}
+  {% if open_positions > 0 %}
+    <h3>Open positions</h3>
+      {% for position in open_positions %}{% unless "listed" == false %}
+        <a class="usa-button" href="{{ site.baseurl }}{{ position.permalink }}">{{ position.position_title | default: position.title }}</a>{% endunless %}
+      {% endfor %}
   {% else %}
-<h4>We don’t have any open positions right now.</h4>
+  <h4>We don’t have any open positions right now.</h4>
+  {% endif %}
   {% endif %}

--- a/_join/job-listings/product-manager.md
+++ b/_join/job-listings/product-manager.md
@@ -14,7 +14,7 @@ subnav_items:
 sub_parent_title: Product Manager
 sub_parent_permalink: /join/product-manager/
 breadcrumb: true
-published: true
+published: false
 listed: false
 ---
 
@@ -375,4 +375,3 @@ To learn more, please consult the following resources:
 </section>
 
 If applicable, please *only* submit all veteran's documentation to Jacqueline Coleman at [jacqueline.coleman@gsa.gov](mailto:jacqueline.coleman@gsa.gov). In the subject line of your email put: Veteran’s Documentation for 1700256JCDE.
-

--- a/_join/open-positions/position-title.md
+++ b/_join/open-positions/position-title.md
@@ -19,7 +19,7 @@ subnav_items:
     permalink: /#additional-information
 breadcrumb: true
 published: false
-listed: true
+listed: false
 ---
 
 ## Basic information

--- a/_join/open-positions/product-manager.md
+++ b/_join/open-positions/product-manager.md
@@ -19,7 +19,7 @@ subnav_items:
     permalink: /#objective-3-you-will-manage-relationships-with-18fs-agency-partners
 breadcrumb: true
 published: false
-listed: true
+listed: false
 ---
 ## Position Summary
 

--- a/_join/open-positions/product-manager.md
+++ b/_join/open-positions/product-manager.md
@@ -18,7 +18,7 @@ subnav_items:
   - text: "Objective 3: Manage relationships"
     permalink: /#objective-3-you-will-manage-relationships-with-18fs-agency-partners
 breadcrumb: true
-published: true
+published: false
 listed: true
 ---
 ## Position Summary


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/unlisting.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/unlisting)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/unlisting/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/unlisting/README.md)

Changes proposed in this pull request:
- Unlists the product manager job description (because it's closed now)

/cc @hestherchang 
