### PR TITLE
Use dark header when showing tags page

### DIFF
--- a/_layouts/tag-results.html
+++ b/_layouts/tag-results.html
@@ -3,16 +3,21 @@ layout: default
 header_border: true
 ---
 
-<section class="usa-grid usa-section page-tag-results break-bottom">
-  <a class="back-blog link-arrow-left" href="{{ site.baseurl }}/blog/">
-  	{% include svg/icons/arrow-left.svg %}
-    <span class="usa-sr-only">Back to</span>
-  	Blog
-  </a>
-  {% assign numberof = page.posts | size %}
-  <h1>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged {{ page.title }}</h1>
+<section class="background-dark usa-section section-intro">
+  <div class="usa-grid">
+    <a class="link-arrow-left" href="{{ site.baseurl }}/blog/">
+      <h1 class="section-heading section-heading-alt">
+        <span class="usa-sr-only">Back to</span>
+          &#10094; 18F Blog
+      </h1>
+    </a>
+    {% assign numberof = page.posts | size %}
+    <h2>{{ numberof }} {% if numberof == 1 %}post{% else %}posts{% endif %} tagged with "{{ page.title }}"</h2>
+  </div>
 </section>
 
+
+  
 <section class="usa-grid content-focus page-tag-results">
   {%
     include tag-results.html


### PR DESCRIPTION
Fixes issue(s) #2899.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/add_color_to_tag_header.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/add_color_to_tag_header)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/add_color_to_tag_header/tags/modular-contracting/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/add_color_to_tag_header/README.md)

Changes proposed in this pull request:
- Changed color of header to dark blue in tags page