### PR TITLE
Adds padding and italics to blockquote elements

### DIFF
--- a/_sass/_components/blockquotes.scss
+++ b/_sass/_components/blockquotes.scss
@@ -2,7 +2,8 @@ $banner-line-height: 1.4;
 
 blockquote {
   border-left: 4px solid color('gray-cool-5');
-
+  padding-left: .7rem;
+  font-style: italic;
 
   cite {
     display: inline;


### PR DESCRIPTION
I noticed blockquote styling is uncomfortably cramped with the left border, and would benefit from padding and typographic styling. 

This pull request:

- adds padding between the blockquote border and the text
- applies italic styling to blockquotes for typographic differentiation

## Current
![Screenshot of ADA webpage showing a heading of writing for action and flexibility and a quote block with a gray left border right up against the text](https://user-images.githubusercontent.com/32855580/178903719-183d162a-2e84-42b7-8859-f8a486da4a83.png)

## This PR
![Screenshot of ADA webpage showing a heading of writing for action and flexibility and a quote block with a gray left border with padding that separates it from the text, and quote text in italic styling](https://user-images.githubusercontent.com/32855580/178903953-73f9e59b-c4d6-43ed-8aae-4d5ed84d1a6a.png)


[🔍 PREVIEW](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.app.cloud.gov/preview/18f/18f.gsa.gov/rj-blockquote/2022/07/13/content-design-ada/)