### PR TITLE
hide loading bar after search completes

### DIFF
--- a/assets/js/jekyll-pages-api-search.js
+++ b/assets/js/jekyll-pages-api-search.js
@@ -8,6 +8,7 @@
  *     be appended
  */
 function renderJekyllPagesApiSearchResults(query, results, doc, resultsElem) {
+  $("#search-loading").hide();
   results.forEach(function(result, index) {
     var resultTitle = result.title;
     var errorPages = resultTitle === '404' || resultTitle === '500' || resultTitle === '';


### PR DESCRIPTION
Fixes issue(s) #2775

Did not previously merge in correctly

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide_loading_bar.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide_loading_bar)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/hide_loading_bar/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/hide_loading_bar/README.md)

Changes proposed in this pull request:
-
-
-

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**


/cc @relevant-people
