### PR TITLE
Update identifier logo image link to direct to GSA homepage

### DIFF
--- a/_includes/navigation/footer.html
+++ b/_includes/navigation/footer.html
@@ -106,7 +106,7 @@
   >
     <div class="usa-identifier__container">
       <div class="usa-identifier__logos">
-        <a href="javascript:void(0);" class="usa-identifier__logo">
+        <a href="https://www.gsa.gov/" class="usa-identifier__logo">
           <img
             class="usa-identifier__logo-img"
             src="{{ site.baseurl }}{{ anchor.agency_logo }}"


### PR DESCRIPTION
`javascript:void(0);` is from demo code markup for USWDS identifier component and should be substituted with the URL of the agency website. Currently, clicking the link does nothing.

See:

- https://designsystem.digital.gov/components/identifier/

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/aduth-identifier-logo-link/)