### PR TITLE
fix typo in meetings blog post

### DIFF
--- a/_posts/2016-12-14-how-to-run-an-efficient-meeting.md
+++ b/_posts/2016-12-14-how-to-run-an-efficient-meeting.md
@@ -97,7 +97,7 @@ If people show up late and need to get up to speed, kindly and firmly refer them
 
 You should work to **develop a presentation style** through iterative practice and feedback that allows you to speak with confidence and nicely keep the meeting on track and free of distractions. Use the parking lot liberally and set time limits at the start of a tricky discussion so you can depersonalize the decision to move on a few minutes later and stay on track. Your meeting’s participants will respect your efficiency and good use of their time — especially managers and executives.
 
-When leading a discussion, pay attention to who has a loud voice in the room and **elevate other voices** to ensure the meeting is useful to everyone. You can seek feedback with a show of hands and call of people that didn’t talk as much in the meeting. When moving on from a topic, be deliberate and don’t allow someone to keep the conversation frozen because they are emphatic — that rewards their insistence and harms your authority.
+When leading a discussion, pay attention to who has a loud voice in the room and **elevate other voices** to ensure the meeting is useful to everyone. You can seek feedback with a show of hands and call on people that didn’t talk as much in the meeting. When moving on from a topic, be deliberate and don’t allow someone to keep the conversation frozen because they are emphatic — that rewards their insistence and harms your authority.
 
 <img src="{{site.baseurl}}/assets/blog/meeting-facilitation/workshopping.jpg" alt="Members of the 18F team at a workshop meeting.">
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Change 'call of people' to 'call on people' in [How to run an efficient meeting](https://18f.gsa.gov/2016/12/14/how-to-run-an-efficient-meeting/) blog post