### PR TITLE
Retire some project pages

### DIFF
--- a/_projects/dod-military-onesource.md
+++ b/_projects/dod-military-onesource.md
@@ -16,8 +16,6 @@ learn_more:
 product_clients:
 published: false
 listed: false
-redirect-to:
-- /what-we-deliver
 ---
 
 The Military Community and Family Policy group, within the Office of the

--- a/_projects/dod-military-onesource.md
+++ b/_projects/dod-military-onesource.md
@@ -14,6 +14,10 @@ github_repo:
 project_url: "[Beta Military OneSource website](http://beta.militaryonesource.mil)"
 learn_more:
 product_clients:
+published: false
+listed: false
+redirect-to:
+- /what-we-deliver
 ---
 
 The Military Community and Family Policy group, within the Office of the

--- a/_projects/doi-every-kid-in-a-park.md
+++ b/_projects/doi-every-kid-in-a-park.md
@@ -14,8 +14,6 @@ github_repo: https://github.com/18F/ekip-api
 project_url: "[Every Kid in a Park website](https://www.everykidinapark.gov)"
 published: false
 listed: false
-redirect-to:
-- /what-we-deliver
 ---
 
 Today, more than 80 percent of American families live in urban areas, and many lack easy access to outdoor spaces. The Department of the Interior created the Every Kid in a Park program to make it easier for fourth graders to discover public lands — but they needed a way for the program to reach fourth graders.

--- a/_projects/doi-every-kid-in-a-park.md
+++ b/_projects/doi-every-kid-in-a-park.md
@@ -12,6 +12,10 @@ tag: every kid in a park
 expiration_date:
 github_repo: https://github.com/18F/ekip-api
 project_url: "[Every Kid in a Park website](https://www.everykidinapark.gov)"
+published: false
+listed: false
+redirect-to:
+- /what-we-deliver
 ---
 
 Today, more than 80 percent of American families live in urban areas, and many lack easy access to outdoor spaces. The Department of the Interior created the Every Kid in a Park program to make it easier for fourth graders to discover public lands — but they needed a way for the program to reach fourth graders.

--- a/_projects/micro-purchase-marketplace.md
+++ b/_projects/micro-purchase-marketplace.md
@@ -18,8 +18,6 @@ product_clients:
 - Federal Election Commission
 published: false
 listed: false
-redirect-to:
-- /what-we-deliver
 ---
 
 Often, government technology projects are built by large companies using

--- a/_projects/micro-purchase-marketplace.md
+++ b/_projects/micro-purchase-marketplace.md
@@ -4,8 +4,8 @@ title: Micro-purchase Marketplace
 subtitle: An marketplace for open source tasks
 permalink: /what-we-deliver/micro-purchase-marketplace/
 excerpt: A reverse auction house where agencies can work with 18F to post coding tasks and vendors can bid on how much they would be willing to be paid to complete the task.
-image: 
-image_accessibility: 
+image:
+image_accessibility:
 image_icon: folderwithclock.svg
 project_weight: 2
 tag: micro-purchase platforms
@@ -16,6 +16,10 @@ learn_more:
 product_clients:
 - General Services Administration
 - Federal Election Commission
+published: false
+listed: false
+redirect-to:
+- /what-we-deliver
 ---
 
 Often, government technology projects are built by large companies using

--- a/_projects/navy-reserve.md
+++ b/_projects/navy-reserve.md
@@ -13,6 +13,10 @@ project_url:
 product_clients:
 quote: A sailor’s time, and more importantly our nation’s use of it, must be focused to the greatest possible extent on the mission and not on administrative overhead.
 quote_source: "[Navy Reserve Vision 2015-2025 (PDF)](https://www.navyreserve.navy.mil/documents/NR_vision_2015.pdf)"
+published: false
+listed: false
+redirect-to:
+- /what-we-deliver
 ---
 
 There are more than 50,000 people who serve part-time in the U.S. Navy Reserve, accounting for one out of every five people in the naval force.

--- a/_projects/navy-reserve.md
+++ b/_projects/navy-reserve.md
@@ -15,8 +15,6 @@ quote: A sailor’s time, and more importantly our nation’s use of it, must be
 quote_source: "[Navy Reserve Vision 2015-2025 (PDF)](https://www.navyreserve.navy.mil/documents/NR_vision_2015.pdf)"
 published: false
 listed: false
-redirect-to:
-- /what-we-deliver
 ---
 
 There are more than 50,000 people who serve part-time in the U.S. Navy Reserve, accounting for one out of every five people in the naval force.

--- a/_projects/treasury-new-ten.md
+++ b/_projects/treasury-new-ten.md
@@ -16,8 +16,6 @@ learn_more:
 product_clients:
 published: false
 listed: false
-redirect-to:
-- /what-we-deliver
 ---
 
 Occasionally, our country’s currency needs technical and aesthetic

--- a/_projects/treasury-new-ten.md
+++ b/_projects/treasury-new-ten.md
@@ -14,6 +14,10 @@ github_repo:
 project_url: "[The New Ten website](https://thenew10.treasury.gov/)"
 learn_more:
 product_clients:
+published: false
+listed: false
+redirect-to:
+- /what-we-deliver
 ---
 
 Occasionally, our country’s currency needs technical and aesthetic

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -7,6 +7,11 @@ content_wide: true
 content_focus: false
 redirect_from:
   - /consulting/
+  - /what-we-deliver/military-onesource/
+  - /what-we-deliver/every-kid-in-a-park/
+  - /what-we-deliver/micro-purchase-marketplace/
+  - /what-we-deliver/ready-2-serve/
+  - /what-we-deliver/new-ten/
 banner_cta: true
 gridless: true
 ---


### PR DESCRIPTION
Fixes issue #2620.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/retire-project-pages.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/retire-project-pages)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/retire-project-pages/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/retire-project-pages/README.md)

**Changes proposed in this pull request:**
Retires project pages for:
- Military One Source
- Every Kid in a Park
- Micro-purchase marketplace
- Ready-2-Serve
- The New Ten

Adds redirects for those pages to /what-we-deliver/

/cc @elainekamlley 
