### PR TITLE
when search results are blank, do not show in results page

### DIFF
--- a/assets/js/jekyll-pages-api-search.js
+++ b/assets/js/jekyll-pages-api-search.js
@@ -1,3 +1,4 @@
+// (function() {
 /*
  * Params:
  * - query: query string
@@ -7,12 +8,10 @@
  *     be appended
  */
 function renderJekyllPagesApiSearchResults(query, results, doc, resultsElem) {
-  $("#search-loading").hide();
-  
   results.forEach(function(result, index) {
     var resultTitle = result.title;
-    var errorPages = resultTitle === '404' || resultTitle === '500';
-
+    var errorPages = resultTitle === '404' || resultTitle === '500' || resultTitle === '';
+    
     if (resultTitle && !errorPages) {
       var item = doc.createElement('li'),
           link = doc.createElement('a'),
@@ -32,3 +31,4 @@ function renderJekyllPagesApiSearchResults(query, results, doc, resultsElem) {
     }
   });
 }
+// })();


### PR DESCRIPTION
Fixes issue(s) # #2777

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/do_not_display_blank_results_in_search.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/do_not_display_blank_results_in_search)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/do_not_display_blank_results_in_search/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/do_not_display_blank_results_in_search/README.md)

Changes proposed in this pull request:
-
-
-

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**


/cc @relevant-people
