### PR TITLE
Changed banner call to action to say Contact us

### DIFF
--- a/_includes/banner-cta.html
+++ b/_includes/banner-cta.html
@@ -5,7 +5,7 @@
         <p>
            Want to see if 18F can help your agency? We’d love to talk more, answer your questions, or learn more about what you’re working on.
         </p>
-        <a href="{{ site.baseurl }}/contact/"><button class="usa-button usa-button-secondary marginless">Get in touch</button></a>
+        <a href="{{ site.baseurl }}/contact/"><button class="usa-button usa-button-secondary marginless">Contact us</button></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/contact-b.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/contact-b)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/contact-b/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Makes all call to action consistent to say `Contact us`

/cc @awfrancisco 
