### PR TITLE
Check baseurl nil for author set_site_url method

### DIFF
--- a/_plugins/author.rb
+++ b/_plugins/author.rb
@@ -36,11 +36,12 @@ module Jekyll
     # works locally, on Federalist, and in production
     def set_site_url
       baseurl = Jekyll.sites[0].config['baseurl']
+      base_url = baseurl ? baseurl : ''
       config_url = Jekyll.sites[0].config['url']
-      if baseurl.include? 'site/18F/18f.gsa.gov'
+      if base_url.include? 'site/18F/18f.gsa.gov'
         config_url
       else
-        baseurl
+        base_url
       end
     end
 


### PR DESCRIPTION
Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/author-baseurl-check.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/author-baseurl-check)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/author-baseurl-check/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/author-baseurl-check/README.md)

Changes proposed in this pull request:
- Trying to fix liquid template exception in Federalist only effected during master branch builds
- Master branch build error `Liquid Exception: undefined method `include?' for nil:NilClass in /_layouts/post.html`
- Federalist garden build [README](https://github.com/18F/federalist-garden-build#environment-variables) states the `BASEURL` is not set on live site branches and `set_site_url` method expects a string.
- If baseurl is nil, a empty string will be set the the baseurl.