### PR TITLE
Update sitemap.xml URL to 18f.gsa.gov

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ description: "18F builds effective, user-centric digital services focused on the
 baseurl: "" # the subpath of your site, e.g. /blog
 permalink: pretty
 url: "https://18f.gsa.gov" # the base hostname & protocol for your sites
-federalist_url: "https://federalist.18f.gov"
 localhost: "localhost:4000"
 env: "production"
 logo: /assets/img/logos/18F-Logo-Bright-S.png

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,12 +4,10 @@
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
   {% if site.url %}
-    {% if site.baseurl == "" %}
-      {% assign site_url = site.url | append: site.baseurl %}
-    {% elsif site.baseurl == '/site' %}
+    {% if site.baseurl == '/site' %}
       {% assign site_url = site.localhost | append: site.baseurl %}
     {% else %}
-      {% assign site_url = site.federalist_url | append: site.baseurl %}
+      {% assign site_url = site.url | append: site.baseurl %}
     {% endif %}
   {% else %}
     {% assign site_url = site.github.url %}


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/18f.gsa.gov/issues/3142

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/bh-sitemap-url/)

Changes proposed in this pull request:
- Removes the `federalist_url` config option (it's only being used for sitemap generation)
- Uses `site.url` instead to reflect 18f.gsa.gov in sitemap.xml

/cc @apburnes 