### PR TITLE
Update gov resume section

### DIFF
--- a/_join/index.md
+++ b/_join/index.md
@@ -32,25 +32,25 @@ Links below will take you to the Technology Transformation Services join page to
 
 <section class="usa-grid-full">
   <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/strategist/">18F Strategist</a>
-</section> 
+</section>
 
 <section class="usa-grid-full">
   <a class="usa-button usa-button-secondary" href="https://join.tts.gsa.gov/join/visual-designer/">18F Visual Designer</a>
-</section> 
+</section>
 
 <section class="usa-grid-full">
   <a class="usa-button usa-button-secondary" href="https://apply.pif.gov/">2018 Fall Presidential Innovation Fellowship</a>
-</section> 
+</section>
 
 <!--**We currently have no open positions at 18F.**   -->
 
 <!-- Links below will take you to the Technology Transformation Services join page to apply. -->
 
-<!-- 
+<!--
 TEMPLATE:
 <section class="usa-grid-full">
   <a class="usa-button usa-button-secondary" href="LINK">JOB TITLE</a>
-</section> 
+</section>
 -->
 
 ----
@@ -75,7 +75,7 @@ We collect applications during the period specified in the job posting (usually 
 
 Once the application collection period ends, you can't add to or modify your application.
 
-A panel of subject matter experts will review each application using a qualification process called [Category Rating](https://www.opm.gov/policy-data-oversight/hiring-information/competitive-hiring/#url=Category-Rating). Once we've evaluated all applications within the cohort, we send all the applications and evaluation scores to General Services Administration (GSA) Human Resources, our partner in the hiring process, to apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx) for candidates who claim it. The top qualified candidates will be contacted to continue on to the interview process. 
+A panel of subject matter experts will review each application using a qualification process called [Category Rating](https://www.opm.gov/policy-data-oversight/hiring-information/competitive-hiring/#url=Category-Rating). Once we've evaluated all applications within the cohort, we send all the applications and evaluation scores to General Services Administration (GSA) Human Resources, our partner in the hiring process, to apply [Veterans' Preference](http://www.fedshirevets.gov/job/vetpref/index.aspx) for candidates who claim it. The top qualified candidates will be contacted to continue on to the interview process.
 
 ----
 
@@ -154,77 +154,78 @@ The [18F Handbook](https://handbook.18f.gov/) has more information about working
 - [Professional development and training processes](https://handbook.18f.gov/professional-development-and-training/#speaking-at-conferences)
 
 -----
-
 ## Government-style resumes
 
-Unlike private-sector resumes, government-style resumes are often several pages long and include detailed information about every job you've held, your responsibilities, and what you accomplished.
+Unlike private-sector resumes, government-style resumes are often several pages long and include detailed information about the jobs you've held, your responsibilities, and what you accomplished.
 
-There are many guides to building a government-style resume. Here are several resources from other organizations:
+### General recommendations
 
-- [GoGovernment's Create Your Federal Resume Guide](http://gogovernment.org/how_to_apply/write_your_federal_resume/create_your_resume.php)
-- [Food and Drug Administration (FDA)'s Federal Resume Template](http://www.fda.gov/downloads/AboutFDA/WorkingatFDA/UCM279014.pdf)
+- When you are preparing your application, be sure to reference the Qualifications & Evaluation sections of the job post to help you best frame your experience.
+- Don’t get hung up on trying to match specific formatting just make sure you’ve included the information relevant to each section.
+- Be as detailed as possible, length is not an issue as long as the information you are including is relevant.
+- For your most relevant, recent, or longest held position, list 8-10 bullet points about your responsibilities and accomplishments. For each prior position, you can list fewer points focusing on the information that is most relevant to the job you are applying to.
+- Don’t be afraid to use technical terminology if it’s relevant to your role or the role you are applying to but avoid acronyms and abbreviations where possible.
+- We don’t use any kind of automated screening tools, your application will be evaluated by humans who will have varying levels of familiarity with the details of the roles. Although it’s not a key-word search, better to be explicit and not assume the reader has the domain knowledge or context to “read between the lines”.
+- Quantify as much as possible (where applicable)
 
-This guide shows how to format a government-style resume and what information to include:
+### Sample Structure/Key Information for each position
 
-> **Name**  
-> **City and state of current residence**  
-> **Email address**  
-> **Phone number**  
->
-> **TECHNICAL SKILLS & TOOLS**
->
-> 8+ years of experience:
-> - *List skills and tools for which you have more than 8 years of experience.*
->
-> 4-7 years of experience:
-> - *List skills and tools for which you have 4-7 years of experience.*
->
-> 1-3 years of experience:
-> - *List skills and tools for which you have 1-3 years of experience.*
->
-> **PROFESSIONAL EXPERIENCE**
->
-> Start with your current employment or your most recent role and list all your professional experiences in reverse-chronological order. Include a full chronology — that is, account for all of your time.
->
-> *See below for employment history formatting.*
->
-> **Role/title, Company name**  
-> **City, State (if within the U.S.) or City, Country**  
-> **Duration of employment (MM/YYYY - MM/YYYY or Present)**  
-> **“Full-time” or “Part-time,” Number of hours per week: __**
->
-> For each listing, include a one-sentence description of the company, including the mission. This will help us understand the scope of your work, the context of your contributions, the scale of the company, and your role.
->
-> For your most relevant, recent, or longest held position, list 8-10 bullet points about your responsibilities and accomplishments. For each prior position, you can list fewer points, but be as detailed as possible. For jobs held many years ago or unrelated to your current role, list 1-2 bullet points each. If these jobs included transferrable skills (management, communication, and problem solving), mention them.
->
-> Here are a few pointers:
->
-> * Though we always enjoy learning more about your team, please focus on what you — not your team — accomplished.
-> * **Don't** be concise! Yes, this flies in the face of what you learned in your English classes, but government resumes must include extreme detail.
-> * Use non-technical terminology. If you must use technical terms, include definitions, where applicable.
-> * Quantify as much as you can: number of projects you worked on, number of people you managed, number of dollars you saved the company, and so on.
->
-> If you were unemployed at any point, please indicate this. Unemployment is completely acceptable and understood — we just need a full timeline with no gaps. For instance:
->
-> **Unemployed**  
-> **Start MM/YYYY - End MM/YYYY** 
->
-> Brief explanation (Took time to travel, to be with my family, and so on) to the extent you’re comfortable sharing. It's also OK not to include a description.
->
-> **EDUCATION**
->
-> **Name of college/university/institution, City, State**  
-> Type of degree, major and minor, MM/YYYY degree received  
-> Graduation honors, if applicable
->
-> **Other sections to include, if applicable:**
->
-> * Volunteer work (include the organization's name, your years of participation, and a one-line description of your role)
-> * Relevant awards (include awarding organization, title of award, year received, and any relevant details, such as chosen as *award winner out of 300 contenders*)
-> * Relevant public speaking engagements and presentations (include title of presentation, name of conference/event, month and year of presentation, and any other relevant details)
-> * Certifications (name of certificate, institution issuing the certificate, year issued)
-> * Relevant professional affiliations (organization name, your years of participation)
-> * Publications (including personal blog posts) (title of published work, month and year of publication)
-> * Training and courses (name of training or course, organization providing the training, MM/YYYY completed)
+This is the information that you should include for each position on your resume.
+- Company/Organization Name
+- Location (City, State)
+- Dates of employment (MM/YYYY)
+- Hours Per Week (e.g. 15, 20, 40. If “full time” list 40 hours)
+- Job Title/Position Title
+- GS Level (Only relevant to current or past federal employees)
+- Brief description of the organization
+- Brief description of the product/project/team you worked on or supported (if applicable).
+- List of relevant skills, tools, technologies used
+- Specific duties, responsibilities, accomplishments of the position
 
+### Detailed Description of Sections
 
+#### Brief Description of the organization & Brief description of the product/project/team you worked on or supported (if applicable).
+
+This section provides context for your work and accomplishments which helps us understand how it’s applicable to our work and the role you are applying for. Examples of the kind of information on team, project, product, etc to include:
+- Clients/Customers type: public facing, end-users, internal, B2B, civic tech, etc
+- Scope of impact/Performance metrics: users, clients, datasets, uptime, cycle time, etc.
+- Team size/composition
+
+#### Relevant Skills, Tools, Technologies Used
+
+Here is where you will capture the skills, methodologies, techniques and tools that you used in that position. Focus on those things that were significant to your work and are relevant to the role that you are applying to. Below are some examples of things that you might include:
+- Scrum, Scaled Agile Framework, paired-programming, test-driven development, contextual inquiry, ethnograph, Lean startup
+- Wireframes, sitemaps, card sorting, storyboards, journey maps, proto-typing, roadmaps, style guides, pattern libraries, A/B testing, continuous integration
+- Information architecture, service design, visual design, content design, project management, copywriting, server-side development, front end development, containerization, configuration management,infrastructure automation
+- Axure, Powerpoint, Trello, Amazon Web Services, Azure, Docker, Slack, Github, Ruby, Mercurial, PyUnit, JUnit, Rspec, Travis, MongoDB, Redis, Cassandra
+
+### Example Resume Excerpt
+
+**Technology Transformation Service - Washington, DC**
+
+_The Technology Transformation Service’s (TTS) mission is to lead the digital transformation of the federal government by helping agencies build, buy, and share technology that allows them to provide more accessible, efficient, and effective products and services to the American people._
+
+**Software Engineer - 07/2015 to Present** - Hours per week: 40
+
+_Developer for USAJobs which is a job posting and application collection portal used by over 500 offices/agencies posting 320k jobs and over 10M applicant accounts_
+
+**Technical Skills Used:** Javascript, Docker, Node.js, Git, Postgres, test-driven development, scrum, Ruby on Rails, Postgres/PostGIS SQL,JSON,Redis, Heroku, Amazon Web Services (AWS), RESTful API, Rspec, CircleCi
+
+- Led and managed backend web development, support and deployment of USAJobs providing metrics and analytics dashboards
+- Developed new features and provided technical support solutions utilizing the Ruby on Rails framework, Postgres/PostGIS SQL, JSON and Redis while maintaining and deploying to Heroku, Amazon Web Services (AWS) cloud technologies including Relational Database Services (RDS) and Elastic Search environments
+- Partnered with departments gathering requirements to develop a joint implementation strategy, obtain access relevant agency internal data systems and data definitions and extract departmental datasets via RESTful APIs.
+- During implementation process met with agency stakeholders weekly to iterate using an Agile development approach to achieve a user centric designed experience
+- Managed codebase in GitHub repository for source control, scoping technical requirements into developmental milestones, releases tagging, issue tracking and source control.
+- Assembled with sales team, database administrators, product managers, data scientists, executive leadership, enterprise architects to form cross-functional, multidisciplinary team to develop a user focused analytics dashboard delivering an insightful analytics dashboard enabling government officials to make data driven decisions
+- Automated testing of codebase using Rspec and CircleCi for continuous integration
+- Guided team members on data infrastructure to implement front end solutions and peer review code commits for potential refactorization to ensure quality
+
+### Other sections to include, if applicable
+
+- Volunteer work (include the organization's name, your years of participation, and a one-line description of your role)
+- Relevant awards (include awarding organization, title of award, year received, and any relevant details, such as chosen as *award winner out of 300 contenders*)
+- Relevant public speaking engagements and presentations (include title of presentation, name of conference/event, month and year of presentation, and any other relevant details)
+- Certifications (name of certificate, institution issuing the certificate, year issued)
+- Relevant professional affiliations (organization name, your years of participation)
+- Publications (including personal blog posts) (title of published work, month and year of publication)
+- Training and courses (name of training or course, organization providing the training, MM/YYYY completed)


### PR DESCRIPTION
Address one part of #2760 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/gov-resume.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/gov-resume)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/gov-resume/)

Changes proposed in this pull request:
- Replace the government resume section with content from join.tts.gsa.gov
