### PR TITLE
Remove date from posts in project pages

### DIFF
--- a/_includes/related-posts.html
+++ b/_includes/related-posts.html
@@ -6,7 +6,6 @@
   {% for post in page.related_posts %}
     <li class="usa-width-one-third">
       <article>
-        <p class="post-date">{{ post.date | date: "%B %-d, %Y" }}</p>
         <h3 class="posts_feature-heading">
           <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}
           {% if post.series %}

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -152,7 +152,6 @@ header_border: true
         <ul>
         {% for post in matching_posts limit:3 %}
           {% include post.html
-             post_date=post.date
              post_title=post.title
              post_excerpt=post.excerpt
              post_url=post.url


### PR DESCRIPTION
Fixes issue(s) #2800  .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts-3.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/remove-date-from-related-posts-3)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/remove-date-from-related-posts-3/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/remove-date-from-related-posts-3/README.md)

Changes proposed in this pull request:
- Remove date from posts in project pages

/cc @awfrancisco 
