### PR TITLE
Update header meta tags for site url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,4 @@
-{% if site.baseurl | blank %}
-  {% assign siteurl = site.url %}
-{% else %}
-  {% assign siteurl = site.federalist_url %}
-{% endif %}
+{% assign siteurl = site.url %}
 
 <!-- site.url: {{ site.url }} -->
 <!-- site.baseurl: {{ site.baseurl }} -->
@@ -60,7 +56,7 @@
   <meta property="og:image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}" />
 
   <meta name="twitter:image" content="{{ siteurl }}{{ site.baseurl }}{{ page.image }}">
-  
+
   {% if page.image_accessibility %}
     <meta name="twitter:image:alt" content="{{ page.image_accessibility }}">
   {% endif %}
@@ -107,4 +103,3 @@
 =================================================== -->
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}" media="all" />
   <link rel="stylesheet" href="{{ "/assets/css/print.css" | prepend: site.baseurl }}" media="print" />
-


### PR DESCRIPTION
Fixes issue #3040

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

Changes proposed in this pull request:
- Update `siteurl` metadata to use the site url and not the `federalist_url` it was set using
- Enables twitter card to pull image when posting
