### PR TITLE
tag change: health and human services to public benefits

### DIFF
--- a/_posts/2016-03-22-helping-california-buy-a-new-child-welfare-system.md
+++ b/_posts/2016-03-22-helping-california-buy-a-new-child-welfare-system.md
@@ -10,7 +10,7 @@ tags:
 - rfp ghostwriting
 - state and local practice
 - modular contracting
-- health and human services
+- public benefits
 excerpt: "Through a partnership with the Department of Health and Human Services, 18F was able to work with California’s Department of Social Services and Office of Systems Integration on the replacement of California's Child Welfare System. We helped them  simplify the contracting documents and incorporate modular contracting, agile development, user-centered design, and open source practices into their project."
 image: /assets/blog/ca-child-welfare/ca-team.jpg
 ---

--- a/_posts/2016-09-20-mississippi-agile-modular-techniques-child-welfare-system.md
+++ b/_posts/2016-09-20-mississippi-agile-modular-techniques-child-welfare-system.md
@@ -9,7 +9,7 @@ tags:
 - agile
 - acquisition services
 - procurement
-- health and human services
+- public benefits
 - modern practices
 excerpt: "The State of Mississippi is about to upgrade its child welfare management system, a system used by about 1,800 state employees in 82 counties, supporting the wellbeing of about 5,000 children across the state. The system was built in the early 2000s, and the employees who use it are stymied by an inefficient interface and aging infrastructure."
 image: /assets/blog/mississippi/seal.jpg

--- a/_posts/2016-10-28-california-takes-new-approach-procurement.md
+++ b/_posts/2016-10-28-california-takes-new-approach-procurement.md
@@ -8,7 +8,7 @@ tags:
 - acquisition services
 - procurement
 - video
-- health and human services
+- public benefits
 excerpt: "The Technology Transformation Service recently held an industry day to talk to the private sector community about our vision, our projects, and how GSA and vendors can work together to bring modern digital services to the federal government. For that event, California’s Stuart Drown recorded a short video talking about 18F’s work with California on their Child Welfare System."
 image:
 ---

--- a/_posts/2016-11-14-modular-procurement-state-local-government.md
+++ b/_posts/2016-11-14-modular-procurement-state-local-government.md
@@ -10,7 +10,7 @@ tags:
 - agile
 - acquisition services
 - procurement
-- health and human services
+- public benefits
 excerpt: "Our recent work with state government agencies in California and Mississippi provides some powerful examples of how 18F’s commitment to working and learning in the open can provide enormous benefits — even to states that are not yet working directly with 18F."
 ---
 At 18F, we build things in the open.

--- a/_posts/2016-11-17-leadership-innovation-california-child-welfare-services.md
+++ b/_posts/2016-11-17-leadership-innovation-california-child-welfare-services.md
@@ -8,7 +8,7 @@ tags:
 - acquisition services
 - rfp ghostwriting
 - procurement
-- health and human services
+- public benefits
 excerpt: "This is the story of how the State of California changed direction on a $500 million IT project for Child Welfare Services. To a large degree it’s about technology. But it‘s also about leadership, changing frames for assessing risk, and relationships based on trust."
 image: /assets/blog/ca-child-welfare/ca-team.jpg
 image_figcaption: The team from the State of California, Code for America, and 18F.

--- a/_posts/2017-09-12-how-alaska-is-using-transparency.md
+++ b/_posts/2017-09-12-how-alaska-is-using-transparency.md
@@ -7,7 +7,7 @@ authors:
 tags:
 - acquisition services
 - alaska
-- health and human services
+- public benefits
 - state and local practice
 excerpt: "Alaska’s Department of Health & Social Services is working
 with the Technology Transformation Services’ Office of Acquisition on a

--- a/_posts/2018-05-22-using-agile-methods-to-improve-the-rfp-process.md
+++ b/_posts/2018-05-22-using-agile-methods-to-improve-the-rfp-process.md
@@ -8,7 +8,7 @@ tags:
 - agile
 - acquisition services
 - alaska
-- health and human services
+- public benefits
 - procurement
 - state and local practice
 excerpt: "The process of developing and issuing RFPs is often viewed as

--- a/_posts/2018-07-03-presidential-innovation-fellows-bringing-new-approaches-to-nations-biggest-challenges.md
+++ b/_posts/2018-07-03-presidential-innovation-fellows-bringing-new-approaches-to-nations-biggest-challenges.md
@@ -7,7 +7,7 @@ authors:
 tags:
 - presidential innovation fellows
 - day in the life
-- health and human services
+- public benefits
 excerpt: "As the application process for the Presidential Innovation
 Fellows (PIF) program ramps up, a number of applicants have been asking:
 What is it like to be a Presidential Innovation Fellow? Two Fellows, Dr.

--- a/_posts/2018-07-03-presidential-innovation-fellows-bringing-new-approaches-to-nations-biggest-challenges.md
+++ b/_posts/2018-07-03-presidential-innovation-fellows-bringing-new-approaches-to-nations-biggest-challenges.md
@@ -7,7 +7,7 @@ authors:
 tags:
 - presidential innovation fellows
 - day in the life
