### PR TITLE
include the time to read in posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :jekyll_plugins do
   gem 'jekyll_pages_api'
   gem 'jekyll_pages_api_search', '~> 0.4.5'
   gem 'jekyll_oembed'
+  gem 'jekyll-time-to-read'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-sitemap (1.0.0)
       jekyll (~> 3.3)
+    jekyll-time-to-read (0.1.2)
+      jekyll
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     jekyll_frontmatter_tests (0.1.0)
@@ -203,6 +205,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-seo-tag
   jekyll-sitemap
+  jekyll-time-to-read
   jekyll_frontmatter_tests (~> 0.1.0)
   jekyll_oembed
   jekyll_pages_api
@@ -220,4 +223,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,6 +24,9 @@ layout: default
           </a>
         {% endfor %}
       </span>
+      <p class="post-time-to-read">
+        Time to read: {{ content | reading_time_as_s }}
+      </p>
     </header>
 
     <div class="post-content" itemprop="articleBody">

--- a/_sass/_components/post-meta.scss
+++ b/_sass/_components/post-meta.scss
@@ -43,3 +43,8 @@
     }
   }
 }
+
+.post-time-to-read {
+  color: $color-gray;
+  font-size: $h5-font-size;
+}


### PR DESCRIPTION
...automatically. Whaddya think?

![screen shot 2018-08-15 at 2 47 51 am](https://user-images.githubusercontent.com/86842/44135218-3021adea-a036-11e8-9591-821a47658856.png)

https://www.sparkreaction.com/blog/estimated-reading-times-on-blogs