### PR TITLE
Clarify job title link

### DIFF
--- a/_includes/open-positions.html
+++ b/_includes/open-positions.html
@@ -7,6 +7,9 @@
     {% for position in open_positions %}{% unless "listed" == false %}
   <a class="usa-button" href="{{ site.baseurl }}{{ position.permalink }}">{{ position.position_title | default: position.title }}</a>{% endunless %}
       {% endfor %}
+
+<p><em>Most of our roles use the “Innovation Specialist” <a href="https://www.opm.gov/faqs/QA.aspx?fid=d2dc8952-41ec-434a-ac7e-bcb6ee8206ba&pid=c9df01f3-8580-4f87-88a4-3e26125f1205">position description</a>, regardless of what team we're hiring for. See the performance profile link above for more detail about specific skills, responsibilities, and expectations.</em></p>
+
   {% else %}
   <h4>We don’t have any open positions right now.</h4>
   {% endif %}

--- a/_join/open-positions/acquisition-technical-lead.md
+++ b/_join/open-positions/acquisition-technical-lead.md
@@ -3,7 +3,7 @@ title: Technical Lead Performance Profile
 permalink: /join/acquisition-technical-lead/
 layout: primary
 lead: Office of Acquisitions
-position_title: Technical Lead
+position_title: Innovation Specialist — Technical Lead
 description: As a Technology Transformation Service (TTS) Office of Acquisition (OA) technical lead, you’ll need to possess excellent judgment, technical skills, and an unflinching belief that federal procurement can not only be efficient, but joyful, too.
 app_close_date:
 subnav_title: Technical Lead
@@ -18,7 +18,7 @@ listed: true
 ---
 ## Position summary
 
-As a Technology Transformation Service (TTS) Office of Acquisition (OA) technical lead, you’ll need to possess excellent judgment, technical skills, and an unflinching belief that federal procurement can not only be efficient, but joyful, too. You will contribute to our team and help our agency partners in three main ways: first, by helping teams (internal and partner agencies) support digital services through their procurement efforts; second, by investigating other agencies’ tools and processes and finding ways to improve both; and third, by working with a cross-functional team to identify, prototype, acquire, and build goods and services for TTS and our partner agencies. Applicants don’t need to have previous federal acquisition experience, but such experience would definitely be helpful for this role. Good humor and empathy are key requirements.
+As a Technology Transformation Service (TTS) Office of Acquisition technical lead, you’ll need to possess excellent judgment, technical skills, and an unflinching belief that federal procurement can not only be efficient, but joyful, too. You will contribute to our team and help our agency partners in three main ways: first, by helping teams (internal and partner agencies) support digital services through their procurement efforts; second, by investigating other agencies’ tools and processes and finding ways to improve both; and third, by working with a cross-functional team to identify, prototype, acquire, and build goods and services for TTS and our partner agencies. Applicants don’t need to have previous federal acquisition experience, but such experience would definitely be helpful for this role. Good humor and empathy are key requirements.
 
 ## Key Objectives
 


### PR DESCRIPTION
Fixes issue(s) #2431 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-title-links.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-title-links/)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/job-title-links/join/)

Changes proposed in this pull request:
- Add `Innovation Specialist — ` to the beginning of the link text
- Add a couple of sentences attempting to explain why people might see multiple postings for "Innovation Specialist" roles

/cc @hestherchang @amandaschonfeld 
