### PR TITLE
Removed oembed videos and instructions on style guide

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -70,8 +70,6 @@ nav_items:
         permalink: /styleguide/blog-components/#blog-tags
       - text: Blockquotes
         permalink: /styleguide/blog-components/#blockquotes
-      - text: Embeds
-        permalink: /styleguide/blog-components/#embeds
       - text: Images
         permalink: /styleguide/blog-components/#images
   - text: For developers

--- a/_posts/2015-04-28-intersection-of-art-and-technology.md
+++ b/_posts/2015-04-28-intersection-of-art-and-technology.md
@@ -15,8 +15,6 @@ description: "Earlier this month, I went to the Museum of Modern Art in New York
 image: /assets/blog/art-tech/dap-dashboard.png
 ---
 
-{% oembed https://twitter.com/PLAndrese/status/587720655652651009 %}
-
 Last month, I went to the [Museum of Modern Art in New York City](https://www.moma.org/) for the first time. I was there to see [a special exhibit featuring the pop singer Bjӧrk](https://www.moma.org/visit/calendar/exhibitions/1501), who is currently presenting a retrospective of her life’s work as a musician, artist and technologist. The retrospective spans back from her early beginnings as a childhood folk singer in Iceland all the way through to her most current album release.
 
 Being a huge fan of Bjӧrk’s work, and having a fine art background myself, I equate this experience to visiting an ancient historical site, relic or monument.

--- a/_posts/2015-05-27-dan-brown-conflict-in-design.md
+++ b/_posts/2015-05-27-dan-brown-conflict-in-design.md
@@ -27,7 +27,7 @@ Brown, an information architect, has worked in the district for large swaths of 
 
 He opened his lecture by listing common issues and stakeholder quotes. For example, “Things have changed since we last spoke.”
 
-{% oembed https://www.youtube.com/watch?time_continue=159&v=mO8PiHST5CI %}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/mO8PiHST5CI?start=159" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 Brown asked who in the audience had been told that before. After a moment, a majority raised their hands. Conflict is a mechanism for positive change, Brown explained. It’s a process, even though it feels negative at times.
 

--- a/_posts/2016-09-19-vendors-government-strengthen-partnership-technology-industry-day.md
+++ b/_posts/2016-09-19-vendors-government-strengthen-partnership-technology-industry-day.md
@@ -33,7 +33,7 @@ Aaron Snow, Deputy Director of TTS.
 If you weren’t able to attend, you can watch the first two hours of the
 event below and [download the slidedeck from the morning presentation]({{site.baseurl}}/assets/blog/industry-day/deck-2016.pdf).
 
-{% oembed https://www.youtube.com/watch?v=NRAlPdiWXN8 %}
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NRAlPdiWXN8" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 Find out more about the projects and platforms we talked about during
 the Technology Industry Day.
@@ -108,11 +108,8 @@ of HHS with California’s Department of Social Services and Office of
 Systems Integration and Code for America to [simplify the contracting
 documents](https://18f.gsa.gov/2016/03/22/helping-california-buy-a-new-child-welfare-system/)
 and to incorporate modular contracting, agile development, user-centered
-design, and open source practices into their project. Hear more from
-Stuart Drown, the California Deputy Secretary for Innovation and
-Accountability, about the project.
+design, and open source practices into their project. 
 
-{% oembed https://www.youtube.com/watch?v=JM4VLjRgqWo %}
 
 ## login.gov
 

--- a/_styleguide/subpages/blog-components.md
+++ b/_styleguide/subpages/blog-components.md
@@ -121,23 +121,6 @@ Post previews are generated dynamically throughout the site. Each preview requir
 
 ---
 
-### Embeds
-
-There are plenty of instances where we want to be able to embed content from other web pages. Where there are several ways to do this successfully, we recommend using a Jekyll filter, `oembed`, to handle embeddable content in a consistent way.
-
-{% capture embed_codeblock %}{% raw %}{% oembed https://www.youtube.com/watch?v=8wcFK2jYlWw %}{% endraw %}{% endcapture %}
-
-
-{% include details-code.html
-   title='embeds'
-   content=embed_codeblock
-   lang="html"
-   description='We are using a Jekyll plugin called `jekyll_oembed`. The URL string should be address of the content, not a URL provided to embed content. If content is private, it might be necessary to directly add HTML in this way as the service will reject any requests by`jekyll_oembed`.'
-   other_ref='https://github.com/18F/jekyll-oembed#usage'
-%}
-
----
-
 ### Images
 
 There are a few ways we render images on the blog: Hero images that span the entire page, within blog post, and team photos. For information on adding images to the site see: 


### PR DESCRIPTION
Fixes issue(s) #2629 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/ombed-fx.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/ombed-fx)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/ombed-fx/)

Changes proposed in this pull request:
- oembed is a unpredictable. Removing the instructions from style guide. Will use `<iframe>` for any videos or tweet moving forward
- removed oembed and replaced it with iframe
- removed unavailable videos
