### PR TITLE
Update identifier logo image role to valid role

### DIFF
--- a/_includes/navigation/footer.html
+++ b/_includes/navigation/footer.html
@@ -111,7 +111,7 @@
             class="usa-identifier__logo-img"
             src="{{ site.baseurl }}{{ anchor.agency_logo }}"
             alt="GSA logo"
-            role="Logo image"
+            role="img"
           />
         </a>
       </div>


### PR DESCRIPTION
Role `Logo image` is not a valid value for `role` attribute. Use `img` instead.

See:
- https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role
- https://w3c.github.io/aria/#introroles
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
- https://designsystem.digital.gov/components/identifier/

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/aduth-identifier-img-role/)
