### PR TITLE
Removing expired job posting and URL fix

### DIFF
--- a/_join/open-positions/front-end-design-intern.md
+++ b/_join/open-positions/front-end-design-intern.md
@@ -13,8 +13,8 @@ subnav_items:
   - text: How to apply
     permalink: /#how-to-apply
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 
 ## Basic information

--- a/_join/open-positions/service-visual-design-intern.md
+++ b/_join/open-positions/service-visual-design-intern.md
@@ -13,8 +13,8 @@ subnav_items:
   - text: How to apply
     permalink: /#how-to-apply
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 
 ## Basic information

--- a/_join/position-no-longer-available.md
+++ b/_join/position-no-longer-available.md
@@ -7,6 +7,8 @@ redirect_from:
   - /join/backend-software-engineer/
   - /join/acquisition-technical-lead/
   - /join/product-manager/
+  - /join/front-end-design-intern/
+  - /join/service-visual-design-intern/
 ---
 
 Head over to the [Join 18F page](https://18f.gsa.gov/join/) to see current open positions or learn more about the application process. You can also [sign up for the 18F Newsletter](https://18f.gsa.gov/contact/) to receive regular updates, including new open positions. 

--- a/_styleguide/subpages/for-developers.md
+++ b/_styleguide/subpages/for-developers.md
@@ -4,7 +4,7 @@ subpage: For developers
 permalink: /styleguide/for-developers/
 ---
 
-[18f.gsa.gov](https://18f.gsa.gov), and many 18F websites deployed to [Federalist](federalist.fr.cloud.gov) use [Jekyll](https://jekyllrb.com/) to build static, maintainable websites.
+[18f.gsa.gov](https://18f.gsa.gov), and many 18F websites deployed to [Federalist](https://federalist.fr.cloud.gov) use [Jekyll](https://jekyllrb.com/) to build static, maintainable websites.
 
 One of the core features of Jekyll is the [Liquid](https://shopify.github.io/liquid/) templating language, which has a series of [filters](https://shopify.github.io/liquid/filters/round/) and [tags](https://shopify.github.io/liquid/tags/iteration/) that allow developers programmatically generate content.
 


### PR DESCRIPTION
**To be merged COB 8/2** 

Fixes issue(s) #2479  .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/expired-pd.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/expired-pd)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/expired-pd/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/expired-pd/README.md)

Changes proposed in this pull request:
- removes internship posting
- fixes URL in styleguide 

/cc @awfrancisco 
