### PR TITLE
Reconfigured side bar in project pages to include multiple GitHub repos

### DIFF
--- a/_includes/side-cta.html
+++ b/_includes/side-cta.html
@@ -1,4 +1,4 @@
-<div class="pad-top-bottom background-medium">
+<div class="margin-spacing pad-top-bottom background-medium">
     <div class="usa-grid usa-flex-baseline">
       <div class="h3">Want to see if 18F can help your agency?</div>
       <div>

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -76,7 +76,7 @@ header_border: true
 
         {% if page.github_repo %}
         <li class="section-info-list-item">
-          <div class="section-info-header">GitHub</div>
+          <div class="section-info-header">See the code on GitHub</div>
             <ul class="{% unless page.github_repo.size > 1 %}usa-unstyled-list{% endunless %}">
             {% for repo in page.github_repo %}
               <li>{{ repo | markdownify }}</a></li>

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -76,8 +76,12 @@ header_border: true
 
         {% if page.github_repo %}
         <li class="section-info-list-item">
-          <div class="section-info-header">GitHub repo</div>
-          <div><a href="{{ page.github_repo }}">{{ page.github_repo | replace: "https://github.com/", "" }}</a></div>
+          <div class="section-info-header">GitHub</div>
+            <ul class="{% unless page.github_repo.size > 1 %}usa-unstyled-list{% endunless %}">
+            {% for repo in page.github_repo %}
+              <li>{{ repo | markdownify }}</a></li>
+            {% endfor %}
+            </ul>
         </li>
         {% endif %}
 
@@ -122,8 +126,8 @@ header_border: true
             <a class="usa-button" href="{{ page.learn_more }}">Learn more</a>
           </li>
         {% endif %}
-          <li>{% include side-cta.html %}</li>
       </ul>
+      <div>{% include side-cta.html %}</div>
     </aside>
     {% endif %}
 

--- a/_products_projects/cloud-gov.md
+++ b/_products_projects/cloud-gov.md
@@ -10,7 +10,7 @@ image_icon: folderwithclock.svg
 project_weight: 3
 tag: cloud.gov
 expiration_date:
-github_repo: https://cloud.gov/docs/ops/repos/
+github_repo: "[https://cloud.gov/docs/ops/repos/](https://cloud.gov/docs/ops/repos/)"
 project_url: "[cloud.gov](https://cloud.gov/)"
 learn_more:
 product_clients:

--- a/_products_projects/federalist.md
+++ b/_products_projects/federalist.md
@@ -9,7 +9,7 @@ image_accessibility: "Abstract image of the Federalist Papers in bluescale"
 project_weight: 3
 tag: federalist
 expiration_date:
-github_repo: https://github.com/18F/federalist
+github_repo: "[https://github.com/18F/federalist](https://cloud.gov/docs/ops/repos/)"
 project_url: "[federalist.18f.gov](https://federalist.18f.gov/)"
 learn_more:
 product_clients:

--- a/_products_projects/micro-purchase-marketplace.md
+++ b/_products_projects/micro-purchase-marketplace.md
@@ -10,7 +10,7 @@ image_icon: folderwithclock.svg
 project_weight: 2
 tag: micro-purchase platforms
 expiration_date:
-github_repo: https://github.com/18F/micropurchase
+github_repo: "[https://github.com/18F/micropurchase](https://github.com/18F/micropurchase)"
 project_url: "[Micro-purchase Marketplace website](https://micropurchase.18f.gov/)"
 learn_more:
 product_clients:

--- a/_sass/_core/utility.scss
+++ b/_sass/_core/utility.scss
@@ -24,6 +24,11 @@ svg {
   margin: 0;
 }
 
