### PR TITLE
Tell people not to submit a PR from a fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ There is a team actively working on the site. You can find us in Slack in the #1
 
 ### Branches
 
-Any 18F team member should be able to make a branch of the site and submit a pull request. Doing so will also generate a preview URL we can use to inspect your changes.
+Any 18F team member should be able to make a branch of the site and submit a pull request. Doing so will also generate a preview URL we can use to inspect your changes. Please do not submit a pull request from a fork of the site, because that does not permit us to inspect your changes.
 
 Because new blog posts are published several times a week, we use several branches to manage parallel work in a predictable way:
 


### PR DESCRIPTION
Per https://github.com/18F/18f.gsa.gov/pull/2460#issuecomment-311119942

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/clarify-fork.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/clarify-fork)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/clarify-fork/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/clarify-fork/README.md)

Changes proposed in this pull request:
- Tell 18F team members not to fork the repo, but instead create a branch.

/cc @elainekamlley