-- public benefits
+- hhs
 excerpt: "As the application process for the Presidential Innovation
 Fellows (PIF) program ramps up, a number of applicants have been asking:
 What is it like to be a Presidential Innovation Fellow? Two Fellows, Dr.

--- a/_posts/2018-10-09-implementing-rules-without-rules-engines.md
+++ b/_posts/2018-10-09-implementing-rules-without-rules-engines.md
@@ -5,7 +5,7 @@ authors:
 - ed-mullen
 tags:
 - data access
-- health and human services
+- public benefits
 - technical guides
 excerpt: "If you’re building a rules-based system, don’t assume that you
 need a separate business rules engine product. Rules can be implemented

--- a/_posts/2018-10-16-exploring-a-new-way-to-make-eligibility-rules-easier-to-implement.md
+++ b/_posts/2018-10-16-exploring-a-new-way-to-make-eligibility-rules-easier-to-implement.md
@@ -5,7 +5,7 @@ date: 2018-10-16
 authors:
 - ed-mullen
 tags:
-- health and human services
+- public benefits
 excerpt: "When federal agencies issue a policy change, say income eligibility guidelines, that policy gets communicated down to the states as text on the Federal Register or via PDF. This translation of federal policy into many state systems creates opportunities for implementation errors."
 image: /assets/blog/eligibility-rules-policy/eligibility-rules-policy.jpg
 ---

--- a/_posts/2018-10-25-modular-contracting-and-working-in-the-open.md
+++ b/_posts/2018-10-25-modular-contracting-and-working-in-the-open.md
@@ -7,7 +7,7 @@ authors:
 tags:
 - acquisition services
 - alaska
-- health and human services 
+- public benefits 
 - lessons learned
 - modular contracting
 - open source

--- a/_posts/2020-05-12-rapid-implementation-of-policy-as-code.md
+++ b/_posts/2020-05-12-rapid-implementation-of-policy-as-code.md
@@ -8,7 +8,7 @@ tags:
 - api
 - 10x
 - transformation services
-- health and human services
+- public benefits
 - rules as code
 excerpt: "No policy or rule stays the same forever. In response to a crisis, policy changes often come much faster, and stakes can be higher."
 image: /assets/blog/rapid-implementation-of-policy-as-code/header.png

--- a/_posts/2020-12-17-18f-and-tts-office-of-acquisition-award-first-assisted-acquisition.md
+++ b/_posts/2020-12-17-18f-and-tts-office-of-acquisition-award-first-assisted-acquisition.md
@@ -11,6 +11,7 @@ tags:
   - procurement
   - how we work
   - public benefits
+  - hhs
   - user research
 excerpt: The Administration for Children & Families’ Office of Family
   Assistance, TTS, and the vendor community worked together to improve the TANF

--- a/_posts/2020-12-17-18f-and-tts-office-of-acquisition-award-first-assisted-acquisition.md
+++ b/_posts/2020-12-17-18f-and-tts-office-of-acquisition-award-first-assisted-acquisition.md
@@ -10,7 +10,7 @@ authors:
 tags:
   - procurement
   - how we work
-  - health and human services
+  - public benefits
   - user research
 excerpt: The Administration for Children & Families’ Office of Family
   Assistance, TTS, and the vendor community worked together to improve the TANF

--- a/_posts/2021-03-31-18f-public-benefits-portfolio-reflects-on-the-last-year.md
+++ b/_posts/2021-03-31-18f-public-benefits-portfolio-reflects-on-the-last-year.md
@@ -5,7 +5,7 @@ authors:
   - elizabeth-ayer
   - alex-pandel
 tags:
-  - health and human services
+  - public benefits
   - user-centered design
   - data access
 excerpt: Pairing our deepening domain knowledge of the unique nuances of

--- a/_posts/2021-03-31-18f-public-benefits-portfolio-reflects-on-the-last-year.md
+++ b/_posts/2021-03-31-18f-public-benefits-portfolio-reflects-on-the-last-year.md
@@ -6,6 +6,7 @@ authors:
   - alex-pandel
 tags:
   - public benefits
+  - hhs
   - user-centered design
   - data access
 excerpt: Pairing our deepening domain knowledge of the unique nuances of

--- a/tests/schema/tags.yml
+++ b/tests/schema/tags.yml
@@ -61,7 +61,6 @@
 - guides
 - gsa
 - hackathons
-- health and human services
 - hiring
 - how we work
 - https
@@ -100,6 +99,7 @@
 - product
 - product launch
 - procurement
+- public benefits
 - public buildings service
 - pulse.cio.gov
 - rules as code

--- a/tests/schema/tags.yml
+++ b/tests/schema/tags.yml
@@ -60,6 +60,7 @@
 - gov.uk
 - guides
 - gsa
+- hhs
 - hackathons
 - hiring
 - how we work


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>

# Pull request summary
Updates requested by the Public Benefits Portfolio team due to name change from Human Services Portfolio. This PR changes the tag "health and human services" to "public benefits" in the tests/schema/tags.yml and 14 posts. Replacing tag was preferred over adding a new tag at this time. 

cc/ @Dahianna for review and approval.

