### PR TITLE
Fix mobile menu accessibility, focus issues

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="site-navbar usa-grid">
-    <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Menu</button>
+    <button class="menu-btn" aria-expanded="false">Menu</button>
     <a class="site-logo media_link" href="{{ site.baseurl }}/">
       <img src="{{ site.baseurl }}/assets/img/logos/18f-logo.svg" alt="18F logo"
       {% if page.url == '/' %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="site-navbar usa-grid">
-    <button class="menu-btn">Menu</button>
+    <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Menu</button>
     <a class="site-logo media_link" href="{{ site.baseurl }}/">
       <img src="{{ site.baseurl }}/assets/img/logos/18f-logo.svg" alt="18F logo"
       {% if page.url == '/' %}

--- a/_includes/navigation/drawer.html
+++ b/_includes/navigation/drawer.html
@@ -1,8 +1,8 @@
 {% assign nav_class_suffix = include.nav_class_suffix | default: '' %}
 
 
-<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation">
-  <button class="sliding-panel-close{{ nav_class_suffix }}">
+<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation" aria-label="site navigation">
+  <button class="sliding-panel-close{{ nav_class_suffix }}" aria-label="close navigation menu">
     {% include svg/icons/close.svg %}
   </button>
 

--- a/_includes/navigation/drawer.html
+++ b/_includes/navigation/drawer.html
@@ -1,7 +1,7 @@
 {% assign nav_class_suffix = include.nav_class_suffix | default: '' %}
 
 
-<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation" aria-label="site navigation">
+<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation" id="sitenav" aria-label="site navigation" tabindex="-1">
   <button class="sliding-panel-close{{ nav_class_suffix }}" aria-label="close navigation menu">
     {% include svg/icons/close.svg %}
   </button>

--- a/_includes/navigation/drawer.html
+++ b/_includes/navigation/drawer.html
@@ -1,7 +1,7 @@
 {% assign nav_class_suffix = include.nav_class_suffix | default: '' %}
 
 
-<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation" id="sitenav" aria-label="site navigation" tabindex="-1">
+<nav class="nav-accordion nav-mobile{{ nav_class_suffix }}{% if include.nav_sticky %} sticky {% endif %}" role="navigation" aria-label="site navigation" tabindex="-1">
   <button class="sliding-panel-close{{ nav_class_suffix }}" aria-label="close navigation menu">
     {% include svg/icons/close.svg %}
   </button>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -33,7 +33,7 @@ $(function (){
 
   function trapFocus(event) {
     var wrapper = event.currentTarget,
-      tabbables = Array.prototype.slice.call(wrapper.querySelectorAll(TABBABLE_SELECTOR)),
+      tabbables = [].slice.call(wrapper.querySelectorAll(TABBABLE_SELECTOR)),
       index = tabbables.indexOf(event.target),
       isReverse = event.shiftKey,
       nextTarget;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -27,7 +27,7 @@ $(function (){
   function toggleMenu(isOpen) {
     $('.nav-mobile, .overlay').toggleClass('is-visible', isOpen);
     $('.menu-btn').attr('aria-expanded', isOpen);
-    var focusTarget = $(isOpen ? '#sitenav' : '.menu-btn');
+    var focusTarget = $(isOpen ? '.nav-mobile' : '.menu-btn');
     focusTarget.focus();
   }
 
@@ -63,7 +63,7 @@ $(function (){
     e.preventDefault();
   });
 
-  $('#sitenav').on('keydown', function(event) {
+  $('.nav-mobile').on('keydown', function(event) {
     switch (event.which) {
       case 27: // Escape
         toggleMenu(false);

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,9 @@ $(function (){
   // Drawer
   $('.menu-btn, .overlay, .sliding-panel-close').on('click touchstart', function (e) {
     $('.nav-mobile, .overlay').toggleClass('is-visible');
+    $('.menu-btn').attr('aria-expanded', function (i, attr) {
+      return attr == 'true' ? 'false' : 'true'
+    });
     var overlay = document.getElementById('sitenav');
     overlay.focus();
     e.preventDefault();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,5 +1,19 @@
 /* eslint-env jquery */
 $(function (){
+  var TABBABLE_SELECTOR = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '[tabindex="0"]',
+    '[contenteditable]'
+  ].join();
+
   // Onclick window location handler
   $('.card-link').on('click', function(e) {
     var url = $(this).data().href;
@@ -10,14 +24,17 @@ $(function (){
     }
   });
 
+  function toggleMenu(isOpen) {
+    $('.nav-mobile, .overlay').toggleClass('is-visible', isOpen);
+    $('.menu-btn').attr('aria-expanded', isOpen);
+    var focusTarget = $(isOpen ? '#sitenav' : '.menu-btn');
+    focusTarget.focus();
+  }
+
   // Drawer
   $('.menu-btn, .overlay, .sliding-panel-close').on('click touchstart', function (e) {
-    $('.nav-mobile, .overlay').toggleClass('is-visible');
-    $('.menu-btn').attr('aria-expanded', function (i, attr) {
-      return attr == 'true' ? 'false' : 'true'
-    });
-    var overlay = document.getElementById('sitenav');
-    overlay.focus();
+    var isCurrentlyOpen = $('.nav-mobile').hasClass('is-visible');
+    toggleMenu(!isCurrentlyOpen);
     e.preventDefault();
   });
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -38,6 +38,14 @@ $(function (){
     e.preventDefault();
   });
 
+  $('#sitenav').on('keydown', function(event) {
+    switch (event.which) {
+      case 27: // Escape
+        toggleMenu(false);
+        break;
+    }
+  });
+
   // Styleguide drawer
   $('.menu-btn-styleguide, .sliding-panel-close-styleguide').on('click touchstart', function (e) {
     $('.nav-mobile-styleguide').toggleClass('is-visible');

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,8 @@ $(function (){
   // Drawer
   $('.menu-btn, .overlay, .sliding-panel-close').on('click touchstart', function (e) {
     $('.nav-mobile, .overlay').toggleClass('is-visible');
+    var overlay = document.getElementById('sitenav');
+    overlay.focus();
     e.preventDefault();
   });
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -31,6 +31,31 @@ $(function (){
     focusTarget.focus();
   }
 
+  function trapFocus(event) {
+    var wrapper = event.currentTarget,
+      tabbables = Array.prototype.slice.call(wrapper.querySelectorAll(TABBABLE_SELECTOR)),
+      index = tabbables.indexOf(event.target),
+      isReverse = event.shiftKey,
+      nextTarget;
+
+    // Focus may be on the container, which should be treated as equivalent to
+    // being at the first element if pressing Shift+Tab.
+    index = Math.max(index, 0);
+
+    if (isReverse && index === 0) {
+      // Shift focus to last tabbable when shift-tabbing from beginning
+      nextTarget = tabbables[tabbables.length - 1];
+    } else if (!isReverse && index === tabbables.length - 1) {
+      // Shift focus to first tabbable when tabbing from end
+      nextTarget = tabbables[0];
+    }
+
+    if (nextTarget) {
+      nextTarget.focus();
+      event.preventDefault();
+    }
+  }
+
   // Drawer
   $('.menu-btn, .overlay, .sliding-panel-close').on('click touchstart', function (e) {
     var isCurrentlyOpen = $('.nav-mobile').hasClass('is-visible');
@@ -42,6 +67,10 @@ $(function (){
     switch (event.which) {
       case 27: // Escape
         toggleMenu(false);
+        break;
+
+      case 9: // Tab
+        trapFocus(event);
         break;
     }
   });


### PR DESCRIPTION
Fixes #3188

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/3188-a11y-mobile-nav.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/3188-a11y-mobile-nav)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/3188-a11y-mobile-nav/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/3188-a11y-mobile-nav/README.md)

Changes proposed in this pull request:
- Adds and controls `aria-expanded` to the "Menu" button, toggled in response to mobile menu opening and closing
- Adds label to mobile menu close button
- Sets focus to mobile menu container when opened
- Sets focus to "Menu" button when mobile menu is closed
- Closes mobile menu in response to <kbd>Escape</kbd> key press
- Traps focus to mobile menu container while opened

This is the first option considered of the options outlined at https://github.com/18F/18f.gsa.gov/issues/3188#issuecomment-649727159 . Notably, this is intended more as an interim solution while work is ongoing at #3097 to incorporate and upgrade U.S. Web Design System. This is essentially a reimplementation of behavior which is already provided through USWDS, which could likely be removed once said migration is completed.

Also worth noting is that this only applies to the main website, though there is similar logic for a custom mobile navigation drawer for the [18F style guide subpage](https://18f.gsa.gov/styleguide/). It might be possible to reuse this logic there, though at a minimum it should not _break_ the behavior of this menu. The style guide website appears to place the mobile menu navigation in the DOM immediately following the menu button, so <kbd>Tab</kbd> behavior works naturally better than it does on the main website.

cc @iamjolly 