### PR TITLE
Removing '18F' from 'About 18F'

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -1,5 +1,5 @@
 ---
-title: About 18F
+title: About
 permalink: /about/
 layout: primary
 lead: We help other government agencies build, buy, and share technology products.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,7 +5,7 @@ navbar:
     - /what-we-deliver/:path/
 - text: How we work
   permalink: /how-we-work/
-- text: About 18F
+- text: About
   permalink: /about/
 - text: Blog
   permalink: /blog/
@@ -23,7 +23,7 @@ drawer:
     - /what-we-deliver/:path/
   - text: How we work
     permalink: /how-we-work/
-  - text: About 18F
+  - text: About
     permalink: /about/
   - text: Blog
     permalink: /blog/
@@ -39,7 +39,7 @@ footer:
     permalink: /what-we-deliver/
     multiple_permalinks:
     - /what-we-deliver/:path/
-  - text: About 18F
+  - text: About
     permalink: /about/
   - text: Partnership Principles
     permalink: /partnership-principles/


### PR DESCRIPTION
Fixes issue(s) #2646 .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/about.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/about)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/about/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/about/README.md)

Changes proposed in this pull request:
- removed `18F` in the `nav` and `/about` page

/cc @awfrancisco 
