### PR TITLE
Include state and local agencies in description

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -9,7 +9,7 @@ redirect_from: /dashboard/
   <section class="hero hero-primary">
     <div class="usa-grid">
       <div class="hero-callout hero-callout-primary background-dark usa-width-one-third usa-width-tablet">
-        <h2>18F partners with federal agencies to improve the user experience of government.</h2>
+        <h2>18F partners with federal, state, and local agencies to improve the user experience of government.</h2>
         <a href="{{ site.baseurl }}/contact/" tabindex="-1"><button class="usa-button usa-button-big usa-button-secondary">Get in touch</button></a>
       </div>
     </div>


### PR DESCRIPTION
18F Acquisition has a State and Local practice, which we promote on the website ([e.g.](https://18f.gsa.gov/what-we-deliver/hhs-states/)), but we inadvertently ignore its existence on the home page. This may be confusing to potential state and local partners, who are currently informed by the home page that we do not do business with them. I propose using broader language, by specifying that we do, indeed, work with state and local agencies.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/client-scope.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/client-scope)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/client-scope/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/client-scope/README.md)

Changes proposed in this pull request:
- Change `federal agencies` to `federal, state, and local agencies` on the home page
