### PR TITLE
Allow VDP to used for testing pre-release

### DIFF
--- a/pages/vulnerability-disclosure-policy.md
+++ b/pages/vulnerability-disclosure-policy.md
@@ -29,7 +29,11 @@ We require that you:
 
 This policy applies to the following systems:
 
-* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `admin.fr.cloud.gov`, `alertmanager.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `diagrams.fr.cloud.gov`, `grafana.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `logs-platform.fr.cloud.gov`, `nessus.fr.cloud.gov`, `opslogin.fr.cloud.gov`, `prometheus.fr.cloud.gov`, `ssh.fr.cloud.gov`, `uaa.fr.cloud.gov`. Any other subdomain of cloud.gov and all customer applications are excluded from this policy (`*.app.cloud.gov` is specifically excluded, except for `federalist-proxy.app.cloud.gov`).
+* [`cloud.gov`](https://cloud.gov) and the following subdomains: `account.fr.cloud.gov`, `admin.fr.cloud.gov`, `alertmanager.fr.cloud.gov`, `api.fr.cloud.gov`, `ci.fr.cloud.gov`, `dashboard.fr.cloud.gov`, `diagrams.fr.cloud.gov`, `grafana.fr.cloud.gov`, `idp.fr.cloud.gov`, `login.fr.cloud.gov`, `logs.fr.cloud.gov`, `logs-platform.fr.cloud.gov`, `nessus.fr.cloud.gov`, `opslogin.fr.cloud.gov`, `prometheus.fr.cloud.gov`, `ssh.fr.cloud.gov`, `uaa.fr.cloud.gov`. 
+  * `*.app.cloud.gov` is excluded from this policy except for:
+    * `federalist-proxy.app.cloud.gov`
+    * any application URL for which you have signed permission and rules of engagement from the application owner and either the cloud.gov Director or cloud.gov ISSO.
+  * All other cloud.gov subdomains and all customer applications are excluded from this policy
 * [`federalist.18f.gov`](https://federalist.18f.gov)
 * [`federalist-docs.18f.gov`](https://federalist-docs.18f.gov)
 * [`federalist-proxy.app.cloud.gov`](https://federalist-proxy.app.cloud.gov)


### PR DESCRIPTION
# Pull request summary

Allows VDP and bug bounty to apply pre-release when authorized.

Tag @LindsayYoung @JJediny @rpalmer-gsa -- Can this work?

## Reminder - please do the following before assigning reviewer

- [ ] update readme
- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introduced
