### PR TITLE
add a blurb to old blog post that Federalist is open for business

### DIFF
--- a/_posts/2015-09-15-federalist-platform-launch.md
+++ b/_posts/2015-09-15-federalist-platform-launch.md
@@ -19,6 +19,8 @@ hero: false
 
 ![The new White House Social and Behavioral Sciences Team homepage]({{site.baseurl}}/assets/blog/federalist/sbst-screenshot-2.jpg)
 
+**Summer 2017 Update** Federalist [left beta in June 2017](https://18f.gsa.gov/2017/06/01/federalist-is-out-of-beta-and-open-for-business/) and is currently [seeking new customers](https://docs.google.com/forms/d/e/1FAIpQLSesNI1qlov7Ec_1u2FralYWg9hV4WsB-3FyAHPXc1pRT6In7w/viewform)! Please reach out to us if interested in using Federalist for your office!
+
 Today, the White House Social and Behavioral Sciences Team (SBST)
 [launched their new website](https://sbst.gov/).
 

--- a/_posts/2015-09-15-federalist-platform-launch.md
+++ b/_posts/2015-09-15-federalist-platform-launch.md
@@ -19,7 +19,7 @@ hero: false
 
 ![The new White House Social and Behavioral Sciences Team homepage]({{site.baseurl}}/assets/blog/federalist/sbst-screenshot-2.jpg)
 
-_Summer 2017 Update: Federalist [left beta in June 2017](https://18f.gsa.gov/2017/06/01/federalist-is-out-of-beta-and-open-for-business/) and is currently seeking new customers. Email us at inquiries18f@gsa.gov or fill out this [Google form](https://docs.google.com/forms/d/e/1FAIpQLSesNI1qlov7Ec_1u2FralYWg9hV4WsB-3FyAHPXc1pRT6In7w/viewform) if you're interested in using Federalist for your office._
+_Summer 2017 Update: Federalist [left beta in June 2017](https://18f.gsa.gov/2017/06/01/federalist-is-out-of-beta-and-open-for-business/) and is currently seeking new customers. Email us at federalist-inquiries@gsa.gov or fill out this [Google form](https://docs.google.com/forms/d/e/1FAIpQLSesNI1qlov7Ec_1u2FralYWg9hV4WsB-3FyAHPXc1pRT6In7w/viewform) if you're interested in using Federalist for your office._
 
 Today, the White House Social and Behavioral Sciences Team (SBST)
 [launched their new website](https://sbst.gov/).

--- a/_posts/2015-09-15-federalist-platform-launch.md
+++ b/_posts/2015-09-15-federalist-platform-launch.md
@@ -19,7 +19,7 @@ hero: false
 
 ![The new White House Social and Behavioral Sciences Team homepage]({{site.baseurl}}/assets/blog/federalist/sbst-screenshot-2.jpg)
 
-**Summer 2017 Update** Federalist [left beta in June 2017](https://18f.gsa.gov/2017/06/01/federalist-is-out-of-beta-and-open-for-business/) and is currently [seeking new customers](https://docs.google.com/forms/d/e/1FAIpQLSesNI1qlov7Ec_1u2FralYWg9hV4WsB-3FyAHPXc1pRT6In7w/viewform)! Please reach out to us if interested in using Federalist for your office!
+_Summer 2017 Update: Federalist [left beta in June 2017](https://18f.gsa.gov/2017/06/01/federalist-is-out-of-beta-and-open-for-business/) and is currently seeking new customers. Email us at inquiries18f@gsa.gov or fill out this [Google form](https://docs.google.com/forms/d/e/1FAIpQLSesNI1qlov7Ec_1u2FralYWg9hV4WsB-3FyAHPXc1pRT6In7w/viewform) if you're interested in using Federalist for your office._
 
 Today, the White House Social and Behavioral Sciences Team (SBST)
 [launched their new website](https://sbst.gov/).


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/wslack-add-blurb.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/wslack-add-blurb)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/wslack-add-blurb/2015/09/15/federalist-platform-launch/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/wslack-add-blurb/README.md)

Changes proposed in this pull request:
- adds a blurb to an old blog post