### PR TITLE
Allow more than just Ruby 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '~>2.3.1'
 
 gem 'accesslint-ci', '0.2.8'
 gem 'html-proofer', '~> 3.6.0'


### PR DESCRIPTION
Using 2.3.3, I was able to successfully build and run. This allows Ruby v2.3.1 to 2.3.99 to work also.