### PR TITLE
Add info on public nature of fed salaries

### DIFF
--- a/_join/index.md
+++ b/_join/index.md
@@ -94,8 +94,7 @@ It can be helpful to start pulling some documents together in advance. The forms
 
 ## Government pay grades
 
-18F team members are hired for specific position descriptions at a specific grade level from the federal general schedule (GS). The GS system is a pay system for civilian employees in the federal government; evaluation and compensation varies by grade level. The qualification requirements for each position at a specific GS level are based on education, background, accomplishments, and experience. The specific requirements will always be listed in the job posting. 
-
+18F team members are hired for specific position descriptions at a specific grade level from the federal general schedule (GS). The GS system is a pay system for civilian employees in the federal government; evaluation and compensation varies by grade level. The qualification requirements for each position at a specific GS level are based on education, background, accomplishments, and experience. The specific requirements will always be listed in the job posting. Salaries of federal employees are public information, and your salary may become publicly available on sites like [FederalPay.org](https://www.federalpay.org/employees).
 
 #### Understanding grade levels
 

--- a/_join/index.md
+++ b/_join/index.md
@@ -201,3 +201,5 @@ This guide shows how to format a government-style resume and what information to
 > * Relevant professional affiliations (organization name, your years of participation)
 > * Publications (including personal blog posts) (title of published work, month and year of publication)
 > * Training and courses (name of training or course, organization providing the training, MM/YYYY completed)
+
+


### PR DESCRIPTION
Fixes issue(s) #2439 .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/awfrancisco-patch-1.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/awfrancisco-patch-1)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/awfrancisco-patch-1/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/awfrancisco-patch-1/README.md)

Changes proposed in this pull request:
- Add information about federal employee salaries being public information.
- Add a link to federalpay.org as an example. 

/cc @elainekamlley @coreycaitlin @commit-dkp 
