### PR TITLE
Adds documentation on testimonials and how we work page to the style guide

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -63,6 +63,8 @@ nav_items:
         permalink: /styleguide/components/#project-cards
       - text: Sticky subnavigation
         permalink: /styleguide/components/#sticky-subnavigation
+      - text: Testimonials and fun facts
+        permalink: /styleguide/components/#testimonials-and-fun-facts
   - text: Blog components
     permalink: /styleguide/blog-components/
     children:

--- a/_styleguide/subpages/components.md
+++ b/_styleguide/subpages/components.md
@@ -194,7 +194,7 @@ To add items to the subnavigation define the subnavigation items directly within
 
 ### Testimonials and fun facts
 
-Testimonials and fun facts are used throughout the site to highlight the impact 18F has made with our partner agencies. You can find the styling used on the home page, how we work and various project pages. 
+Testimonials and fun facts are used throughout the site to highlight the impact 18F has made with our partner agencies. You can find the styling used on the home page, how we work, and various project pages. 
 
 {% capture testimonial_codeblock %}{% raw %}
 
@@ -213,7 +213,7 @@ Testimonials and fun facts are used throughout the site to highlight the impact 
 
 #### How to use
 
-- For a testimonial: Add the class `testimonial-blockquote` to the element (ex. `div`) that holds the quote. This will place the large quote mark before the content. Place the name, position and agency within the `<span>` tag. This bolds, adds color and removes italics to the text. 
+- For a testimonial: Add the class `testimonial-blockquote` to the element (ex. `div`) that holds the quote. This will place the large quote mark before the content. Place the name, position, and agency within the `<span>` tag. This bolds, adds color, and removes italics to the text. 
 - For a fun fact: Add the class `funfact-blockquote` to the element (ex. `div`) that holds the information. This has similar styling to a testimonial but adjusted for just text. 
 
 {% endcapture %}

--- a/_styleguide/subpages/components.md
+++ b/_styleguide/subpages/components.md
@@ -100,7 +100,7 @@ The card component is used as a preview for project pages, but could be adapted 
   <section class="usa-flex usa-flex-wrap">
     {% include card-project.html project='fec-gov' %}
     {% include card-project.html project='hhs-states' %}
-    {% include card-project.html project='doi-every-kid-in-a-park' %}
+    {% include card-project.html project='dhs-myuscis' %}
   </section>
 </div>
 {% endraw %}{% endcapture %}
@@ -187,4 +187,40 @@ To add items to the subnavigation define the subnavigation items directly within
    content=sticky_codeblock
    lang="html"
    description=sticky_description
+%}
+
+
+---
+
+### Testimonials and fun facts
+
+Testimonials and fun facts are used throughout the site to highlight the impact 18F has made with our partner agencies. You can find the styling used on the home page, how we work and various project pages. 
+
+{% capture testimonial_codeblock %}{% raw %}
+
+<div class="testimonial-blockquote">
+  18F has helped us [build something] that lead to [improved thing] resulting in [impact] within our agency.
+    <span>- [name], [position], [agency]</span>
+</div>
+
+<div class="funfact-blockquote">
+  The day [platform] launched, [x-number]organizations were already using the data and API to enhance existing tools or build new products to better serve their customers.
+</div>
+
+{% endraw %}{% endcapture %}
+
+{% capture testimonial_description %}
+
+#### How to use
+
+- For a testimonial: Add the class `testimonial-blockquote` to the element (ex. `div`) that holds the quote. This will place the large quote mark before the content. Place the name, position and agency within the `<span>` tag. This bolds, adds color and removes italics to the text. 
+- For a fun fact: Add the class `funfact-blockquote` to the element (ex. `div`) that holds the information. This has similar styling to a testimonial but adjusted for just text. 
+
+{% endcapture %}
+
+{% include details-code.html
+   title='testimonial'
+   content=testimonial_codeblock
+   lang="html"
+   description=testimonial_description
 %}

--- a/_styleguide/subpages/layout.md
+++ b/_styleguide/subpages/layout.md
@@ -48,6 +48,13 @@ Attribute | Type | What it does
 `image_figcaption` | String | _(optional)_ A caption that will be displayed on top of the image
 `breadcrumb` | Boolean | _(optional)_ Set to `false` by default. Specify `true` to enable the breadcrumb. If set to `true`, set `subnav_title` if the breadcrumb text differs from the page `title`. [View breadcrumb component]({{ site.baseurl }}/styleguide/components/#breadcumbs)
 
+### How we work page
+
+`/how-we-work` page is similar to the primary template but with a few adjustments that help to highlight how we support our customers. We pull these components:
+
+- Project cards are placed at the bottom of the bottom of the page to highlight past work and to bring users to `/what-we-deliver`.[View project cards component]({{ site.baseurl }}/styleguide/components/#project-cards)
+- Testimonal quote is used within the body of the content. Bringing the voices of our partner agencies front and center is a top priority. [View testimonial component]({{ site.baseurl }}/styleguide/components/#testimonials-and-fun-facts)
+
 ---
 
 ### Project page template

--- a/_styleguide/subpages/layout.md
+++ b/_styleguide/subpages/layout.md
@@ -52,7 +52,7 @@ Attribute | Type | What it does
 
 `/how-we-work` page is similar to the primary template but with a few adjustments that help to highlight how we support our customers. We pull these components:
 
-- Project cards are placed at the bottom of the bottom of the page to highlight past work and to bring users to `/what-we-deliver`.[View project cards component]({{ site.baseurl }}/styleguide/components/#project-cards)
+- Project cards are placed at the bottom of the page to highlight past work and to bring users to `/what-we-deliver`.[View project cards component]({{ site.baseurl }}/styleguide/components/#project-cards)
 - Testimonal quote is used within the body of the content. Bringing the voices of our partner agencies front and center is a top priority. [View testimonial component]({{ site.baseurl }}/styleguide/components/#testimonials-and-fun-facts)
 
 ---


### PR DESCRIPTION
Fixes issue(s) #2698 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/docu-hww.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/docu-hww)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/docu-hww/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/docu-hww/README.md)

Changes proposed in this pull request:
- Adds documentation of testimonials to components section
- Adds a section about `how-we-work` layout under primary layout 

/cc @awfrancisco 
