### PR TITLE
Revised project page documentation on style guide

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -50,6 +50,8 @@ nav_items:
         permalink: /styleguide/images/#adding-images
       - text: Image lists
         permalink: /styleguide/images/#image-lists
+      - text: Project page images
+        permalink: /styleguide/images/#project-page-images
   - text: Components
     permalink: /styleguide/components/
     children:

--- a/_styleguide/subpages/images.md
+++ b/_styleguide/subpages/images.md
@@ -200,28 +200,27 @@ It really helps to have good pictures to help us highlight project work — but 
 
 **If possible:**
 
-1. Image should relate to the project title, the department, the process (in order of preference)
+1. Image should relate to the project title, the department, or the process (in order of preference)
 1. Show real users that benefit from this project
 1. Show a screenshot from the project
-1. Mix it up! look at the current project list do you see too many of the same type of image (e.g. mostly screenshots, mostly brainstorming sessions)
+1. Mix it up! Look at the current project list. Do you see too many of the same type of image (for example, mostly screenshots, mostly brainstorming sessions)
 
 **Consider accessibility and try to avoid images that:**
 
 * Are low-contrast
 * Have wording on them
 
-
 **Consider the audience (government employees and potential partners!) and try to avoid images with the following:**
 
-* Sensitive subject material (e.g. children when writing about Child Protective Services)
+* Sensitive subject material (for example, children when writing about Child Protective Services)
 * Uninteresting subjects
 * Super meta imagery (too much of a cognitive leap when relating to subject matter)
 
 **Size:**
 
-* Banner: size 1300x 866
+* Banner: Size 1300x866
 
 **Additional guidance:**
 
 * Look at images on site for ideas
-* Ask on #18f-branding, #visual-design, or #beta-18f-site
+* Ask in #18f-branding, #visual-design, or #18f-site

--- a/_styleguide/subpages/images.md
+++ b/_styleguide/subpages/images.md
@@ -191,3 +191,37 @@ This pattern associates text with an icon to break up text blocks improve user u
    description='This component is not available as a Jekyll include. To use it, copy the code snippet above and update the icon, title, and body text accordingly.'
    scss_ref="https://github.com/18F/18f.gsa.gov/blob/master/_sass/_components/icon-list.scss"
 %}
+
+---
+
+### Project page images
+
+It really helps to have good pictures to help us highlight project work — but you might need a little more guidance about how to get pictures that will tell a story best. Here are some helpful tips:
+
+**If possible:**
+
+1. Image should relate to the project title, the department, the process (in order of preference)
+1. Show real users that benefit from this project
+1. Show a screenshot from the project
+1. Mix it up! look at the current project list do you see too many of the same type of image (e.g. mostly screenshots, mostly brainstorming sessions)
+
+**Consider accessibility and try to avoid images that:**
+
+* Are low-contrast
+* Have wording on them
+
+
+**Consider the audience (government employees and potential partners!) and try to avoid images with the following:**
+
+* Sensitive subject material (e.g. children when writing about Child Protective Services)
+* Uninteresting subjects
+* Super meta imagery (too much of a cognitive leap when relating to subject matter)
+
+**Size:**
+
+* Banner: size 1300x 866
+
+**Additional guidance:**
+
+* Look at images on site for ideas
+* Ask on #18f-branding, #visual-design, or #beta-18f-site

