### PR TITLE
Correction: Capitalize F in 18f logo image path

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
   <div class="site-navbar usa-grid">
     <button class="menu-btn">Menu</button>
     <a class="site-logo media_link" href="{{ site.baseurl }}/">
-      <img src="{{ site.baseurl }}/assets/img/logos/18f-Logo-Pride.png" alt="18F Pride logo"
+      <img src="{{ site.baseurl }}/assets/img/logos/18F-Logo-Pride.png" alt="18F Pride logo"
       {% if page.url == '/' %}
         aria-hidden="true"
       {% endif %}

--- a/_includes/navigation/footer-desktop.html
+++ b/_includes/navigation/footer-desktop.html
@@ -1,7 +1,7 @@
 <nav class="footer-desktop">
   <div class="footer-logo-links">
     <a class="footer-logo media_link" href="{{ site.url }}">
-      <img src="{{ site.baseurl }}/assets/img/logos/18f-Logo-Pride.png" alt="18F pride logo">
+      <img src="{{ site.baseurl }}/assets/img/logos/18F-Logo-Pride.png" alt="18F pride logo">
     </a>
     <a class="footer-logo media_link" href="http://www.gsa.gov/">
       <img src="{{ site.baseurl }}/assets/img/logos/gsa-logo.svg" alt="GSA">


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/capitalize-f.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/capitalize-f/)


Changes proposed in this pull request:
- image path correction


/cc @awfrancisco 
