### PR TITLE
All CMS to create new services projects pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -48,6 +48,7 @@ collections:
       - {label: "Published", name: "published", widget: "boolean"}
   - label: Services Projects
     name: services-projects
+    create: true
     folder: _services_projects/
     slug: "{{permalink}}"
     editor:


### PR DESCRIPTION
# Pull request summary
Allow the netlify CMS to create new services projects pages
