### PR TITLE
Redirect page for positions no longer available 

### DIFF
--- a/_join/position-no-longer-available.md
+++ b/_join/position-no-longer-available.md
@@ -1,0 +1,14 @@
+---
+title: The position you’re looking for is no longer available
+permalink: /join/position-no-longer-available/
+layout: primary
+lead:
+redirect_from:
+  - /join/backend-software-engineer/
+  - /join/acquisition-technical-lead/
+  - /join/product-manager/
+---
+
+Head over to the [Join 18F page](https://18f.gsa.gov/join/) to see current open positions or learn more about the application process. You can also [sign up for the 18F Newsletter](https://18f.gsa.gov/contact/) to receive regular updates, including new open positions. 
+
+Questions? Contact the Talent Team at [join18f@gsa.gov](mailto:join18f@gsa.gov).


### PR DESCRIPTION
Fixes issue(s) #2425  .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/pd-redirects.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/pd-redirects)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/pd-redirects/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/pd-redirects/README.md)

Changes proposed in this pull request:
- Created page to notify users a job position is no longer available 
- Added expired job postings to redirect front matter

/cc @awfrancisco 
