### PR TITLE
Make "part one" and "part two" links more legible in PM Perspective posts

### DIFF
--- a/_posts/2019-08-22-building-product-management-capacity-in-government-part-1.md
+++ b/_posts/2019-08-22-building-product-management-capacity-in-government-part-1.md
@@ -18,7 +18,7 @@ image: /assets/blog/product-guide/product-manager.jpg
 *This is the kick-off post in a in a series of posts about building
 product management capacity in government agencies. The series explores
 the process of helping agency staff transition into product management
-roles, from both an 18F and partner [agency perspective](https://18f.gsa.gov/2019/11/19/building-product-management-capacity-in-government-part-2/).*
+roles, from both the 18F perspective and [partner agency perspective (part two)](https://18f.gsa.gov/2019/11/19/building-product-management-capacity-in-government-part-2/).*
 
 While standard practice in the private sector, product management is
 still in its infancy in the government. We believe that [government needs product managers](https://medium.com/the-u-s-digital-service/the-importance-of-product-management-in-government-b59933d01874)

--- a/_posts/2019-11-19-building-product-management-capacity-in-government-part-2.md
+++ b/_posts/2019-11-19-building-product-management-capacity-in-government-part-2.md
@@ -12,7 +12,7 @@ excerpt: "This is part two in a series of posts about building product managemen
 image: /assets/blog/product-guide/product-manager.jpg
 ---
 
-*This is part two in a series of posts about building product management capacity in government agencies. The series explores the process of helping agency staff transition into product management roles, from both the [18F](https://18f.gsa.gov/2019/08/22/building-product-management-capacity-in-government-part-1/) and partner agency perspective. For this post, we chatted with Jerome Lee of the Centers for Medicare & Medicaid Services about his experience as a product manager on our current project. These are Jerome's opinions and are not official views of the Centers for Medicare & Medicaid Services or the US Public Health Service.*
+*This is part two in a series of posts about building product management capacity in government agencies. The series explores the process of helping agency staff transition into product management roles, from both the [18F perspective (part one)](https://18f.gsa.gov/2019/08/22/building-product-management-capacity-in-government-part-1/) and partner agency perspective. For this post, we chatted with Jerome Lee of the Centers for Medicare & Medicaid Services about his experience as a product manager on our current project. These are Jerome's opinions and are not official views of the Centers for Medicare & Medicaid Services or the US Public Health Service.*
 
 We chatted with Jerome Lee of the Centers for Medicare & Medicaid Services (CMS) about our work helping CMS streamline the funding application process for state Medicaid agencies seeking money to improve their IT systems.
 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:

- I was reading these two blog posts today, and I couldn't find the links to go between the two parts. I then figured out they were hiding in the "18F" and "agency perspective" links in the introductory paragraph. I expect a link to "18F" to go to the 18F website, so I didn't think to click it. This change makes the link text more obvious.

/cc @Dahianna 