### PR TITLE
Add redirect for previous blog post URL

### DIFF
--- a/_posts/2018-02-22-new-home-for-the-federal-plain-language-community.md
+++ b/_posts/2018-02-22-new-home-for-the-federal-plain-language-community.md
@@ -10,6 +10,8 @@ tags:
 - federalist
 - interview
 excerpt: "The Plain Language Action and Information Network (PLAIN) is one of the longest-standing champions for great content and user experience in government. A small team from 18F worked closely with DigitalGov and PLAIN to redesign plainlanguage.gov, making it more modern and usable."
+redirect_from: 
+  - /2018/02/20/new-home-for-the-federal-plain-language-community/
 ---
 
 The Plain Language Action and Information Network (PLAIN) is one of the longest-standing champions for great content and user experience in government. Since the 90s, this incredible community has shepherded the adoption of plain language in federal regulations and communications with the public. Last year, we were honored to partner with them to update and redesign [plainlanguage.gov](https://www.plainlanguage.gov/).


### PR DESCRIPTION
To help out @nicoleslaw - she tweeted out the link to the blog post's original URL and it's currently a 404. This redirects the outdated URL to the correct one.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hursey013-patch-1.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hursey013-patch-1)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/hursey013-patch-1/)