### PR TITLE
Add external link js to add icon for non gov and mil sites

### DIFF
--- a/_assets/js/external-links.js
+++ b/_assets/js/external-links.js
@@ -1,0 +1,54 @@
+(function() {
+
+  // Parse and return a domain string from a string
+  // returns null if string pattern is not a domain
+  function matchDomain(href) {
+    const hrefDomain = href.match(/^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+)/g);
+    if (!hrefDomain) return null;
+    return hrefDomain[0];
+  }
+
+  // Selects only .gov and .mil domains with true
+  // returns false is not
+  function isNonGovDomain(domain) {
+    if (!domain) return false;
+    const segments = domain.split('.');
+    const tld = segments[segments.length - 1];
+    return !(
+      (tld === 'mil') ||
+      (tld === 'gov') ||
+      (tld === 'http://localhost') ||
+      (tld === '1')
+    );
+  }
+
+  // Ignore if class has className
+  // IE use for social-link-ico
+  function anchorHasClass(element, className) {
+    return element.className.includes(className);
+  }
+
+  // Select anchor tags, filter non gov domains and add style
+  function styleExternalLinks() {
+    const anchors = document.getElementsByTagName('a');
+    const totalAnchors = anchors.length;
+
+    for (let step = 0; step < totalAnchors; step++) {
+      const a = anchors[step];
+      const isSocialLink = anchorHasClass(a, 'usa-social-link');
+      const isLogo = anchorHasClass(a, 'usa-identifier__logo');
+      const domain = matchDomain(a.href);
+      const shouldGetIcon = isNonGovDomain(domain)
+        && !isSocialLink
+        && !isLogo;
+
+      if (shouldGetIcon) {
+        a.className = a.className + ' ' + 'usa-link--external';
+        a.setAttribute('title', 'external link"')
+      }
+    }
+  }
+
+  // Run code
+  styleExternalLinks();
+})();

--- a/_config-accesslint.yml
+++ b/_config-accesslint.yml
@@ -166,6 +166,7 @@ exclude:
 - _posts/2015-08-07-technical-debt-1.md
 - _posts/2015-11-19-delivery-partnership-playbook.md
 - _posts/2016-07-11-conversation-about-static-dynamic-websites.md
+- _posts/2020-12-14-a-dashboard-for-privacy-offices.md
 - _posts/2017-08-30-what-makes-a-great-vendor-team.md
 - _posts/2016-04-25-lean-on-me-asking-for-help-on-the-content-team.md
 - _posts/2017-09-26-automated-scanning-for-sensitive-information.md
@@ -475,6 +476,7 @@ exclude:
 - _posts/2014-05-11-18f-shows-what-is-possible-in-government-with-fbopen.md
 - _posts/2014-04-01-ask-us-almost-anything.md
 - _posts/2014-09-15-say-hello-to-the-new-presidential-innovation-fellows.md
+- _posts/2020-11-23-the-key-role-of-product-owners-in-federated-data-projects.md
 - _posts/2016-04-21-checklistomania-makes-it-easy-to-keep-track-of-relative-tasks.md
 - _posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.md
 - _posts/2016-10-04-what-is-static-source-analysis.md

--- a/_config-blog.yml
+++ b/_config-blog.yml
@@ -163,6 +163,7 @@ exclude:
 - _posts/2015-08-07-technical-debt-1.md
 - _posts/2015-11-19-delivery-partnership-playbook.md
 - _posts/2016-07-11-conversation-about-static-dynamic-websites.md
+- _posts/2020-12-14-a-dashboard-for-privacy-offices.md
 - _posts/2017-08-30-what-makes-a-great-vendor-team.md
 - _posts/2016-04-25-lean-on-me-asking-for-help-on-the-content-team.md
 - _posts/2017-09-26-automated-scanning-for-sensitive-information.md
@@ -472,6 +473,7 @@ exclude:
 - _posts/2014-05-11-18f-shows-what-is-possible-in-government-with-fbopen.md
 - _posts/2014-04-01-ask-us-almost-anything.md
 - _posts/2014-09-15-say-hello-to-the-new-presidential-innovation-fellows.md
+- _posts/2020-11-23-the-key-role-of-product-owners-in-federated-data-projects.md
 - _posts/2016-04-21-checklistomania-makes-it-easy-to-keep-track-of-relative-tasks.md
 - _posts/2014-04-12-how-a-pepperoni-pizza-is-inspiring-open-government.md
 - _posts/2016-10-04-what-is-static-source-analysis.md

--- a/_config.yml
+++ b/_config.yml
@@ -205,3 +205,4 @@ jekyll_pages_api_search:
 assets:
   sources:
     - node_modules/netlify-cms/dist
+    - _assets/js

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -6,6 +6,7 @@
 <script src="{{ '/assets/js/waypoints.js' | prepend: site.baseurl  }}"></script>
 <script src="{{ '/assets/js/jekyll-pages-api-search.js' | prepend: site.baseurl  }}"></script>
 <script src="{{ '/assets/js/sticky.js' | prepend: site.baseurl  }}"></script>
+{% asset external-links.js %}
 
 <!--
   analytics for DAP, for more info visit

--- a/_sass/_theme/_uswds-theme-color.scss
+++ b/_sass/_theme/_uswds-theme-color.scss
@@ -57,7 +57,7 @@ $theme-color-accent-cool-family: false;
 $theme-color-accent-cool-lightest: false;
 $theme-color-accent-cool-lighter: false;
 $theme-color-accent-cool-light: false;
-$theme-color-accent-cool: $color-gsa-blue;
+$theme-color-accent-cool: 'blue-cool-70v';
 $theme-color-accent-cool-dark: 'blue-cool-70v';
 $theme-color-accent-cool-darker: 'blue-cool-80';
 $theme-color-accent-cool-darkest: false;


### PR DESCRIPTION
Fixes issue(s) #3132 by closing out the final piece of criteria.

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/apb-external-link-js.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/apb-external-link-js)

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/apb-external-link-js/)

Changes proposed in this pull request:
- Adds a snippet of js with `external-links.js` to add the `usa-link--external` for any non .gov or .mil links
- Ignores the `usa-social-link` icons to twitter, linkedin, and github
- Ignores the GSA logo 
