### PR TITLE
Add derisking guide to guide list, fix size of ux icon

### DIFF
--- a/assets/img/guides/derisking.svg
+++ b/assets/img/guides/derisking.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 66 66" style="enable-background:new 0 0 66 66;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#00CFFF;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<desc>Created with Sketch.</desc>
+<g id="_x2A__x2A_-Sticker-Sheets">
+	<g id="sticker-sheet--all--page-4" transform="translate(-717.000000, -876.000000)">
+		<g id="icon-preview-row-copy-155" transform="translate(0.000000, 850.000000)">
+			<g id="Icon-Row">
+				<g id="icon-_x2F_-map" transform="translate(709.000000, 18.214286)">
+					<path id="Combined-Shape" class="st0" d="M30.4,64.1L9.6,72.6V17.5L30.4,9l20.8,8.5L72.1,9v55.2l-20.8,8.5L30.4,64.1z M30.4,9
+						v55.2 M51.2,17.5v55.2"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+</svg>

--- a/assets/img/guides/user-interviews-love--c.svg
+++ b/assets/img/guides/user-interviews-love--c.svg
@@ -1,17 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="56px" height="53px" viewBox="0 0 56 53" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 61.1 (89650) - https://sketch.com -->
-    <title>svg/bright/user-interviews-love--c</title>
-    <desc>Created with Sketch.</desc>
-    <g id="**-Sticker-Sheets" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g id="sticker-sheet--all--page-6" transform="translate(-713.000000, -2907.000000)" stroke="#00CFFF" stroke-width="2">
-            <g id="icon-preview-row-copy-27" transform="translate(0.000000, 2889.000000)">
-                <g id="Icon-Row--Large-icon">
-                    <g id="user-interviews-love--c" transform="translate(709.000000, 11.000000)">
-                        <path d="M5,20.2777995 C4.99507046,22.1842722 5.44049654,24.0649601 6.30003909,25.7666797 C8.37865039,29.9257021 12.6282738,32.5537587 17.2777995,32.5555578 C19.1842722,32.5605285 21.0649601,32.1151024 22.7666797,31.2555599 L31,34 L28.2555599,25.7666797 C29.1151024,24.0649601 29.5605285,22.1842722 29.5555578,20.2777995 C29.5537587,15.6282738 26.9257021,11.3786504 22.7666797,9.30003909 C21.0649601,8.44049654 19.1842722,7.99507046 17.2777995,8 L16.5555784,8 C10.3216413,8.34396238 5.34396238,13.3216413 5,19.5555784 L5,20.2777995 L5,20.2777995 Z M59,59 L59,55 C59,50.581722 55.5302068,47 51.25,47 L35.75,47 C31.4697932,47 28,50.581722 28,55 L28,59 M43.5,41 C47.6421356,41 51,37.418278 51,33 C51,28.581722 47.6421356,25 43.5,25 C39.3578644,25 36,28.581722 36,33 C36,37.418278 39.3578644,41 43.5,41 Z M21.2289065,16.7956653 C20.7354279,16.2862222 20.0659881,16 19.36794,16 C18.6698919,16 18.0004521,16.2862222 17.5069735,16.7956653 L16.999872,17.3189261 L16.4927706,16.7956653 C15.4649872,15.7351303 13.798621,15.7351303 12.7708376,16.7956653 C11.7430542,17.8562003 11.7430541,19.5756672 12.7708376,20.6362022 L13.277939,21.159463 L16.999872,25 L20.7218051,21.159463 L21.2289065,20.6362022 C21.7226169,20.1269983 22,19.436226 22,18.7159338 C22,17.9956415 21.7226169,17.3048692 21.2289065,16.7956653 Z"></path>
-                    </g>
-                </g>
-            </g>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 66 66" style="enable-background:new 0 0 66 66;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#00CFFF;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<desc>Created with Sketch.</desc>
+<g id="_x2A__x2A_-Sticker-Sheets">
+	<g id="sticker-sheet--all--page-6" transform="translate(-713.000000, -2907.000000)">
+		<g id="icon-preview-row-copy-27" transform="translate(0.000000, 2889.000000)">
+			<g id="Icon-Row--Large-icon">
+				<g id="user-interviews-love--c" transform="translate(709.000000, 11.000000)">
+					<path class="st0" d="M5,24.3c0,2.2,0.5,4.5,1.6,6.5c2.4,4.9,7.5,8,13,8c2.2,0,4.5-0.5,6.5-1.6l9.8,3.3l-3.3-9.8
+						c1.1-2,1.6-4.3,1.6-6.5c0-5.5-3.1-10.6-8-13c-2-1.1-4.3-1.6-6.5-1.6h-0.9C11.3,10.2,5.4,16.1,5,23.5V24.3L5,24.3z M69,70.3
+						v-4.8c0-5.2-4.1-9.5-9.2-9.5H41.5c-5,0-9.2,4.3-9.2,9.5v4.8 M50.6,48.9c4.9,0,8.9-4.3,8.9-9.5s-4-9.5-8.9-9.5s-8.9,4.3-8.9,9.5
+						S45.7,48.9,50.6,48.9z M24.2,20.2c-0.6-0.6-1.4-1-2.2-1s-1.6,0.3-2.2,1l-0.6,0.6l-0.6-0.6c-1.3-1.3-3.2-1.3-4.4,0
+						c-1.3,1.3-1.3,3.3,0,4.6l0.6,0.6l4.4,4.6l4.4-4.6l0.6-0.6c0.6-0.6,0.9-1.5,0.9-2.2C25.2,21.7,24.8,20.8,24.2,20.2z"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
 </svg>

--- a/pages/guides.md
+++ b/pages/guides.md
@@ -38,6 +38,15 @@ banner_cta: true
       </a>
     </div>
     <div class="graphic-list-item">
+      <a class="graphic-list-link" href="https://derisking-guide.18f.gov/">
+        <img src="{{ site.baseurl }}/assets/img/guides/derisking.svg" alt="">
+        <p class="link-arrow-right">
+          Derisking
+          {% include svg/icons/arrow-right.svg %}
+        </p>
+      </a>
+    </div>
+    <div class="graphic-list-item">
       <a class="graphic-list-link" href="https://methods.18f.gov/">
         <img src="{{ site.baseurl }}/assets/img/guides/design-methods.svg" alt="">
         <p class="link-arrow-right">


### PR DESCRIPTION
Fixes issue(s) #3244 and #3245  simultaneously, to prevent awkward alignment of the UX guide icon and title

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

👓  &nbsp; [Preview](https://federalist-d703a102-c627-4805-8934-78f5bf4c97da.app.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/ik-add-derisking/guides/)


Changes proposed in this pull request:
- Add derisking guide to the guides page, with icon
- Make the UX guide icon slightly larger

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**


/cc @Dahianna 
