### PR TITLE
fix repeated "the" typo on https://18f.gsa.gov/2018/08/09/etl-extract-transform-learn/

### DIFF
--- a/_posts/2018-08-09-etl-extract-transform-learn.md
+++ b/_posts/2018-08-09-etl-extract-transform-learn.md
@@ -83,7 +83,7 @@ extensive ETL process.
 But [agile, user-centered
 design](https://18f.gsa.gov/2015/11/17/choose-design-over-architecture)
 means you can’t know the application's final format at the beginning of
-a project; it evolves continually with the the experiences of the
+a project; it evolves continually with the experiences of the
 developers, product owner, and end users. Our front-end developers made
 extensive changes as needs were clarified and discovered.
 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Reading https://18f.gsa.gov/2018/08/09/etl-extract-transform-learn/ I noticed a typo (repeated "the" twice) in the "Transform modestly" section. This PR simply fixes the typo.