### PR TITLE
center-align figure captions

### DIFF
--- a/_sass/_components/figure.scss
+++ b/_sass/_components/figure.scss
@@ -16,7 +16,6 @@
 figcaption {
   font-size: $small-font-size;
   color: $color-gray;
-  text-align: left;
 
   &.align-center {
     text-align: center;
@@ -42,4 +41,3 @@ figcaption {
   margin-left: $section-margins;
   margin-bottom: $paragraph-margins-thick;
 }
-


### PR DESCRIPTION
I personally think the captions look better center-aligned, but this is just a suggestion!

## Before

![screen shot 2018-08-15 at 12 19 11 am](https://user-images.githubusercontent.com/86842/44131437-07eb23e8-a021-11e8-92f5-3b4a1711a3bb.png)

## After

![screen shot 2018-08-15 at 12 19 21 am](https://user-images.githubusercontent.com/86842/44131438-07f84118-a021-11e8-9cd5-1007a29ae2e0.png)
