### PR TITLE
Fix blog layout after updating USWDS

### DIFF
--- a/_sass/_components/blog-index.scss
+++ b/_sass/_components/blog-index.scss
@@ -3,11 +3,11 @@
 
 .blog-content,
 .sidebar {
-  margin-top: $section-margins;
+  margin-top: $section-margins !important;
 }
 
 .blog-content {
-  padding-right: 10px;
+  padding-right: 10px !important;
 }
 
 .sidebar {

--- a/_sass/_components/buttons.scss
+++ b/_sass/_components/buttons.scss
@@ -141,7 +141,7 @@ button,
 .back-blog {
   display: inline-block;
   font-size: $h6-font-size;
-  margin-top: $section-margins;
+  margin-top: $section-margins !important;
 
   @include media($medium-screen + 200px) {
     margin-top: 0.7rem;

--- a/_sass/_components/post-meta.scss
+++ b/_sass/_components/post-meta.scss
@@ -28,7 +28,7 @@
 
 .post-tags {
   display: block;
-  margin-bottom: $paragraph-margins-thick;
+  margin-bottom: $paragraph-margins-thick !important;
   a {
     @include padding(0.6rem null);
     background-color: $color-gray-lightest;

--- a/_sass/_components/search.scss
+++ b/_sass/_components/search.scss
@@ -1,0 +1,28 @@
+.search-interface {
+    width: 100%;
+
+    .label-text {
+        display: block;
+        padding: 0 0 $spacer-margins 0;
+        font-size: 2.1rem;
+        font-weight: 700;
+    }
+
+    input {
+        &[type=search] {
+            border-right: 0.1rem solid #5b616b;
+        }
+    }
+
+    button {
+        &[type=submit] {
+            height: 3.3rem;
+            margin: 0 $spacer-margins;
+            line-height: .5;
+
+            @media screen and (max-width: 505px) {
+                margin: $spacer-margins 0;
+            }
+        }
+    }
+}

--- a/_sass/_components/search.scss
+++ b/_sass/_components/search.scss
@@ -1,28 +1,28 @@
 .search-interface {
-    width: 100%;
+  width: 100%;
 
-    .label-text {
-        display: block;
-        padding: 0 0 $spacer-margins 0;
-        font-size: 2.1rem;
-        font-weight: 700;
+  .label-text {
+    display: block;
+    padding-bottom: $spacer-margins;
+    font-size: 2.1rem;
+    font-weight: 700;
+  }
+
+  input {
+    &[type=search] {
+      border-right: 0.1rem solid $color-gray-border;
     }
+  }
 
-    input {
-        &[type=search] {
-            border-right: 0.1rem solid #5b616b;
-        }
+  button {
+    &[type=submit] {
+      height: 3.3rem;
+      margin: 0 $spacer-margins;
+      line-height: .5;
+
+      @media screen and (max-width: 505px) {
+        margin: $spacer-margins 0;
+      }
     }
-
-    button {
-        &[type=submit] {
-            height: 3.3rem;
-            margin: 0 $spacer-margins;
-            line-height: .5;
-
-            @media screen and (max-width: 505px) {
-                margin: $spacer-margins 0;
-            }
-        }
-    }
+  }
 }

--- a/_sass/_core/variables.scss
+++ b/_sass/_core/variables.scss
@@ -37,6 +37,8 @@ $color-gray-lightest: #f1f1f1; // Adding bc used in our $border-light in this fi
 $color-gray-hover:    #fafafa;
 $color-gray-divider:  #bbbbbb;
 
+$color-gray-border:   #5b616b;
+
 // Spacing
 $spacer-margins:     0.5rem;
 $grid-margins:       100px;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -60,6 +60,7 @@
 @import "_components/image-adjustments";
 @import "_components/nav-subnav";
 @import "_components/oembed";
+@import "_components/search";
 @import "_components/section-contact-cta";
 @import "_components/skipnav";
 


### PR DESCRIPTION
Fixes issue(s) #3046

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[`/blog` PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/apburnes-blog-post-adjustment/blog)

Changes proposed in this pull request:
- Update related blog classes margin to `!important`
  - FYI, The update to USWDS uses class selectors ie `.usa-grid :first-child` which overrides the related blog classes margins

To Review:
- View the layout for the blog and blog posts
- View the [search input](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/apburnes-blog-post-adjustment/search/?q=hello)