### PR TITLE
Correct an error in faux-code indentation

### DIFF
--- a/_posts/2016-10-04-what-is-static-source-analysis.md
+++ b/_posts/2016-10-04-what-is-static-source-analysis.md
@@ -105,21 +105,21 @@ Consider some code that describes your daily activities, by day of the
 week and time of day. It might look something like this:
 
 ```
-If it is Monday…
+If it is Monday...
   If it is morning...
     Eat breakfast
     Take a shower
     Go to work
-If it is noon...
-  Eat lunch
-  Go for a walk
-If it is five o’clock...
-  Go to the gym
-  Workout
-  Go home
-  Eat dinner
-If it is 11 o’clock...
-  Go to sleep
+  If it is noon...
+    Eat lunch
+    Go for a walk
+  If it is five o’clock...
+    Go to the gym
+    Workout
+    Go home
+    Eat dinner
+  If it is 11 o’clock...
+    Go to sleep
 ```
 
 While the full math around cyclomatic complexity is a bit hairy, *there


### PR DESCRIPTION
This example doesn't make sense without having all children nested under the top line. I confirmed with @mgwalker that this is a bug. I also standardized the ellipses.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

Changes proposed in this pull request:
-indent all lines of code
-replace ellipsis character with three periods

