### PR TITLE
Igorkorenfeld/ik current link color

### DIFF
--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -107,3 +107,8 @@ header[role=banner] {
     }
   }
 }
+
+.usa-header--basic .usa-nav__primary-item > .usa-current::after,
+.usa-header--basic .usa-nav__link:hover::after {
+  background-color: $color-medium;
+}


### PR DESCRIPTION
This PR adjusts the color of the bar under the current page in the navigation to an 18F brand color.

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/igorkorenfeld/ik-current-link-color/)

[Preview README for this branch](https://github.com/18F/18f.gsa.gov/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Update color of hover header links
