### PR TITLE
Remove storify links

### DIFF
--- a/_posts/2015-02-26-Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One.md
+++ b/_posts/2015-02-26-Five-Ways-To-Turn-A-Bad-Idea-Into-A-Great-One.md
@@ -21,9 +21,9 @@ Last Friday, consultant and author [Steve Portigal](http://www.portigal.com/) le
 
 We encourage you to watch the [entirety of Steve’s presentation](https://www.youtube.com/watch?v=B0qK94cCnQs#t=430) (including the Q&A), and you can [view his Slideshare here](http://www.slideshare.net/steveportigal/the-power-of-bad-ideas). Of course, we also encourage you to read his book [*Interviewing Users: How To Uncover Compelling Insights*](http://rosenfeldmedia.com/books/interviewing-users/), and check out his podcast ([Dollars to Donuts podcast](https://itunes.apple.com/us/podcast/dollars-to-donuts/id956673263)), too. For a quick recap of Friday’s event, read on.
 
-Steve began by defining the bad idea as one that causes a visceral reaction: the gut-punch, stomach-drop feeling you get when you hear something so ridiculous you feel you must have heard wrong. 
+Steve began by defining the bad idea as one that causes a visceral reaction: the gut-punch, stomach-drop feeling you get when you hear something so ridiculous you feel you must have heard wrong.
 
-Definition established, Steve got right to the crux of his argument: The generation of bad ideas is necessary for the discovery of good ones. How can you harness the power of bad ideas to increase your team’s creative output? By keeping the following in mind: 
+Definition established, Steve got right to the crux of his argument: The generation of bad ideas is necessary for the discovery of good ones. How can you harness the power of bad ideas to increase your team’s creative output? By keeping the following in mind:
 
 ## Bad ideas pave the way for good ones
 
@@ -46,12 +46,12 @@ In fact, lots of famous creatives rely on bad ideas to get them to their great o
 
 ## Bad is judged by the marketplace
 
-Bad ideas are great during the ideation process, but can be harmful if they make their way into the world. One powerful example: The [Homeless Hotspots](http://www.wired.com/2012/03/the-damning-backstory-behind-homeless-hotspots-at-sxswi/) created for SxSW in 2012. What was conceived as a charitable experiment drew flak for its creators’ apparent lack of cultural awareness. A similar idea for mobile battery-charging stations, which were [staffed by Craigslist-sourced contractors](https://storify.com/vdlr/fedex-homeless-hotspot-charged-with-exploiting-peo), drew far less criticism. Though both promotions offered similar services and both came from a place of good intent, one hit on complex convictions about the employment and marginalization of different populations. Before implementing an idea, always consider the context into which you’re introducing it and the cultural implications your idea may carry.
+Bad ideas are great during the ideation process, but can be harmful if they make their way into the world. One powerful example: The [Homeless Hotspots](http://www.wired.com/2012/03/the-damning-backstory-behind-homeless-hotspots-at-sxswi/) created for SxSW in 2012. What was conceived as a charitable experiment drew flak for its creators’ apparent lack of cultural awareness. A similar idea for mobile battery-charging stations, which were staffed by Craigslist-sourced contractors, drew far less criticism. Though both promotions offered similar services and both came from a place of good intent, one hit on complex convictions about the employment and marginalization of different populations. Before implementing an idea, always consider the context into which you’re introducing it and the cultural implications your idea may carry.
 
 ## *Bad* helps us define the criteria for *good*
 
-Being confronted by shockingly bad ideas — those that stand in decided opposition to established social norms — can actually help us refine and concretize our definition of bad. Encountering a truly terrible idea gives us the chance to discuss why that idea is terrible and develop shared evaluative principles — a common vocabulary for what’s good. 
+Being confronted by shockingly bad ideas — those that stand in decided opposition to established social norms — can actually help us refine and concretize our definition of bad. Encountering a truly terrible idea gives us the chance to discuss why that idea is terrible and develop shared evaluative principles — a common vocabulary for what’s good.
 
 Many thanks to Steve for coming to talk to us, and thanks to all who attended and participated in the Q&A.
 
-Our next speaker, Knight-Mozilla Fellow Livia Labate, will be presenting in March — stay tuned for more details! 
+Our next speaker, Knight-Mozilla Fellow Livia Labate, will be presenting in March — stay tuned for more details!

--- a/_posts/2015-04-03-how-to-welcome-new-coders-to-a-civic-hackathon.md
+++ b/_posts/2015-04-03-how-to-welcome-new-coders-to-a-civic-hackathon.md
@@ -132,7 +132,7 @@ for new projects.)
 Not everyone can get to a nearby city to hack on the National Civic Day
 of Hacking, but this doesn’t mean they should be excluded from
 participating. During our
-[GovTechHack](https://storify.com/ultrasaurus/govtechhack-sf-march-27-28),
+GovTechHack,
 members of the 18F team – maintainers of the projects, especially – were
 available for questions and consultations, even if participants weren’t
 physically in San Francisco. You can connect with people in many ways,

--- a/_posts/2015-07-15-openfec-api-update.md
+++ b/_posts/2015-07-15-openfec-api-update.md
@@ -18,7 +18,7 @@ image: /assets/blog/openfec-api/openfec-banner.jpg
 image_accessibility: "OpenFEC: Explore campaign finance data"
 ---
 
-We’re so glad that people have been [so excited](https://storify.com/18F/18f) about the [Federal Election Commission’s (FEC) first API](https://18f.gsa.gov/2015/07/08/openfec-api/). Now, there are millions of more records for you to explore! We’re looking forward to seeing what the public will build with its data.
+We’re so glad that people have been so excited about the [Federal Election Commission’s (FEC) first API](https://18f.gsa.gov/2015/07/08/openfec-api/). Now, there are millions of more records for you to explore! We’re looking forward to seeing what the public will build with its data.
 
 The [OpenFEC API](https://api.open.fec.gov/developers) added a filings endpoint as well as itemized receipt and disbursement data. This is the first major update to the API, but the OpenFEC API is part of a larger project that will have continual improvements and additions. **The records we’re adding today are the meat and potatoes of campaign finance. You can see in detail where a campaign’s money comes from and where they spend their money.**
 


### PR DESCRIPTION
Fixes issue(s) #2640.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/storify.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/storify)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/storify/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/storify/README.md)

Changes proposed in this pull request:
- Remove links to Storify from 3 blog posts

cc @elainekamlley 