+.margin-spacing {
+  margin-top: $section-margins;
+  margin-bottom: $section-margins;
+}
+
 .pad-top-bottom {
   padding-top: $paragraph-margins-thick;
   padding-bottom: $paragraph-margins-thick;

--- a/_services_projects/c2.md
+++ b/_services_projects/c2.md
@@ -9,7 +9,7 @@ image_accessibility:
 image_icon: folderwithclock.svg
 tag: c2
 expiration_date:
-github_repo: https://github.com/18F/C2
+github_repo: "[https://github.com/18F/C2](https://github.com/18F/C2)"
 project_url: "[cap.18f.gov](https://cap.18f.gov/)"
 learn_more:
 product_clients:

--- a/_services_projects/calc.md
+++ b/_services_projects/calc.md
@@ -9,7 +9,7 @@ image_accessibility:
 image_icon:
 tag: calc
 expiration_date:
-github_repo: https://github.com/18F/calc
+github_repo: "[https://github.com/18F/calc](https://github.com/18F/calc)"
 project_url: "[calc.gsa.gov](https://calc.gsa.gov/)"
 quote: CALC was built to save hours spent on market research and price analysis for federal government contracts, and has the potential to save millions of taxpayer dollars on services contracts.
 quote_source: "Kelly Bailey, Product Owner of CALC, Federal Acquisition Service"

--- a/_services_projects/dol-wage-and-hour.md
+++ b/_services_projects/dol-wage-and-hour.md
@@ -10,7 +10,7 @@ image_icon: folderwithclock.svg
 project_weight: 3
 tag: department of labor
 expiration_date:
-github_repo: https://github.com/18F/dol-whd-14c
+github_repo: "[https://github.com/18F/dol-whd-14c](https://github.com/18F/dol-whd-14c)"
 project_url:
 learn_more:
 product_clients:

--- a/_services_projects/ed-college-scorecard.md
+++ b/_services_projects/ed-college-scorecard.md
@@ -7,7 +7,7 @@ image: /assets/blog/college-scorecard/college-scorecard-3.jpg
 image_accessibility: "Grayscale photograph of eleven people meeting in small groups during a workshop"
 tag: college scorecard
 expiration_date:
-github_repo: https://github.com/RTICWDT/college-scorecard
+github_repo: "[https://github.com/RTICWDT/college-scorecard](https://github.com/RTICWDT/college-scorecard)"
 project_url: "[collegescorecard.ed.gov](https://collegescorecard.ed.gov/)"
 permalink: /what-we-deliver/college-scorecard/
 redirect_from: /project/ed-college-scorecard/

--- a/_services_projects/fbi-crime-data-explorer.md
+++ b/_services_projects/fbi-crime-data-explorer.md
@@ -10,7 +10,7 @@ image_icon:
 project_weight: 2
 tag: fbi
 expiration_date:
-github_repo: https://github.com/18F/crime-data-explorer
+github_repo: "[https://github.com/18F/crime-data-explorer](https://github.com/18F/crime-data-explorer)"
 project_url: "[Crime Data Explorer website](https://crime-data-explorer.fr.cloud.gov/)"
 learn_more:
 product_clients:

--- a/_services_projects/fec-gov.md
+++ b/_services_projects/fec-gov.md
@@ -10,7 +10,7 @@ image_accessibility: Screenshot of the FEC data explorer with stylized magnifyin
 project_weight: 5
 tag: fec.gov
 expiration_date:
-github_repo: https://github.com/18F/fec-cms
+github_repo: "[https://github.com/18F/FEC](https://github.com/18F/FEC)"
 project_url: "[Federal Election Commission website](https://www.fec.gov/)"
 quote:
 ---

--- a/_services_projects/forest-service.md
+++ b/_services_projects/forest-service.md
@@ -11,13 +11,13 @@ project_weight: 2
 tag: forest service
 expiration_date:
 github_repo:
+  - "[https://github.com/18F/bpa-fs-epermit-api](https://github.com/18F/bpa-fs-epermit-api)"
+  - "[https://github.com/18F/bpa-fs-epermit-intake](https://github.com/18F/bpa-fs-epermit-intake)"
+  - "[https://github.com/18F/bpa-fs-xmas-trees](https://github.com/18F/bpa-fs-xmas-trees)"
 project_url:
 learn_more:
 product_clients:
 resources:
-  - "[GitHub repository for API module](https://github.com/18F/bpa-fs-epermit-api)"
-  - "[GitHub repository for intake module](https://github.com/18F/bpa-fs-epermit-intake)"
-  - "[GitHub repository for Christmas tree module](https://github.com/18F/bpa-fs-xmas-trees)"
 ---
 
 The U.S. Department of Agriculture’s Forest Service issues permits to

--- a/_services_projects/nsf-seedfund.md
+++ b/_services_projects/nsf-seedfund.md
@@ -10,7 +10,7 @@ image_icon:
 project_weight: 2
 tag: national science foundation
 expiration_date:
-github_repo: https://github.com/18F/nsf-sbir
+github_repo: "[https://github.com/18F/nsf-sbir](https://github.com/18F/nsf-sbir)"
 project_url: "[America's Seed Fund powered by NSF website](https://seedfund.nsf.gov/)"
 learn_more:
 product_clients:

--- a/_services_projects/us-web-design-standards.md
+++ b/_services_projects/us-web-design-standards.md
@@ -10,7 +10,7 @@ image_icon: monitor.svg
 project_weight: 2
 tag: web design system
 expiration_date:
-github_repo: https://github.com/uswds/uswds
+github_repo: "[https://github.com/uswds/uswds](https://github.com/uswds/uswds)"
 project_url: "[U.S. Web Design System website](https://designsystem.digital.gov/)"
 learn_more:
 product_clients:

--- a/tests/schema/products_projects.yml
+++ b/tests/schema/products_projects.yml
@@ -5,7 +5,7 @@ excerpt: String
 tag: String
 permalink: String
 config:
-  path: _projects
+  path: _products_projects
   ignore:
   - README.md
   - ..

--- a/tests/schema/services_projects.yml
+++ b/tests/schema/services_projects.yml
@@ -5,7 +5,7 @@ excerpt: String
 tag: String
 permalink: String
 config:
-  path: _projects
+  path: _services_projects
   ignore:
   - README.md
   - ..


### PR DESCRIPTION
Fixes issue(s) #2645  .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/moar-repos.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/moar-repos)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/moar-repos/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/moar-repos/README.md)

Changes proposed in this pull request:
- Now able to add multiple repost
- Github repos links now have to be in markdown
- Added additional margins to call to action 

/cc @awfrancisco 
