### PR TITLE
Removes acq tech lead positions

### DIFF
--- a/_includes/open-positions.html
+++ b/_includes/open-positions.html
@@ -11,6 +11,6 @@
 <p><em>Most of our roles use the “Innovation Specialist” <a href="https://www.opm.gov/faqs/QA.aspx?fid=d2dc8952-41ec-434a-ac7e-bcb6ee8206ba&pid=c9df01f3-8580-4f87-88a4-3e26125f1205">position description</a>, regardless of what team we're hiring for. See the performance profile link above for more detail about specific skills, responsibilities, and expectations.</em></p>
 
   {% else %}
-  <h4>We don’t have any open positions right now.</h4>
+  <h4>We don’t have any open positions right now. You can sign up for the <a href="https://18f.gsa.gov/contact/#newsletter">18F Newsletter</a> to receive regular updates, including new open positions.</h4>
   {% endif %}
   {% endif %}

--- a/_join/open-positions/acquisition-technical-lead-gs14.md
+++ b/_join/open-positions/acquisition-technical-lead-gs14.md
@@ -23,8 +23,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 
 We're hiring a Technical Lead to help us build amazing products for our clients. This page includes key objectives for the role as well as the official job description. The [Duties]({{site.baseurl}}/join/acquisition-technical-lead-gs14/#duties) and [Qualifications]({{site.baseurl}}/join/acquisition-technical-lead-gs14/#qualifications) on this page are specific to the GS-14 level position. You can apply at the bottom or learn more about the application process at [Joining 18F](https://18f.gsa.gov/join/#how-to-apply).

--- a/_join/open-positions/acquisition-technical-lead-gs15.md
+++ b/_join/open-positions/acquisition-technical-lead-gs15.md
@@ -23,8 +23,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
 
 We're hiring a Technical Lead to help us build amazing products for our clients. This page includes key objectives for the role as well as the official job description. The [Duties]({{site.baseurl}}/join/acquisition-technical-lead-gs15/#duties) and [Qualifications]({{site.baseurl}}/join/acquisition-technical-lead-gs15/#qualifications) on this page are specific to the GS-15 level position. You can apply at the bottom or learn more about the application process at [Joining 18F](https://18f.gsa.gov/join/#how-to-apply).

--- a/_join/position-no-longer-available.md
+++ b/_join/position-no-longer-available.md
@@ -24,6 +24,8 @@ redirect_from:
   - /join/job-listings/acq-gs-15/
   - /join/job-listings/acq-gs-14/
   - /join/job-listings/acq-gs-13/
+  - /join/acquisition-technical-lead-gs14/
+  - /join/acquisition-technical-lead-gs15/
 ---
 
 Head over to the [Join 18F page](https://18f.gsa.gov/join/) to see current open positions or learn more about the application process. You can also [sign up for the 18F Newsletter](https://18f.gsa.gov/contact/) to receive regular updates, including new open positions. 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/acq-jobs-takedown.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/acq-jobs-takedown)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/acq-jobs-takedown/)

Changes proposed in this pull request:
- Removes Acq Tech Lead positions
- Added newsletter link when there are no open positions


/cc @awfrancisco 