### PR TITLE
Remove OPP engineer position

### DIFF
--- a/_join/open-positions/opp-feedback-analytics-engineer.md
+++ b/_join/open-positions/opp-feedback-analytics-engineer.md
@@ -23,8 +23,8 @@ subnav_items:
   - text: What to expect
     permalink: /#what-to-expect
 breadcrumb: true
-published: true
-listed: true
+published: false
+listed: false
 ---
  
 We're hiring a Feedback Analytics Engineer in the Office of Products and Programs at the GS-15 level to help us build amazing products for our clients. Note that the Office of Products and Programs is a separate division from 18F, but both are part of the [Technology Transformation Service](https://www.gsa.gov/tts) and work closely with one another. 

--- a/_join/position-no-longer-available.md
+++ b/_join/position-no-longer-available.md
@@ -27,6 +27,7 @@ redirect_from:
   - /join/acquisition-technical-lead-gs14/
   - /join/acquisition-technical-lead-gs15/
   - /join/acquisition-design-lead/
+  - /join/feedback-analytics-engineer-gs15/
 ---
 
 Head over to the [Join 18F page](https://18f.gsa.gov/join/) to see current open positions or learn more about the application process. You can also [sign up for the 18F Newsletter](https://18f.gsa.gov/contact/) to receive regular updates, including new open positions. 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-takedown.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/job-takedown)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/job-takedown/)

Changes proposed in this pull request:
- OPP Feedback analytics engineer position is now closed. Removing post

/cc @awfrancisco 
