### PR TITLE
In .gov domain post: fixing broken links, using HTTPS, removing interim text

### DIFF
--- a/_posts/2014-12-18-a-complete-list-of-gov-domains.md
+++ b/_posts/2014-12-18-a-complete-list-of-gov-domains.md
@@ -20,7 +20,7 @@ tags:
 
 <figure>
   <img src="{{site.baseurl}}/assets/blog/dotgovs/dot-govs-screen.png" alt="A section of a spreadsheet of the .gov domain list">
-  <figcaption>Excerpt of the <a href="https://github.com/GSA/data/blob/gh-pages/dotgov-domains/current-full.csv">.gov domain list (CSV)</a></figcaption>
+  <figcaption>Excerpt of the <a href="https://github.com/GSA/data/blob/master/dotgov-domains/current-full.csv">.gov domain list (CSV)</a></figcaption>
 </figure>
 
 There are a lot of `.gov` domains: over 5,300 of them. About 1,300 of these are used by the federal government's executive, legislative, and judicial branches. The rest are spread across states, territories, counties, cities, and native tribes.
@@ -29,14 +29,12 @@ For a while now, the public has been able to download a dataset of the [roughly 
 
 We're happy to say that the `.gov` registry is now releasing the **entire set of 5,300 `.gov` domains**, including those outside of the federal executive branch.
 
-Some background: the `.gov` registry is a [centrally operated top-level domain](https://www.dotgov.gov) managed by the [Office of Government-wide Policy](http://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](http://www.gsa.gov/) (GSA). The associated [DotGov.gov](https://www.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
+Some background: the `.gov` registry is a [centrally operated top-level domain](https://domains.dotgov.gov) managed by the [Office of Government-wide Policy](https://www.gsa.gov/portal/content/104550) (OGP), which is part of the [General Services Administration](https://www.gsa.gov/) (GSA). The associated [DotGov.gov](https://domains.dotgov.gov) provides more background, as well as tools such as WHOIS lookup and DNSSEC analysis.
 
 You can download the complete `.gov` domain list in CSV form here:
 
- * [https://github.com/GSA/data/raw/gh-pages/dotgov-domains/current-full.csv](https://github.com/GSA/data/raw/gh-pages/dotgov-domains/current-full.csv)
+ * [https://github.com/GSA/data/raw/master/dotgov-domains/current-full.csv](https://github.com/GSA/data/raw/master/dotgov-domains/current-full.csv)
 
-We’re hosting it on GSA's GitHub account, which also allows for [easy in-browser viewing of the full list](https://github.com/GSA/data/blob/gh-pages/dotgov-domains/current-full.csv).
+We’re hosting it on GSA's GitHub account, which also allows for [easy in-browser viewing of the full list](https://github.com/GSA/data/blob/master/dotgov-domains/current-full.csv).
 
-**Note**: This dataset is an interim release and a snapshot in time, first taken on December 1, 2014. While the data will continue to be updated for the foreseeable future, the long-term plan is for the complete dataset to be listed and regularly updated [on Data.gov](https://catalog.data.gov/dataset/gov-domains-api-c9856).
-
-In the meantime, we and the Office of Government-wide Policy hope this data is useful to the public, and to anyone helping make the `.gov` landscape better.
+We and the Office of Government-wide Policy hope this data is useful to the public, and to anyone helping make the `.gov` landscape better.


### PR DESCRIPTION
This fixes a couple of broken links to the CSV of .gov domains (we switched branches from `gh-pages` to `master`), moves some links to `https://` where we can, and it removes an outdated note about the intended landing place of the .gov domain data. (It's now ending up at home.dotgov.gov/data/, not at data.gov.)

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

/cc @h-m-f-t 
