### PR TITLE
Add image to twitter card

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -58,7 +58,13 @@
   <link rel="image_src" href="{{ siteurl }}{{ site.baseurl }}{{ page.image }}">
   <meta name="image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}">
   <meta property="og:image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}" />
-  <meta name="twitter:image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}">
+
+  {% if page.image %}
+    <meta name="twitter:image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}">
+  {% else %}
+    <meta name="twitter:image" content="{{ siteurl }}{{ site.baseurl }}/assets/img/logos/18f-logo.svg">
+  {% endif %}
+  
   {% if page.image_accessibility %}
     <meta name="twitter:image:alt" content="{{ page.image_accessibility }}">
   {% endif %}


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/18f.gsa.gov/issues/2942

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/add_social_image.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/add_social_image)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/add_social_image/)

Changes proposed in this pull request:
- Added default image to Twitter card
