### PR TITLE
Project template fix

### DIFF
--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -77,15 +77,17 @@ header_border: true
 
         {% if page.project_url %}
         <li>
-          <h5>See our work</div>
-          {{ page.project_url | markdownify }}
+          <h5>See our work</h5>
+          <ul class="usa-sidenav__sublist">
+            <li> {{ page.project_url | markdownify }} </li>
+          </ul>
         </li>
         {% endif %}
 
         {% if page.github_repo %}
         <li>
           <h5>See the code on GitHub</h5>
-            <ul class="{% if page.github_repo.size > 1 %}usa-sidenav__sublist{% endif %}">
+            <ul class="usa-sidenav__sublist">
             {% for repo in page.github_repo %}
               <li>{{ repo | markdownify }}</a></li>
             {% endfor %}
@@ -152,7 +154,7 @@ header_border: true
           <div class="tablet:grid-col-4">
             <a class="link-arrow-right" href="{{ site.baseurl }}/tags/{{ page.tag | slugify }}/">See all posts about this project {% include svg/icons/arrow-right.svg %}</a>
           </div>
-            
+
           {% endif %}
         </div>
         <ul class="grid-row grid-gap">

--- a/_services_projects/doj-crt-portal.md
+++ b/_services_projects/doj-crt-portal.md
@@ -13,8 +13,7 @@ tag: civil rights
 expiration_date:
 github_repo:
   - "[Project respository](https://github.com/18F/civil-rights-complaints)"
-project_url: 
-  - "[civilrights.justice.gov](https://civilrights.justice.gov/)"
+project_url: "[civilrights.justice.gov](https://civilrights.justice.gov/)"
 learn_more:
 product_clients:
 resources:


### PR DESCRIPTION
Fixes the sidebar template issue in #3386 by correcting a tag and adding the `sublist` class to most sidenav items. 

👓 &nbsp;[Federalist Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/project-template-fix/what-we-deliver/doj-crt/)

![image](https://user-images.githubusercontent.com/52677065/111527863-cb13fa80-8736-11eb-97c7-68f90fb5c67a.png)
