### PR TITLE
hide date from Related blog posts section

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -2,10 +2,13 @@
 {% assign post_title = include.title | default: post.title %}
 {% assign post_excerpt = include.excerpt | default: post.excerpt %}
 {% assign post_url = include.url | default: post.url %}
+{% assign hide_date = include.hide_date | default: false %}
 
 <li class="post usa-width-one-third usa-width-tablet">
   <article>
-    <p class="post-date">{{ post_date | date: "%B %-d, %Y" }}</p>
+    {% if hide_date == true %}
+      <p class="post-date">{{ post_date | date: "%B %-d, %Y" }}</p>
+    {% endif %}  
     <h3 class="h4 posts_feature-heading">
       <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post_title }}</a>
     </h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -64,4 +64,4 @@ layout: default
   </section>
 {% endif %}
 
-{% include related-posts.html %}
+{% include related-posts.html hide_date=true  %}


### PR DESCRIPTION
Fixes issue(s) #2800 .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide_date_in_related_blog_posts_section.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/hide_date_in_related_blog_posts_section)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/hide_date_in_related_blog_posts_section/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/hide_date_in_related_blog_posts_section/README.md)

Changes proposed in this pull request:
-
-
-

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**


/cc @Dahianna 