### PR TITLE
convert em units to rem

### DIFF
--- a/_sass/_components/blockquotes.scss
+++ b/_sass/_components/blockquotes.scss
@@ -147,18 +147,18 @@ p ~ .pquote:not(.pquote-single) {
     content: '\201C';
     color: $color-medium;
     position: absolute;
-    font-size: 3em;
+    font-size: 5.45rem;
     left: 30px;
     top: 0;
 
     @include at-media('tablet') {
-      font-size: 4em;
+      font-size: 7.25rem;
       left: 20px;
       top: -5px;
     }
 
     @include at-media('desktop-lg') {
-      font-size: 5em;
+      font-size: 9rem;
       left: 10px;
       top: -10px;
     }


### PR DESCRIPTION
Proposed fix for https://github.com/18F/18f.gsa.gov/issues/3181.

Changes proposed in this pull request:
- convert `em` units to `rem`

It appears the `em` calculation was getting misapplied in IE11 so the easiest fix I could think of is to do a simple conversion to `rem` units. However the catch is upwards of `1px` is shaved off of the quote character, depending on the screen size, since root is defined as `11px` (summarized below).

| Screen size | Intended Font Size | Proposed Font Size |
| --- | --- | --- |
| Mobile | 60px | 59.95px |
| Tablet | 80px | 79.75px |
| Desktop | 100px | 99px |

I'm not sure what your design tolerance is for changes like this so if you still need to hit the original sizes I can update the PR to do so. I can do the division right in the style declaration itself, do the math as declared variables at the top of the file then use them down below, etc. based on whatever the house style is!

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

/cc @relevant-people
