### PR TITLE
remove broken link to https://18f.gsa.gov/hub/api/

### DIFF
--- a/pages/developer.md
+++ b/pages/developer.md
@@ -24,10 +24,6 @@ The [Discovery API](https://discovery.gsa.gov/docs/) drives the [Discovery Marke
 
 The [FOIA Modernization API](http://foia-hub.readthedocs.org/en/latest/api.html) lists all agencies for whom a FOIA request can be submitted.  It also includes components within those agencies that are large enough (and well known enough) to have their own FOIA system.
 
-### Hub
-
-The [Hub API](https://18f.gsa.gov/hub/api/) provides web services for the [18F Hub](https://18f.gsa.gov/hub/), a repository of team and project information ([more details here]({{ site.baseurl }}/2014/12/23/hub/)).
-
 
 ### OpenFEC
 

--- a/pages/developer.md
+++ b/pages/developer.md
@@ -31,6 +31,7 @@ The [OpenFEC API](https://api.open.fec.gov/developers) is the first RESTful API 
 
 ## 18F Initiatives
 
+
 ### /Developer Program
 
 The [/Developer Program](https://api-all-the-x.18f.gov/) is a suite of tools and resources to assist in the production and management of government APIs. The information is available to all and can be readily repurposed to the needs of individual agencies.  Furthermore, the program includes various options for direct support which are available to any federal agency. Learn more from the [blog post announcing the program]({{ site.baseurl }}/2014/05/29/announcing-the-developer-program-a-new-hub-for/).


### PR DESCRIPTION
Remove link to https://18f.gsa.gov/hub/api/ since this service no longer exists

/cc @awfrancisco 
