### PR TITLE
Removes non-breaking space between words

### DIFF
--- a/_posts/2021-04-01-building_a_user-centered_data_strategy.md
+++ b/_posts/2021-04-01-building_a_user-centered_data_strategy.md
@@ -40,7 +40,7 @@ Our approach to data projects is summed up in these principles: 
 
 Developing a data strategy is challenging. The ever increasing availability of powerful new data tools, and the urgent need to derive new insights from data often results in a more tactical, less strategic approach. They know they want to do something, but often their specific goals are unclear.
 
-18F works with agencies to help them understand  their current data and what they hope to achieve with it. This starts with user research, a process that helps us understand who produces and uses data. This user-centric approach ensures that agencies understand who the real users of data are, and what they actually need to do their jobs more effectively.  
+18F works with agencies to help them understand their current data and what they hope to achieve with it. This starts with user research, a process that helps us understand who produces and uses data. This user-centric approach ensures that agencies understand who the real users of data are, and what they actually need to do their jobs more effectively.  
 
 As one example, the partnership between [18F and the USGS Water Resources Mission Area](https://18f.gsa.gov/2020/08/06/doing-user-research-to-design-the-next-gen-wdfn/) partnered to understand their goals for making better use of data. They made use of the following user research questions: 
 


### PR DESCRIPTION
This post has a non-breaking space (`&nbsp;`) between words, resulting in two spaces between "understanding" and "their". This patch removes the non-breaking space and replaces it with a single space.

![Screenshot of blog post with two spaces between "understand" and "their" with inspect element showing a non-breaking space entity in the HTML output](https://user-images.githubusercontent.com/32855580/113352258-da777400-92f0-11eb-90f5-49d38e8456fa.png)
