### PR TITLE
Set theme typography to Helvetica

### DIFF
--- a/_sass/_theme/_uswds-theme-typography.scss
+++ b/_sass/_theme/_uswds-theme-typography.scss
@@ -33,7 +33,7 @@ $theme-font-type-lang: false;
 $theme-font-type-mono: 'roboto-mono';
 
 // sans-serif
-$theme-font-type-sans: 'source-sans-pro';
+$theme-font-type-sans: 'helvetica';
 
 // serif
 $theme-font-type-serif: 'merriweather';
@@ -53,10 +53,10 @@ $theme-font-sans-custom-src: false;
 $theme-font-serif-custom-src: false;
 
 $theme-font-role-ui: 'sans';
-$theme-font-role-heading: 'serif';
+$theme-font-role-heading: 'sans';
 $theme-font-role-body: 'sans';
 $theme-font-role-code: 'mono';
-$theme-font-role-alt: 'serif';
+$theme-font-role-alt: 'sans';
 
 $theme-type-scale-3xs: 2;
 $theme-type-scale-2xs: 3;


### PR DESCRIPTION
Part of issue(s) https://github.com/18F/18f.gsa.gov/issues/3130 .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-d703a102-c627-4805-8934-78f5bf4c97da.app.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/ik-font-update/)

Changes proposed in this pull request:
- Change theme typography back to Helvetica to match 18F branding

Checklist:
- [x] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**


/cc @Dahianna 
