### PR TITLE
Fix blog pagination to not add unnecessary slash to path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ analytics:
 
 # blog archive at /blog
 paginate: 5
-paginate_path: "blog/page/:num"
+paginate_path: "blog/page/:num/"
 
 jekyll-archives:
   enabled:

--- a/blog/index.html
+++ b/blog/index.html
@@ -101,7 +101,7 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
 <section class="pagination usa-grid content-focus">
   <div>
     {% if paginator.previous_page %}
-      <a class="link-arrow-left" href="{{ site.baseurl }}{{ paginator.previous_page_path }}/">
+      <a class="link-arrow-left" href="{{ site.baseurl }}{{ paginator.previous_page_path }}">
         {% include svg/icons/arrow-left.svg %} Previous {{ paginator.per_page }} posts
       </a>
     {% else %}
@@ -113,7 +113,7 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
   </div>
   <div>
     {% if paginator.next_page %}
-    <a class="link-arrow-right" href="{{ site.baseurl }}{{ paginator.next_page_path }}/">
+    <a class="link-arrow-right" href="{{ site.baseurl }}{{ paginator.next_page_path }}">
       Next {{ paginator.per_page }} posts {% include svg/icons/arrow-right.svg %}
     </a>
     {% else %}


### PR DESCRIPTION
Fixes issue(s) #1825

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/apburnes/fix-pagination)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/apburnes/fix-pagination/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/apburnes/fix-pagination/README.md)

Changes proposed in this pull request:
- Remove slashes from blog's markup pagination links
- Let the Jekyll's paginator handle slashes
