### PR TITLE
Changed all references to deprecated repositories

### DIFF
--- a/_projects/fec-gov.md
+++ b/_projects/fec-gov.md
@@ -10,7 +10,7 @@ image_accessibility: Screenshot of the FEC data explorer with stylized magnifyin
 project_weight: 5
 tag: fec.gov
 expiration_date:
-github_repo: https://github.com/18F/openFEC-web-app
+github_repo: https://github.com/18F/FEC
 project_url: "[Federal Election Commission website](https://beta.fec.gov/)"
 quote:
 ---

--- a/spec/_posts/project_page.rb
+++ b/spec/_posts/project_page.rb
@@ -54,7 +54,7 @@
         "fec.gov"
       ],
       "expiration_date": nil,
-      "github_repo": "https://github.com/18F/openFEC-web-app",
+      "github_repo": "https://github.com/18F/FEC",
       "project_url": "https://beta.fec.gov/",
       "slug": "fec-gov",
       "ext": ".md",
@@ -109,7 +109,7 @@
     "fec.gov"
   ],
   "expiration_date": nil,
-  "github_repo": "https://github.com/18F/openFEC-web-app",
+  "github_repo": "https://github.com/18F/FEC",
   "project_url": "https://beta.fec.gov/",
   "slug": "fec-gov",
   "ext": ".md",


### PR DESCRIPTION
openFEC-web-app is deprecated, I updated all references to https://github.com/18F/FEC In re: #2607