### PR TITLE
Fix "Get in touch" button destination

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -126,7 +126,7 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
   <div class="usa-grid">
     <h2 class="usa-width-three-fourths">{{ page.footer_text }}</h2>
     <div class="usa-width-one-fourth">
-      <a class="usa-button usa-button-secondary" href="/site/contact/">Get in touch</a>
+      <a class="usa-button usa-button-secondary" href="/contact/">Get in touch</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This PR does not fix any open issues.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/bugfix/blog-404.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/bugfix/blog-404)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/bugfix/blog-404/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- On the "Blog" index page, fixes the "Get in touch" button link which is currently a 404.

Other notes:
- Consider running htmlproofer on more than 0 files to automatically detect errors like this in the future!

Checklist:
- [x] All images being added have been optimized **(N/A)**
