### PR TITLE
Remove head.html, add meta.html

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -4,22 +4,18 @@
 <!-- site.baseurl: {{ site.baseurl }} -->
 <!-- siteurl: {{ siteurl }} -->
 
-<head>
 
 <!-- Basic Page Needs
 ================================================== -->
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="google-site-verification" content="vmVo2wbQpKGMHVpllQP7bQ0w5gICWD356VH9DNbv5f4" />
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="google-site-verification" content="vmVo2wbQpKGMHVpllQP7bQ0w5gICWD356VH9DNbv5f4" />
 
 <!-- Mobile Specific Metas
 ================================================== -->
-  <meta name="HandheldFriendly" content="True">
-  <meta name="MobileOptimized" content="320">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-<!-- Meta tags
-================================================== -->
+<meta name="HandheldFriendly" content="True">
+<meta name="MobileOptimized" content="320">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 
 <!-- Creator -->
@@ -83,26 +79,24 @@
   <meta name="keywords" content="{{ page.tags  | array_to_sentence_string }}">
 {% endif %}
 
-  <link rel="canonical" href="{{ siteurl }}{{ site.baseurl }}{{ page.url }}" />
+<link rel="canonical" href="{{ siteurl }}{{ site.baseurl }}{{ page.url }}" />
 
 <!--[if lt IE 9]>
-  <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
+<script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
+<script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
 <![endif]-->
 
 <!-- Favicons
 ================================================== -->
 
-  <!--  Touch icon for iOS 2.0+ and Android 2.1+ -->
-  <link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/assets/img/favicons/18F-Logo-152.png">
+<!--  Touch icon for iOS 2.0+ and Android 2.1+ -->
+<link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/assets/img/favicons/18F-Logo-152.png">
 
-  <!--  Desktop icon -->
-  <link rel="icon" href="{{ site.baseurl }}/assets/img/favicons/18F-Logo-152.png" type="image/png">
+<!--  Desktop icon -->
+<link rel="icon" href="{{ site.baseurl }}/assets/img/favicons/18F-Logo-152.png" type="image/png">
 
   <!--  More info: https://github.com/audreyr/favicon-cheat-sheet -->
 
 <!-- CSS
 =================================================== -->
-
-</head>

--- a/_posts/2022-01-25-tech-talks.md
+++ b/_posts/2022-01-25-tech-talks.md
@@ -9,6 +9,7 @@ tags:
   - agency work
   - communication tools and practices
 excerpt: "Building cross-system interoperability is long-term work, but the tech talks became an early step in establishing shared understandings and contexts for OHS."
+image: /assets/blog/tech-talks/building-trust.png
 ---
 
 


### PR DESCRIPTION
# Pull request summary

This PR:

- *Removes* `_includes/head.html` which does not seem to be called anywhere, and is not overwriting anything on the uswds--jekyll template.
-  *Adds* `_includes/meta.html` which will overwrite the `_includes/meta.html` from the [uswds-jekyll template](https://github.com/18F/uswds-jekyll/blob/main/_includes/meta.html). The basic uswds-jekyll metadata does not include social thumbnail details.
- Updates the image of my blog post to be the header image so it will be read in as the thumbnail image

Note: I am not 100% sure that the `head.html` file is not called anywhere, since I am not very familiar with Jekyll. It would be good if someone more familiar with it would give this a review!

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introduced
