### PR TITLE
Update to language around product owner

### DIFF
--- a/_principles/index.md
+++ b/_principles/index.md
@@ -87,18 +87,18 @@ Other partners might take the time to do this, too. But we carve out this initia
 
 ## <a name="partnering-with-an-empowered-product-owner"></a>Partnering with an empowered product owner
 
-Achieving success depends on building a close working relationship between 18F and your team. To make that happen, we’ll work with an empowered [product owner](https://playbook.cio.gov/#play6) from your agency. An empowered product owner is someone who understands your organization, the problem we’re solving, and can advocate for the product we ultimately build together. They’ll be responsible for carrying the long-term vision of the project and guiding its progress, as informed by user research. This person will work closely with the 18F team as a subject matter expert on your agency and help us jointly navigate the complexities of interoffice and stakeholder relationships.
+Achieving success depends on building a close working relationship between 18F and your team. To make that happen, we’ll work with an empowered [product owner](https://playbook.cio.gov/#play6) from your agency. An empowered product owner is someone who understands your organization, the problem we’re solving, and can advocate for the product we ultimately build together. They’ll be responsible for establishing and carrying the long-term vision of the project, implementing a strategy, and guiding its progress, as informed by user research. This person will work closely with the 18F team as a subject matter expert on your agency and help us jointly navigate the complexities of interoffice and stakeholder relationships.
 
 ### A successful product owner has:
 
-- **Authority to make decisions:** The product owner removes obstacles and helps the team work as quickly as they can. They make decisions independently and have sufficient authority to make changes large and small to the project without additional review from superiors. 
-- **Time to work with us:** The product owner is just as much a part of the team as designers, researchers, and developers. Most product owners need 15-20 hours of their week to work with us.
+- **Authority to make decisions:** The product owner removes obstacles and helps the team work as quickly as they can. They make decisions independently and have sufficient authority to make changes large and small to the product without additional review from superiors. 
+- **Time to work with us:** The product owner is just as much a part of the team as designers, researchers, and developers. Product owners should lead the product team: crafting a product vision and strategy, prioritizing work, evangelizing to stakeholders and users, working with developers and designers and measuring results.
 - **Subject matter expertise:** Public service work is detail-oriented. It’s often focused in the niche areas of expertise our team doesn’t have. While we bring technical expertise, your product owners provide guidance and expertise about your program and users.
 - **Advocacy inside your agency:** The product owner can identify stakeholders inside your agency and gain their support. Whether we have research results to present, a major milestone to celebrate, or questions for another office in your agency, the product owner is our connection to the relevant people.
 
 ### What does this mean for you? 
 
-The product owner will be an integral part of the project team. While they may not know agile or lean methodologies at the outset, our team will help them learn the skills necessary. In addition, while a time commitment of 15-20 hour per week is significant, we’ve found that an empowered product owner dramatically shortens the length of a project, reduces overall risk, and creates solutions that help meet project goals. 
+The product owner will lead the product team. While they may not already know best practices in product management, or agile or lean methodologies at the outset, our team will coach them to learn the necessary skills. We've found that an empowered product owner dramatically shortens the time to delivery, reduces overall risk, and creates solutions that align with the agency mission while serving user needs. 
 
 # Got questions?
 

--- a/_principles/index.md
+++ b/_principles/index.md
@@ -92,7 +92,7 @@ Achieving success depends on building a close working relationship between 18F a
 ### A successful product owner has:
 
 - **Authority to make decisions:** The product owner removes obstacles and helps the team work as quickly as they can. They make decisions independently and have sufficient authority to make changes large and small to the product without additional review from superiors. 
-- **Time to work with us:** The product owner is just as much a part of the team as designers, researchers, and developers. Product owners should lead the product team: crafting a product vision and strategy, prioritizing work, evangelizing to stakeholders and users, working with developers and designers and measuring results.
+- **Time to work with us:** The product owner is just as much a part of the team as designers, researchers, and developers. Product owners should lead the product team: crafting a product vision and strategy, prioritizing work, evangelizing to stakeholders and users, working with developers and designers, and measuring results.
 - **Subject matter expertise:** Public service work is detail-oriented. It’s often focused in the niche areas of expertise our team doesn’t have. While we bring technical expertise, your product owners provide guidance and expertise about your program and users.
 - **Advocacy inside your agency:** The product owner can identify stakeholders inside your agency and gain their support. Whether we have research results to present, a major milestone to celebrate, or questions for another office in your agency, the product owner is our connection to the relevant people.
 
@@ -103,5 +103,3 @@ The product owner will lead the product team. While they may not already know be
 # Got questions?
 
 If you already have a primary contact at 18F, they can answer any questions you may have about these principles. If you don’t yet have a primary contact, please reach out to our Agency Partnerships team at [inquiries18f@gsa.gov](mailto:inquiries18f@gsa.gov). We’ll be more than happy to discuss possibilities and concerns. 
-
-


### PR DESCRIPTION
Emphasize the important role that product owners need to play in our engagements. Remove ambiguities between product management and agile. Removed references to part time commitments.

Two specific changes that may need clarification:

1. I'm taking out the reference to time commitment from the PO and replacing it with what the PO needs to do in order to set the project up for success. 15-20 hours per week does not accurately account for the dedication to [product work that we are finding is necessary in our projects](https://breathepublication.com/product-for-president-59580e3b554c). Instead, I am recommending we talk about what we expect the product owner to be doing. If the partner cannot take on that responsibility, it will be a risk to the project, and they should be aware of this as soon as possible

2. I'm also taking out the reference to empowered product owner shortening the length of the project. Project length is fixed. What we want is an empowered product owner who can facilitate delivery of as much value as possible given the time frame.

@awfrancisco 

Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
-
-
-

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**


/cc @relevant-people
