### PR TITLE
Removes Talent positions from join page

### DIFF
--- a/_join/open-positions/talent-acquisition-specialist.md
+++ b/_join/open-positions/talent-acquisition-specialist.md
@@ -21,8 +21,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 We're hiring a Talent Acquisition Specialist to help us build an amazing team. This person will work with all of TTS to recruit, interview, and evaluate candidates. This page includes key objectives for the role as well as the official job description. 
 

--- a/_join/open-positions/talent-engagement-lead.md
+++ b/_join/open-positions/talent-engagement-lead.md
@@ -21,8 +21,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 We're hiring a Talent Engagement Lead to help us build an amazing team. This person will work with all of TTS to recruit, interview, and evaluate candidates. This page includes key objectives for the role as well as the official job description. 
 

--- a/_join/open-positions/talent-engagement-specialist.md
+++ b/_join/open-positions/talent-engagement-specialist.md
@@ -21,8 +21,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 We're hiring a Talent Engagement Specialist to help us build an amazing team. This person will work with all of TTS to recruit, interview, and evaluate candidates. This page includes key objectives for the role as well as the official job description. 
 

--- a/_join/position-no-longer-available.md
+++ b/_join/position-no-longer-available.md
@@ -9,6 +9,9 @@ redirect_from:
   - /join/product-manager/
   - /join/front-end-design-intern/
   - /join/service-visual-design-intern/
+  - /join/talent-acquisition-specialist/
+  - /join/talent-engagement-lead/
+  - /join/talent-engagement-specialist/
 ---
 
 Head over to the [Join 18F page](https://18f.gsa.gov/join/) to see current open positions or learn more about the application process. You can also [sign up for the 18F Newsletter](https://18f.gsa.gov/contact/) to receive regular updates, including new open positions. 


### PR DESCRIPTION
To me merged at 9:00 PM ET. 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-takedown.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-takedown)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/job-takedown/)

Changes proposed in this pull request:
- Removing talent job descriptions 

/cc @rooneywp 
