### PR TITLE
Update to use current GS salary calculator

### DIFF
--- a/_join/index.md
+++ b/_join/index.md
@@ -111,7 +111,7 @@ employee](https://www.opm.gov/policy-data-oversight/pay-leave/pay-administration
 The annual salary cap for all GS employees is \$164,200 per year. You
 cannot be offered more than this under any circumstance. Use this [OPM
 General Schedule (GS) Salary
-Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2017/general-schedule-gs-salary-calculator/)
+Calculator](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2018/general-schedule-gs-salary-calculator/)
 to help you understand how GS level, step, and locality affect
 compensation.
 


### PR DESCRIPTION
Change from 2017 General Schedule (GS) Salary Calculator to 2018.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Update the Join page's salary calculator link from the [2017 version](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2017/general-schedule-gs-salary-calculator/) to [the current version](https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2018/general-schedule-gs-salary-calculator/).

/cc @ctro 
