### PR TITLE
Sync with up current vuln disclosure policy

### DIFF
--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -29,7 +29,7 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `community.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `metrics.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `admin.fr.cloud.gov`, `alertmanager.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `diagrams.fr.cloud.gov`, `grafana.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `logs-platform.fr.cloud.gov`, `nessus.fr.cloud.gov`, `opslogin.fr.cloud.gov`, `prometheus.fr.cloud.gov`, `ssh.fr.cloud.gov`, `uaa.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)
@@ -38,7 +38,6 @@ This policy applies to the following systems:
 * [`vote.gov`](https://vote.gov)
 * [`analytics.usa.gov`](https://analytics.usa.gov)
 * [`calc.gsa.gov`](https://calc.gsa.gov)
-* [`micropurchase.18f.gov`](https://micropurchase.18f.gov)
 * [`18f.gsa.gov`](https://18f.gsa.gov)
 
 **Any services not expressly listed above, such as any connected services, are excluded from scope** and are not authorized for testing. Additionally, vulnerabilities found in non-federal systems from our vendors fall outside of this policy's scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren't sure whether a system or endpoint is in scope or not, contact us at [`tts-vulnerability-reports@gsa.gov`](mailto:tts-vulnerability-reports@gsa.gov) before starting your research.


### PR DESCRIPTION
This syncs the VDP with the latest from its source GitHub repository.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/sync-vdp.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/sync-vdp)

[:sunglasses: PREVIEW](https://federalist.fr.cloud.gov/preview/18f/18f.gsa.gov/sync-vdp/)


/cc @jacobian 
