### PR TITLE
Remove date of blog posts on project pages

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -6,7 +6,6 @@
   {% for post in page.related_posts %}
     <li class="usa-width-one-third">
       <article>
-        <p class="post-date">{{ post.date | date: "%B %-d, %Y" }}</p>
         <h3 class="posts_feature-heading">
           <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}
           {% if post.series %}


### PR DESCRIPTION
Old dates on the blog posts at the bottom of project pages can give the impression that the site is outdated, even if there are new blog posts published elsewhere. Removing line `<p class="post-date">{{ post.date | date: "%B %-d, %Y" }}</p>` should do the trick.

Fixes issue(s) #2800 

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/remove-date-from-related-posts/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/remove-date-from-related-posts/README.md)

Changes proposed in this pull request:
- Remove date from blog post on project pages

/cc @awfrancisco @eddietejeda @hbillings 
