### PR TITLE
add og image to metatags if no page image

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,6 +63,7 @@
 {% else %}
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="{{ siteurl }}{{ site.baseurl }}/assets/img/logos/18F-Logo-M.png">
+  <meta name="og:image" content="{{ siteurl }}{{ site.baseurl }}/assets/img/logos/18F-Logo-M.png">
 {% endif %}
 
 <!-- Author -->


### PR DESCRIPTION
this will allow the 18f logo to populate on linkedin and Facebook if a specific page doesn't have an image

Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/lg/metatag-image-1)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- update meta og title to work on FB /linkedin if there isn't a page image

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**


/cc @relevant-people
