### PR TITLE
Fix broken link in PULL_REQUEST_TEMPLATE

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Changes proposed in this pull request:
 -
 
 Checklist:
-- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**
+- [ ] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**
 
 
 /cc @relevant-people


### PR DESCRIPTION
Changes proposed in this pull request:
- This fixes a broken link in the pull request template. 
  + As you can see in the "Checklist" section below, the link to learn more about how to optimize images is currently being parsed as a relative path within GitHub. 
  + This PR updates the link URL to point to the styleguide hosted within the blog.  


Checklist:
- [ ] All images being added have been optimized **_--> [learn more](18f.gsa.gov/styleguide/images/#using-and-optimizing-jpg-and-png) about how to optimize images <--_**
