### PR TITLE
Point to master branch of data-act-broker-backend

### DIFF
--- a/_posts/2018-10-09-implementing-rules-without-rules-engines.md
+++ b/_posts/2018-10-09-implementing-rules-without-rules-engines.md
@@ -96,7 +96,7 @@ costs and effort of hiring vendors or individuals are more reasonable, as you ar
 
 ### It fosters openness and accountability.
 
-When you use common programming languages to describe the rules in code, you open yourself to the benefits of open source software: improved quality, security, reusability, and trustworthiness. The code can readily be shared through a public code repository, as you can see with the [DATA Act rules on GitHub](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/48e3323/dataactvalidator/config/sqlrules).
+When you use common programming languages to describe the rules in code, you open yourself to the benefits of open source software: improved quality, security, reusability, and trustworthiness. The code can readily be shared through a public code repository, as you can see with the [DATA Act rules on GitHub](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactvalidator/config/sqlrules).
 Federal oversight bodies as well as the public can review your code and see exactly how the rules are being implemented, creating confidence that the policies set by the federal and state agencies are being accurately applied. Non-governmental partners can view the rules as implemented and integrate public APIs or reuse your rulesets to aid their clients in determining their best options. Government partners can repurpose the rules without the need to procure the same rules engine. Legislators could use the code to run tests against test data to investigate impacts of potential legislative changes.  
 
 ## Take the easier approach


### PR DESCRIPTION
Although there may be a good reason to point to tag fixed in time, generally people want to see that latest production work.

Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/pdb/rules-engine-patch-1.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/pdb/rules-engine-patch-1)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/pdb/rules-engine-patch-1/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/pdb/rules-engine-patch-1/README.md)

Changes proposed in this pull request:
- Change url to point to master instead of tree in github
-
-

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**


/cc @relevant-people
