### PR TITLE
Makes all project cards consistent to use agency name and title as headers

### DIFF
--- a/_includes/card-project.html
+++ b/_includes/card-project.html
@@ -6,7 +6,7 @@
    image_alt=project.image_accessibility
    image_icon=project.image_icon
    agency=project.agency
-   tagline=project.subtitle
+   tagline=project.title
    description=project.excerpt
    link=project.permalink
    columns=3

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -28,6 +28,7 @@ gridless: true
            image_src=project.image
            image_alt=project.image_accessibility
            image_icon=project.image_icon
+           agency=project.agency
            tagline=project.title
            description=project.excerpt
            link=project.permalink

--- a/pages/what-we-deliver.md
+++ b/pages/what-we-deliver.md
@@ -46,6 +46,7 @@ gridless: true
          image_src=project.image
          image_alt=project.image_accessibility
          image_icon=project.image_icon
+         agency=project.agency
          tagline=project.title
          description=project.excerpt
          link=project.permalink


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/p-cards.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/p-cards)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/p-cards/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/p-cards/README.md)

Changes proposed in this pull request:
- Updated the project card includes to use title and agency as headers


/cc @awfrancisco 
