### PR TITLE
Update running local instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Run each of the following steps to get the site up and running.
 1. `git clone git@github.com:18F/18f.gsa.gov`
 2. `cd 18f.gsa.gov`
 3. `bundle install`
-4. `./serve`
+4. `npm install`
+5. `./serve`
 
 To dramatically reduce the build time, there are two commands that you can run instead of `./serve`:
 


### PR DESCRIPTION
This PR updates the readme instructions to include a step to run `npm install` when running locally. I was encountering an issue where the local server wouldn't start up because it was missing a `netlify-cms` js file. Running npm install solved the issue. 