### PR TITLE
Ik current link color

### DIFF
--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -108,7 +108,6 @@ header[role=banner] {
   }
 }
 
-
 .usa-header--basic .usa-nav__primary-item > .usa-current::after, .usa-header--basic .usa-nav__link:hover::after {
   background-color: $color-medium ;
 }

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -107,3 +107,8 @@ header[role=banner] {
     }
   }
 }
+
+
+.usa-header--basic .usa-nav__primary-item > .usa-current::after, .usa-header--basic .usa-nav__link:hover::after {
+  background-color: $color-medium ;
+}

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -108,6 +108,7 @@ header[role=banner] {
   }
 }
 
-.usa-header--basic .usa-nav__primary-item > .usa-current::after, .usa-header--basic .usa-nav__link:hover::after {
-  background-color: $color-medium ;
+.usa-header--basic .usa-nav__primary-item > .usa-current::after,
+.usa-header--basic .usa-nav__link:hover::after {
+  background-color: $color-medium;
 }


### PR DESCRIPTION
This PR adjusts the color of the bar under the current page in the navigation to an 18F brand color.
😎  &nbsp; [Preview](https://federalist-d703a102-c627-4805-8934-78f5bf4c97da.app.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/ik-current-link-color/what-we-deliver/)

The current color is `cyan-70` which is not in our brand color palette
![image](https://user-images.githubusercontent.com/52677065/103041223-9ecb5200-452a-11eb-9b77-6b11e85d2b6a.png)
 

/cc @Dahianna 
