### PR TITLE
custom style for sidenav hover contrast, resolves #3238

### DIFF
--- a/_sass/_components/nav-subnav.scss
+++ b/_sass/_components/nav-subnav.scss
@@ -27,6 +27,10 @@
 
 .usa-sidenav__item {
   a {
-    @include u-text('bold')
+    @include u-text('bold');
+
+    &:hover {
+      color: $color-medium-hover;
+    }
   }
 }

--- a/_sass/_theme/_uswds-theme-custom-styles.scss
+++ b/_sass/_theme/_uswds-theme-custom-styles.scss
@@ -4,3 +4,9 @@
 .background-dark .usa-button-secondary.usa-button:focus {
     color: $color-gray-lightest;
 }
+
+// Fix side nav a:hover text contrast
+
+.usa-sidenav a:hover{
+    color: #005ea2;
+}

--- a/_sass/_theme/_uswds-theme-custom-styles.scss
+++ b/_sass/_theme/_uswds-theme-custom-styles.scss
@@ -4,9 +4,3 @@
 .background-dark .usa-button-secondary.usa-button:focus {
   color: $color-gray-lightest;
 }
-
-// Fix side nav a:hover text contrast
-
-.usa-sidenav a:hover {
-  color: $color-medium-hover;
-}

--- a/_sass/_theme/_uswds-theme-custom-styles.scss
+++ b/_sass/_theme/_uswds-theme-custom-styles.scss
@@ -2,11 +2,11 @@
 // Fix hero area button:focus text contrast
 
 .background-dark .usa-button-secondary.usa-button:focus {
-    color: $color-gray-lightest;
+  color: $color-gray-lightest;
 }
 
 // Fix side nav a:hover text contrast
 
-.usa-sidenav a:hover{
-    color: #005ea2;
+.usa-sidenav a:hover {
+  color: $color-medium-hover;
 }


### PR DESCRIPTION
Fixes issue(s) #3238.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/iamjolly/fix-sidenav-hover-contrast/)

[:sunglasses: PREVIEW the About page with corrected hover link contrast](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/iamjolly/fix-sidenav-hover-contrast/about/)

Changes proposed in this pull request:
- Improve contrast of page submenu (`.sidenav a:hover`) when hovered

Screenshot of fix:
![Screen Shot 2020-09-11 at 8 55 55 AM](https://user-images.githubusercontent.com/1093423/92941936-37bbde80-f40e-11ea-9e4d-3d36ea1ebbdc.png)

