### PR TITLE
Adjust spacing and sizing on hww page

### DIFF
--- a/_sass/_templates/how-we-work.scss
+++ b/_sass/_templates/how-we-work.scss
@@ -1,6 +1,8 @@
 // How we work
 // ==========================
 
+  $hww-icon-size: 3rem;
+
   .graphic-list {
     border-top: units(1) solid color('accent-cool');
 
@@ -20,8 +22,8 @@
 
     img {
       height: 60px;
-      margin-right: 3rem;
-      width: max-content;
+      margin-right: units(3);
+      width: $hww-icon-size;
     }
 
     span {
@@ -46,10 +48,26 @@
 
 .hww-subheading {
   @include h3;
-  margin-bottom: 3rem;
-  margin-top: 0;
+  color: $color-medium;
+  margin-bottom: units(1);
+  margin-top: units(.5);
 }
 
 .section-case-studies-text {
   margin-bottom: 4rem;
+}
+
+.hww-main-content {
+  .grid-row {
+    margin-bottom: units(5);
+  }
+
+  hr {
+    margin: units(5) 0;
+    border: 1px solid color($theme-color-base-lighter)
+  }
+}
+
+.acq-intro {
+  margin-bottom: units(5);
 }

--- a/pages/how-we-work.md
+++ b/pages/how-we-work.md
@@ -16,17 +16,19 @@ content_focus: false
 
 </div>
 
----
+* * *
 
 {% capture pa-1 %}
-## Path Analysis:
+
+## Path Analysis
+
 ### Asking the right questions, solving the right problems.
 {: .hww-subheading}
 
 Each Path Analysis is customized to the needs of an agency, with the goal of moving you from identifying a problem to working on a solution. With a Path Analysis, we’ll develop an action-oriented analysis of routes to pursue, places to narrow the project's scope, and the best ways to deliver value to your users.
+
 {% endcapture %}
 
-<div class="grid-row usa-section">
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-8">
       {{ pa-1 | markdownify }}
@@ -54,17 +56,17 @@ Each Path Analysis is customized to the needs of an agency, with the goal of mov
       </ul>
     </div>
   </div>
-</div>
 
 {% capture ei-1 %}
-## Experiment & Iterate:
+
+## Experiment & Iterate
+
 ### Exploring user-centered solutions.
 {: .hww-subheading}
 
 Once your team has completed a Path Analysis, we can experiment and iterate on a solution to your problem. We'll work shoulder-to-shoulder with your team to explore the challenges your users face and develop solutions to those problems. Experiment & Iterate phases can focus on building a working product, preparing a procurement package, or training your team to take over development. This model allows you to stay in control of your budget and remain flexible.
 {% endcapture %}
 
-<div class="grid-row usa-section">
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-8">
       {{ ei-1 | markdownify }}
@@ -92,16 +94,18 @@ Once your team has completed a Path Analysis, we can experiment and iterate on a
       </ul>
     </div>
   </div>
-</div>
 
 {% capture bundle-1 %}
-## Bundle: Path Analysis + Experiment & Iterate:
+
+## Bundle: Path Analysis + Experiment&nbsp;&&nbsp;Iterate
+
 ### Assess and explore.
 {: .hww-subheading}
 
 We’ll start with a Path Analysis and move directly to an Experiment & Iterate phase (both described above) as soon as possible. With this bundle option, we are able to more flexibly move between the phases of the project, without losing momentum.
 {% endcapture %}
-<div class="grid-row grid-gap usa-section" id="bundle">
+
+<div class="grid-row grid-gap" id="bundle">
   <div class="tablet:grid-col-8" markdown="1">
     {{ bundle-1 }}
   </div>
@@ -123,60 +127,66 @@ We’ll start with a Path Analysis and move directly to an Experiment & Iterate 
   </div>
 </div>
 
----
+* * *
 
-<div class="acq-intro usa-section" markdown="1">
+<div class="acq-intro" markdown="1">
 ## Acquisitions Services
 
 Our acquisition team specializes in modern information technology – IT modernization, legacy system upgrades, software development services, and cloud services (SaaS, IaaS, and PaaS).  Our approach allows you to structure your contracts for modern software development—such as agile development— which reduces risk, increases flexibility, and awards contracts faster and **to the most** qualified industry partner(s). Members of the 18F cross-disciplinary team, which may include designers, developers, product managers, and acquisition experts, will support you throughout the lifecycle of the procurement.
+
 </div>
 
 {% capture ac-1 %}
-## Acquisition Consulting:
+
+## Acquisition Consulting
+
 ### Coaching your team through the procurement process.
 {: .hww-subheading}
 
 Your contracting officer will conduct the procurement with guidance and coaching from our team. We will work with your team to:
 
-- Conduct user research and discovery
-- Develop the procurement package and any necessary justification materials
-- Conduct a three-day acquisition workshop to draft a solicitation
-- Assist with market research, help identify qualified contractors, support Q&A, serve as advisors to the evaluation panel, and support the contractor kick-off meeting.
-- De-risk the procurement through prototyping
-- Support the contractor kick-off meeting
+-   Conduct user research and discovery
+-   Develop the procurement package and any necessary justification materials
+-   Conduct a three-day acquisition workshop to draft a solicitation
+-   Assist with market research, help identify qualified contractors, support Q&A, serve as advisors to the evaluation panel, and support the contractor kick-off meeting.
+-   De-risk the procurement through prototyping
+-   Support the contractor kick-off meeting
 
 18F can also provide post-award support for additional fees.
 {% endcapture %}
-<div class="grid-row grid-gap usa-section" id="acquisition-consulting">
+
+<div class="grid-row grid-gap" id="acquisition-consulting">
   <div class="tablet:grid-col-8" markdown="1">
     {{ ac-1 }}
   </div>
-  <div class="tablet:grid-col-4">
+  <!-- <div class="tablet:grid-col-4">
     <ul class="graphic-list">
     </ul>
-  </div>
+  </div> -->
 </div>
 
 {% capture aa-1 %}
-## Assisted Acquisition:
+
+## Assisted Acquisition
+
 ### Managing the procurement process for your team.
 {: .hww-subheading}
 
 18F will conduct the procurement and issue an award using a GSA/FAS procurement vehicle. Assisted acquisition includes all the consulting acquisition offerings, plus:
 
-- Conduct market research, solicit industry, conduct Q&A, evaluate proposals/bids, award the contract, and facilitate the contractor kick-off meeting.
-- Provide post-award management and support, which includes training your team to direct the vendor team, assess the work, and get into production
+-   Conduct market research, solicit industry, conduct Q&A, evaluate proposals/bids, award the contract, and facilitate the contractor kick-off meeting.
+-   Provide post-award management and support, which includes training your team to direct the vendor team, assess the work, and get into production
 
 In each of our projects, our teams will work to build your agency’s capacity for agile digital service delivery. We’ll empower your team to continue to do this work beyond our engagement.
 
 {% endcapture %}
-<div class="grid-row grid-gap usa-section" id="assisted-acquisition">
+
+<div class="grid-row grid-gap" id="assisted-acquisition">
   <div class="tablet:grid-col-8" markdown="1">
     {{ aa-1 }}
   </div>
-  <div class="tablet:grid-col-4">
+  <!-- <div class="tablet:grid-col-4">
     <ul class="graphic-list">
     </ul>
-  </div>
+  </div> -->
 </div>
-


### PR DESCRIPTION
# Pull request summary
This PR adjusts some of the styling issue on the current `How-we-work` page:

1.  It  aligns the text of the service offerings with the introductory text. 

2. Adds more consistent spacing and groupings of sections. Headers and subheaders are placed closer to one another and closer to the text, meanwhile there is more space between different service offerings. This way there are "units" of information, grouped together. 

3. Icons are sized down slightly so they don't run into the text

4. Remove the medium-blue lines from the sidebar for the acquisition section that currently don't have additional details about team size or duration. 

👓 &nbsp;[Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/ik-hww-styling/how-we-work/)


![image](https://user-images.githubusercontent.com/52677065/139136286-118e462a-c8a6-4531-b1d2-e118af71cbce.png)
