### PR TITLE
Update nokogiri to >= 1.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development do
 end
 
 group :test do
+  gem 'nokogiri', '>= 1.11.1'
   gem 'codeclimate-test-reporter', '~> 1.0.0'
   gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,11 +153,12 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.1)
     netrc (0.11.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     parallel (1.19.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -165,6 +166,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.5)
+    racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -247,6 +249,7 @@ DEPENDENCIES
   jekyll_oembed
   jemoji (>= 0.11.1)
   kramdown-parser-gfm
+  nokogiri (>= 1.11.1)
   parallel
   pry
   rack (>= 2.1.4)


### PR DESCRIPTION
Fixes issue(s) dependabot alert for nokogiri

[:sunglasses: PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/apb/update-nokogiri/)

Changes proposed in this pull request:
- Update nokogiri to `>= 1.11.1`
