### PR TITLE
Removing date from posts in project pages

### DIFF
--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -152,7 +152,6 @@ header_border: true
         <ul>
         {% for post in matching_posts limit:3 %}
           {% include post.html
-             post_date=post.date
              post_title=post.title
              post_excerpt=post.excerpt
              post_url=post.url


### PR DESCRIPTION
After removing the date line from `_includes/related-posts.html` the date continues to show. We'll see if removing `post_date=post.date` in this layout will fix the issue

Fixes issue(s) #2800  .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts-2.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts-2)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/remove-date-from-related-posts-2/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/remove-date-from-related-posts-2/README.md)

Changes proposed in this pull request:
- Remove date from related blog posts on project pages

/cc @awfrancisco @eddietejeda @hbillings 
