### PR TITLE
added gems to _config so they are detected when we run tests

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -193,6 +193,8 @@ gems:
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-paginate
+  - jekyll_pages_api_search
+  - jekyll_oembed
 
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:


### PR DESCRIPTION
Fix the error message when running tests.

`Liquid Exception: Liquid syntax error (line 30): Unknown tag 'jekyll_pages_api_search_load' in /_layouts/default.html`


`Liquid Exception: Liquid syntax error (line 71): Unknown tag 'oembed' in /Users/eddie/Code/18f.gsa.gov/_posts/2014-05-14-hacking-bureaucracy-improving-hiring-and-software.md`

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/include_gems_when_building_test_to_pass_test.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/include_gems_when_building_test_to_pass_test)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/include_gems_when_building_test_to_pass_test/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/include_gems_when_building_test_to_pass_test/README.md)

Changes proposed in this pull request:
- Tests failed because they did not detect gems that modified the standard Liquid markup.