--- a/_styleguide/subpages/layout.md
+++ b/_styleguide/subpages/layout.md
@@ -62,13 +62,13 @@ Located at [`_layouts/project-page.html`](https://github.com/18F/18f.gsa.gov/tre
 
 #### Add a project page
 1. Determine if the project is a service or a product and find the corresponding directory
-2. Create a new file within either `_products_projects` or `_servicess_projects` directory, named with the following format: `[agency acronym]-[project-name].md`.
+2. Create a new file within either the `_products_projects` or `_servicess_projects` directory and name it with the following format: `[agency acronym]-[project-name].md`.
 2. Copy the [project page template](https://raw.githubusercontent.com/18F/18f.gsa.gov/master/examples/project-template.md) to that file. Here you can build out the page to include:
-  - main content on the project's background and 18F's approach
-  - the sidebar for at a glance information like the project's website or github repos. To do this, update the front matter related to the sidebar. If you don't want something to show up in the sidebar, remove it from the front matter
-  - testimonials or fun facts styling within the body of the page  
+  - Main content on the project's background and 18F's approach
+  - The sidebar for at-a-glance information like the project's website or GitHub repos. To do this, update the front matter related to the sidebar. If you don't want something to show up in the sidebar, remove it from the front matter
+  - Testimonials or fun facts styling within the body of the page  
 3. Replace all relavent front matter fields. To see if a field is required, see the [project page schema](https://github.com/18F/18f.gsa.gov/blob/master/tests/schema/_services_projects.yml).
-4. If you are adding an image, make sure to [check out tips on picking a project page image]({{ site.baseurl }}/styleguide/images/#project-page-images ). If you are not adding an image, make sure to specify an `image_icon` property in the front matter, and reference an SVG available in the [SVG catalog]({{ site.basurl }}/images/svg-include-catalog) like so:
+4. If you're adding an image, make sure to [check out tips on picking a project page image]({{ site.baseurl }}/styleguide/images/#project-page-images ). If you're not adding an image, make sure to specify an `image_icon` property in the front matter, and reference an SVG available in the [SVG catalog]({{ site.basurl }}/images/svg-include-catalog) like so:
   ```yml
   image_icon: gavel.svg
   ```

--- a/_styleguide/subpages/layout.md
+++ b/_styleguide/subpages/layout.md
@@ -61,14 +61,17 @@ Located at [`_layouts/project-page.html`](https://github.com/18F/18f.gsa.gov/tre
 
 
 #### Add a project page
-1. Create a new file within the `_projects` directory, named with the following format: `[agency acronym]-[project-name].md`.
-2. Copy the [project page template](https://raw.githubusercontent.com/18F/18f.gsa.gov/master/examples/project-template.md) to that file.
-3. Replace all relavent front matter fields. To see if a field is required, see the [project page schema](https://github.com/18F/18f.gsa.gov/blob/master/tests/schema/_projects.yml).
-4. If you are adding an image, make sure to [check out the wiki](https://github.com/18F/18f.gsa.gov/wiki/Finding-the-right-image-for-a-project-page). If you are not adding an image, make sure to specify an `image_icon` property in the front matter, and reference an SVG available in the [SVG catalog]({{ site.basurl }}/images/svg-include-catalog) like so:
+1. Determine if the project is a service or a product and find the corresponding directory
+2. Create a new file within either `_products_projects` or `_servicess_projects` directory, named with the following format: `[agency acronym]-[project-name].md`.
+2. Copy the [project page template](https://raw.githubusercontent.com/18F/18f.gsa.gov/master/examples/project-template.md) to that file. Here you can build out the page to include:
+  - main content on the project's background and 18F's approach
+  - the sidebar for at a glance information like the project's website or github repos. To do this, update the front matter related to the sidebar. If you don't want something to show up in the sidebar, remove it from the front matter
+  - testimonials or fun facts styling within the body of the page  
+3. Replace all relavent front matter fields. To see if a field is required, see the [project page schema](https://github.com/18F/18f.gsa.gov/blob/master/tests/schema/_services_projects.yml).
+4. If you are adding an image, make sure to [check out tips on picking a project page image]({{ site.baseurl }}/styleguide/images/#project-page-images ). If you are not adding an image, make sure to specify an `image_icon` property in the front matter, and reference an SVG available in the [SVG catalog]({{ site.basurl }}/images/svg-include-catalog) like so:
   ```yml
   image_icon: gavel.svg
   ```
-5. Populate the sidebar for at a glance information. To do this, update the front matter related to the sidebar. If you don't want something to show up in the sidebar, remove it from the front matter.
 
 ---
 

--- a/examples/project-template.md
+++ b/examples/project-template.md
@@ -15,6 +15,10 @@ github_repo: if there is one
 project_url: "[Page name](url)"
 project_weight: 2 (the higher number the higher on the What we deliver landing page)
 learn_more:
+github_repo: 
+- "[Page name](url)"
+- "[Page name](url)"
+- "[Page name](url)"
 product_clients:
 -
 -
@@ -23,12 +27,20 @@ resources:
 - "[Page name](url)"
 - "[Page name](url)"
 - "[Page name](url)"
-quote:
 
 ---
 
-Intro sentences or paragraphs.
+Intro sentences or paragraphs about project.
 
+=== Testimonial or fun fact ===
+<div class="testimonial-blockquote">
+  18F has helped us [something built] that lead to [insert impact]
+    <span>- [name], [position], [agency]</span>
+</div>
+
+<div class="funfact-blockquote">
+	The day [platform] launched, [x-number]organizations were already using the data and API to enhance existing tools or build new products to better serve their customers.
+</div>
 <div class="small-caps">Approach</div>
 ### Approach subtitle goes here
 


### PR DESCRIPTION
Fixes issue(s) #2660

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/docu-wha.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/docu-wha)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/docu-wha/styleguide/#project-page-template)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/docu-wha/README.md)

Changes proposed in this pull request:
- Updated project page template documentation style guide 


/cc @awfrancisco 
