### PR TITLE
updating the vul policy with the latest

### DIFF
--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -29,8 +29,12 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy.
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
+* [`federalist.18f.gov`](https://federalist.18f.gov)
+* [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
+* [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)
 * [`login.gov`](https://login.gov) and the following subdomains: `demo.login.gov`, `int.login.gov`, `dev.login.gov`, `qa.login.gov`, `pt.login.gov`, `staging.login.gov`, `dm.login.gov`, `prod.login.gov`, `dashboard.demo.login.gov`, `dashboard.qa.login.gov`, `dashboard.dev.login.gov`. Any other subdomain of login.gov is excluded from this policy.
+* [`data.gov`](https://data.gov) and the following subdomains: `www.data.gov`, `federation.data.gov`, `sdg.data.gov`, `labs.data.gov`, `catalog.data.gov`, `inventory.data.gov`, `static.data.gov`, `admin-catalog-bsp.data.gov`, `manage.data.gov`. Any other subdomains of data.gov are excluded from this policy (`api.data.gov` is specifically excluded).
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)


### PR DESCRIPTION
Pulled content on https://github.com/18F/vulnerability-disclosure-policy into the 18f.gsa.gov page.

Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/wslack-update-vul.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/wslack-update-vul)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/wslack-update-vul/)