### PR TITLE
Change layout of testimonials

### DIFF
--- a/_includes/testimonial.html
+++ b/_includes/testimonial.html
@@ -1,10 +1,12 @@
 <section class="usa-section grid-container testimonial">
     <div class="grid-row grid-gap">
-      <div class="tablet:grid-col-8 testimonial__body">
+      <div class="tablet:grid-offset-2 tablet:grid-col-8 testimonial__body">
         &#8220;{{ include.quote }}&#8221;
       </div>
-      <div class="tablet:grid-col-4 testimonial__attribution">
-        <img class="circle-9" src="{{ site.baseurl }}/assets/img/logos/agencies/{{ include.agency_image }}" alt="">
+    </div>
+    <div class="grid-row grid gap">
+      <div class="tablet:grid-offset-2 tablet:grid-col-6 testimonial__attribution">
+        <img class="circle-7" src="{{ site.baseurl }}/assets/img/logos/agencies/{{ include.agency_image }}" alt="">
         <p><span>&#8212; {{ include.attribution }}</span><br>
             {{ include.position }}
         </p>

--- a/_sass/_components/blockquotes.scss
+++ b/_sass/_components/blockquotes.scss
@@ -91,7 +91,6 @@ blockquote {
 
 .testimonial {
   color: color('base-darker');
-
   .testimonial__body {
     font-size: font-size('sans', 'lg');
     font-weight: 300;
@@ -99,9 +98,14 @@ blockquote {
   }
 
   .testimonial__attribution {
+    display: flex;
+    margin-top: units(2);
     font-style: italic;
     font-size: font-size('sans', 'xs');
 
+    p {
+      margin: 0 units(1.5);
+    }
     span {
       font-style: normal;
       font-weight: bold;

--- a/_sass/_components/blockquotes.scss
+++ b/_sass/_components/blockquotes.scss
@@ -106,6 +106,7 @@ blockquote {
     p {
       margin: 0 units(1.5);
     }
+    
     span {
       font-style: normal;
       font-weight: bold;

--- a/_sass/_components/blockquotes.scss
+++ b/_sass/_components/blockquotes.scss
@@ -106,7 +106,7 @@ blockquote {
     p {
       margin: 0 units(1.5);
     }
-    
+
     span {
       font-style: normal;
       font-weight: bold;


### PR DESCRIPTION
This PR changes the layout of the testimonial, moving the attribution below the quote and shifting over the quote to the center. I polled designers on Slack, and they preferred this layout over the current side by side layout. 

👓  [Preview](https://federalist-d703a102-c627-4805-8934-78f5bf4c97da.app.cloud.gov/preview/igorkorenfeld/18f.gsa.gov/testimonial/)

![Screen Shot 2021-03-16 at 11 59 56 AM](https://user-images.githubusercontent.com/52677065/111369150-195cc700-866d-11eb-84a3-f77981cb7021.png)
![Screen Shot 2021-03-16 at 11 57 46 AM](https://user-images.githubusercontent.com/52677065/111369169-1e217b00-866d-11eb-9fb3-1566618bbe04.png)

