### PR TITLE
Add line breaks where intended to gov resume format

### DIFF
--- a/_join/index.md
+++ b/_join/index.md
@@ -146,9 +146,9 @@ There are many guides to building a government-style resume. Here are several re
 
 This guide shows how to format a government-style resume and what information to include:
 
-> **Name**
-> **City and state of current residence**
-> **Email address**
+> **Name**  
+> **City and state of current residence**  
+> **Email address**  
 > **Phone number**
 >
 > **TECHNICAL SKILLS & TOOLS**
@@ -168,9 +168,9 @@ This guide shows how to format a government-style resume and what information to
 >
 > *See below for employment history formatting.*
 >
-> **Role/title, Company name**
-> **City, State (if within the U.S.) or City, Country**
-> **Duration of employment (MM/YYYY - MM/YYYY or Present)**
+> **Role/title, Company name**  
+> **City, State (if within the U.S.) or City, Country**  
+> **Duration of employment (MM/YYYY - MM/YYYY or Present)**  
 > **“Full-time” or “Part-time,” Number of hours per week: __**
 >
 > For each listing, include a one-sentence description of the company, including the mission. This will help us understand the scope of your work, the context of your contributions, the scale of the company, and your role.
@@ -186,8 +186,9 @@ This guide shows how to format a government-style resume and what information to
 >
 > If you were unemployed at any point, please indicate this. Unemployment is completely acceptable and understood — we just need a full timeline with no gaps. For instance:
 >
-> **Unemployed**
+> **Unemployed**  
 > **Start MM/YYYY - End MM/YYYY**
+>
 > Brief explanation (Took time to travel, to be with my family, and so on) to the extent you’re comfortable sharing. It's also OK not to include a description.
 >
 > **EDUCATION**

--- a/_join/index.md
+++ b/_join/index.md
@@ -193,7 +193,7 @@ This guide shows how to format a government-style resume and what information to
 >
 > **EDUCATION**
 >
-> **Name of college/university/institution, City, State**
+> **Name of college/university/institution, City, State**  
 > Type of degree, major and minor, MM/YYYY degree received
 > Graduation honors, if applicable
 >


### PR DESCRIPTION
This PR modifies the example government-style resume to insert line-breaks where seemingly intended according to the original markdown file. Single line breaks in markdown don't automatically translate to `<br />` tags. To create the line breaks in the HTML, I added two single spaces to the ends of the lines where a line break should occur. [Two single spaces or more at the end of a line in markdown](https://daringfireball.net/projects/markdown/syntax#p), when rendered to HTML, creates the intended `<br />`.

This fix can be a bit tricky to preserve though, if anyone who edits the file has settings in their editor to strip trailing spaces on save.

## Before

![image](https://user-images.githubusercontent.com/2487968/29228880-9c74ec82-7ea9-11e7-99cd-d75b3348bbfe.png)

![image](https://user-images.githubusercontent.com/2487968/29228828-5f589038-7ea9-11e7-8e5b-53c6737b5bbf.png)

![image](https://user-images.githubusercontent.com/2487968/29228867-876d7d0e-7ea9-11e7-80f4-2a6d66705ad7.png)

## After

![image](https://user-images.githubusercontent.com/2487968/29228890-a57c44ce-7ea9-11e7-9051-b785236ec803.png)

![image](https://user-images.githubusercontent.com/2487968/29228845-75f4d72a-7ea9-11e7-9de2-9c90984af268.png)

![image](https://user-images.githubusercontent.com/2487968/29228874-8fcbba9c-7ea9-11e7-9459-450794df4ff1.png)

