### PR TITLE
remove alt for decorative image, resolves #3523

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          # NOTE: remove space between { { here and in all below examples
-          - v1-dependencies-bundler-{ { checksum "Gemfile.lock" }}
+          - v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-bundler-
-      - run: 
+          - v2-dependencies-bundler-
+      - run:
           name: Bundle install dependencies
           command: |
             bundle config set path 'vendor/bundle'
@@ -22,18 +21,18 @@ jobs:
       - save_cache:
           paths:
             - vendor/bundle
-          key: v1-dependencies-bundler-{ { checksum "Gemfile.lock" }}
+          key: v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
 
       - restore_cache:
           keys:
-          - v1-dependencies-npm-{ { checksum "package-lock.json" }}
+          - v1-dependencies-npm-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-npm-
       - run: npm install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-npm-{ { checksum "package-lock.json" }}
+          key: v1-dependencies-npm-{{ checksum "package-lock.json" }}
       - run: bundle exec jekyll build
       - run: npm run htmlproofer
       - run:

--- a/pages/home.html
+++ b/pages/home.html
@@ -117,7 +117,7 @@ redirect_from: /developer/
             <img
               class="list-images-image"
               src="{{ partner.logo | prepend: site.baseurl }}"
-              alt="{{ partner.logo }} logo"
+              alt=""
             />
             {% if partner.agency_url %}
             <a


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>

# Pull request summary
Resolves issue described in #3523 -> unfriendly `alt` was being set on otherwise decorative images for agency logos in home page "who we've worked with" section

(Optional) Closes #3523.
<!-- If you add a number it will automatically close the issue -->

## Reminder - please do the following before assigning reviewer

Make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
