### PR TITLE
downgrade jekyll to resolve build problems with new version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '~>2.3.1'
 
 gem 'accesslint-ci', '0.2.8'
 gem 'html-proofer', '~> 3.6.0'
-gem 'jekyll', '~> 3.x'
+gem 'jekyll', '~> 3.3'
 gem 'jemoji'
 gem 'parallel'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 1.0.0)
   colorize
   html-proofer (~> 3.6.0)
-  jekyll (~> 3.x)
+  jekyll (~> 3.3)
   jekyll-archives!
   jekyll-feed
   jekyll-paginate


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/downgrade_gemfile_april_2019.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/downgrade_gemfile_april_2019)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/downgrade_gemfile_april_2019/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/downgrade_gemfile_april_2019/README.md)

Changes proposed in this pull request:
- The latest version of Jekyll breaks in the production environment. This version builds okay.

cc: @amirbey 
