### PR TITLE
Switch about to guides in header nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,8 +5,8 @@ navbar:
     - /what-we-deliver/:path/
 - text: How we work
   permalink: /how-we-work/
-- text: About
-  permalink: /about/
+- text: Guides
+  permalink: /guides/
 - text: Blog
   permalink: /blog/
   multiple_permalinks:

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -12,7 +12,6 @@ header[role=banner] {
 
       a {
         @include u-padding-y(2.5);
-        @include u-padding-x(2);
 
         color: color('gray-cool-60');
         font-weight: $theme-font-weight-bold;
@@ -99,11 +98,12 @@ header[role=banner] {
     color: color('white');
   }
 }
-// scss-lint:enable PropertyCount
 
-//Fix alignment of navigation items
-.usa-header--basic .usa-nav {
-  @include at-media('desktop') {
-    padding-left: 0;
+.usa-nav__primary > .usa-nav__primary-item {
+  a {
+    @include at-media('desktop') {
+      @include u-padding-x(1);
+
+    }
   }
 }


### PR DESCRIPTION
Fixes issue(s) # .

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/header-nav-guides.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/header-nav-guides)

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/header-nav-guides/)

Changes proposed in this pull request:
- Change about to guides link for header nav
