### PR TITLE
added strategist & visual design roles to Open positions

### DIFF
--- a/_join/index.md
+++ b/_join/index.md
@@ -31,11 +31,11 @@ If you have any questions, please contact our Talent Team at [jointts@gsa.gov](m
 Links below will take you to the Technology Transformation Services join page to apply.
 
 <section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/strategist/">Strategist</a>
+  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/strategist/">18F Strategist</a>
 </section> 
 
 <section class="usa-grid-full">
-  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/visual-designer/">Visual Designer</a>
+  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/visual-designer/">18F Visual Designer</a>
 </section> 
 
 <section class="usa-grid-full">

--- a/_join/index.md
+++ b/_join/index.md
@@ -31,6 +31,14 @@ If you have any questions, please contact our Talent Team at [jointts@gsa.gov](m
 Links below will take you to the Technology Transformation Services join page to apply.
 
 <section class="usa-grid-full">
+  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/strategist/">Strategist</a>
+</section> 
+
+<section class="usa-grid-full">
+  <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/visual-designer/">Visual Designer</a>
+</section> 
+
+<section class="usa-grid-full">
   <a class="usa-button usa-button-secondary" href="https://apply.pif.gov/">2018 Fall Presidential Innovation Fellowship</a>
 </section> 
 


### PR DESCRIPTION
Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/addstratandvisroles.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/addstratandvisroles)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/addstratandvisroles/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/addstratandvisroles/README.md)

Changes proposed in this pull request:
- roles ready to be merged on Monday.  Can move forward with tweeting about virtual design role.  Should make an announcement about virtual location option

/cc @awfrancisco 
