### PR TITLE
Fix one more Word file link in Agile software blog entry

### DIFF
--- a/_posts/2019-08-20-an-agile-software-development-solicitation-guide.md
+++ b/_posts/2019-08-20-an-agile-software-development-solicitation-guide.md
@@ -22,7 +22,7 @@ Government solicitations to procure custom software are often long and
 complicated, include many pages of requirements, and can take months —
 even years — to write. But an agency can hire an agile software
 contractor with a solicitation that’s only a dozen pages, written in an
-afternoon, using our [agile contract format](https://github.com/18F/18f.gsa.gov/blob/master/assets/presentations/agile-software-development-solicitation-template.docx). It can be done under
+afternoon, using our [agile contract format](https://18f.gsa.gov/assets/presentations/agile-software-development-solicitation-template.docx). It can be done under
 existing procurement regulations and within contracting officers’
 existing authority. The savings, in time and money, can be enormous.
 


### PR DESCRIPTION
The link to a Word file goes to GitHub, instead of to Federalist, so the link doesn't work. I've corrected that. I attempted to fix this in #3052, but in my haste to fix a live blog entry, I missed one of the links.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/word-link.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/word-link)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/word-link/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/word-link/README.md)

Changes proposed in this pull request:
- Fix link to Word file

/cc @Dahianna 
