### PR TITLE
Remove extra word

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ]
 - [ ]
 
-## This is issue is done when:
+## This issue is done when:
 - [ ]
 - [ ]
 - [ ]


### PR DESCRIPTION
Just a very small change — I noticed the word "is" was in there twice by accident, so I figured I'd submit a PR to address it. 🙂

Changes proposed in this pull request:
- Remove a likely typo/extra word

(I deleted most of the PR template fields here as they look like they're not so relevant for this PR)