### PR TITLE
Add markdown editor to service projects content

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -200,6 +200,11 @@ collections:
       - {label: "Product Clients", name: "product_clients", widget: "list", required: false}
       - {label: "Published", name: "published", widget: "boolean", required: false}
       - {label: "Listed", name: "listed", widget: "boolean", required: false}
+      - {
+          label: "Body",
+          name: "body",
+          widget: "markdown"
+        }
   - label: Posts
     name: posts
     folder: _posts/


### PR DESCRIPTION
When a CMS editor goes to add a Service Project, there is a WSIWYG editor for the body of the page

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/18f.gsa.gov/apb-projects-markdown-1/)

Changes proposed in this pull request:
- Add markdown widget to service projects collection