### PR TITLE
Remove padding in nav to align items

### DIFF
--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -100,3 +100,10 @@ header[role=banner] {
   }
 }
 // scss-lint:enable PropertyCount
+
+//Fix alignment of navigation items
+.usa-header--basic .usa-nav {
+  @include at-media('desktop') {
+    padding-left: 0;
+  }
+}

--- a/_sass/_theme/_uswds-theme-custom-styles.scss
+++ b/_sass/_theme/_uswds-theme-custom-styles.scss
@@ -4,11 +4,3 @@
 .background-dark .usa-button-secondary.usa-button:focus {
   color: $color-gray-lightest;
 }
-
-
-//Fix alignment of navigation items
-.usa-header--basic .usa-nav {
-  @include at-media('desktop') {
-    padding-left: 0;
-  }
-}

--- a/_sass/_theme/_uswds-theme-custom-styles.scss
+++ b/_sass/_theme/_uswds-theme-custom-styles.scss
@@ -4,3 +4,11 @@
 .background-dark .usa-button-secondary.usa-button:focus {
   color: $color-gray-lightest;
 }
+
+
+//Fix alignment of navigation items
+.usa-header--basic .usa-nav {
+  @include at-media('desktop') {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
Fixes issue(s) #3229.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-d703a102-c627-4805-8934-78f5bf4c97da.app.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/ik-nav-align/)

Changes proposed in this pull request:
- Remove left padding from the list of navigation links (`navbar`)

/cc @Dahianna and @jstrothman (just FYI since we talked about this)