### PR TITLE
Remove blog search bar

### DIFF
--- a/_sass/_components/blog-index.scss
+++ b/_sass/_components/blog-index.scss
@@ -25,21 +25,6 @@
   }
 }
 
-.blog-search {
-  width: 100%;
-  padding-bottom: 4.5rem;
-  margin-bottom: $paragraph-margins;
-  border-bottom: 10px solid $color-medium;
-
-  @include at-media('tablet') {
-    max-width: 29rem;
-  }
-
-  label {
-    margin-top: 0;
-  }
-}
-
 .sidebar-callout {
   background-color: color('gray-cool-5');
   margin-bottom: 4rem;
@@ -59,7 +44,8 @@
 }
 
 .sidebar-heading-topic {
-  margin-top: 2.3rem;
+  padding-top: 2.3rem;
+  border-top: 10px solid $color-medium;
 }
 
 .blog-footer {

--- a/blog/index.html
+++ b/blog/index.html
@@ -50,18 +50,6 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
     </div>
 
     <aside class="sidebar tablet:grid-col-4">
-      <div class="blog-search">
-              <form class="usa-search usa-search--small" action="{{ site.baseurl }}/search/">
-                <label for="search-field-small">Blog search</label>
-                <div role="search">
-            <input class="usa-input" id="search-field-small" type="search" name="q">
-            <button class="usa-button" type="submit">
-              <span class="usa-sr-only">Search</span>
-            </button>
-          </div>
-        </form>
-        <!-- <p><a class="link-rss" href="{{ "/feed.xml" | prepend: site.baseurl }}">RSS feed</a></p> -->
-      </div>
       <h4 class="sidebar-heading-topic">Browse by topic</h4>
       <ul>
         <li>


### PR DESCRIPTION
Fixes issue(s) #[3258](https://github.com/18F/18f.gsa.gov/issues/3258) - Happy New Year!

[![CircleCI](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/18f.gsa.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Remove blog search bar
- Remove unused style def for search bar 
- Add styling to next component down to maintain the blue border at the top of the sidebar. I used the `Contact` page as a reference but if this is wrong let me know and I will modify it. 

Checklist:
- [ ] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**


/cc @apburnes @Dahianna 
