### PR TITLE
New Blog Post: Senior executives part 3

### DIFF
--- a/_authors/stacy-dion.md
+++ b/_authors/stacy-dion.md
@@ -1,0 +1,7 @@
+---
+name: stacy-dion
+first_name: Stacy
+last_name: Dion
+full_name: Stacy Dion
+published: true
+---

--- a/_posts/2022-08-09-senior-executives-pt3.md
+++ b/_posts/2022-08-09-senior-executives-pt3.md
@@ -1,0 +1,25 @@
+---
+title: "Senior executives part 3: Use short-term initiatives to build confidence in long-term decisions"
+date: 2022-08-09
+authors:
+  - colin-murphy
+  - stacy-dion
+  - allison-press
+  - jeffrey-durland
+tags:
+  - senior executives
+  - stakeholder management
+  - modern practices
+  - agile
+excerpt: "Major technology decisions are driven by deadlines. They can force you to make long-term decisions without much certainty they’ll be successful. In the grand scheme, it doesn’t take much time to seek understanding and be confident in these decisions. This is part three in a series on how senior executives and tech teams can be better allies."
+---
+_This series examines how teams need to work closer with senior executives as allies. ([see part 1]({{site.baseurl}}/2022/07/20/senior-executives-pt1/))_
+
+In the typical planning and budgeting process, senior executives are forced to plan and budget far in advance. That means they have to make big technology decisions without knowing if a solution works for them and for users. **Shorter time frames allow senior executives and product teams to reduce risk** ([see part 2]({{site.baseurl}}/2022/08/02/senior-executives-pt2/) for a definition of a product team). By using an alternative type of contract called a time and material contract (T&M) and working closely on prototyping sprints, executives can evaluate whether a project should continue, pivot, or stop. 
+
+**Instead of buying an entire new system and planning before testing it, product teams should spend 4–6 weeks prototyping a solution with a real use case.** This will enable you to test out criteria or critical functions. Prototypes are built to explore components, capabilities, and limitations of a system, not for production use. Prototyping is not requirements gathering, which is the process of defining all of the necessary features upfront. They focus on 1-2 specific use cases in order to test with real data and critical scenarios. Examples from past work include: 
+* For beta.ada.gov, we created [a prototyping environment](https://github.com/18F/ada-sandbox) using the US Web Design System to test the feasibility and impact of redesigning their content
+* For the Administrative Office (AO) of the US Courts, [we prototyped an API](https://github.com/18F/aocourts-api) that could interface with their existing systems
+* For the DOJ's knowledge management system, we tested the entire content governance process of writing, formatting, reviewing, editing, publishing using travel guidance as an example, in order to compare our two options – a custom, static site and sharepoint
+
+**Once you’ve decided on the best technical approach for the initiative, you can maintain control of delivery by using a T&M contract that doesn’t go beyond three years.** A T&M contract pays vendors based on specified hourly rates and the cost of materials, rather than, for example, a fixed price for an entire large project. As noted in the [18F De-risking Guide](https://derisking-guide.18f.gov/), a traditional government fear of T&M contracts is that costs spin out of control, but an empowered product owner and team can reduce this risk through frequent communication and inspection of performance against a quality assurance surveillance plan ([QASP](https://derisking-guide.18f.gov/qasp/)). Agencies may incrementally fund a T&M contract, so vendors have an incentive to keep demonstrating value. All of this enables senior executives, the product team, contracting officer, and information security office (ISO) to align continuously on the direction, cost, and success of your initiative.

--- a/_posts/2022-08-11-senior-executives-pt3.md
+++ b/_posts/2022-08-11-senior-executives-pt3.md
@@ -1,6 +1,6 @@
 ---
 title: "Senior executives part 3: Use short-term initiatives to build confidence in long-term decisions"
-date: 2022-08-09
+date: 2022-08-11
 authors:
   - colin-murphy
   - stacy-dion

--- a/_posts/2022-08-11-senior-executives-pt3.md
+++ b/_posts/2022-08-11-senior-executives-pt3.md
@@ -11,7 +11,7 @@ tags:
   - stakeholder management
   - modern practices
   - agile
-excerpt: "Major technology decisions are driven by deadlines. They can force you to make long-term decisions without much certainty they’ll be successful. In the grand scheme, it doesn’t take much time to seek understanding and be confident in these decisions. This is part three in a series on how senior executives and tech teams can be better allies."
+excerpt: "Deadlines often force executives to make long-term decisions about technology without certainty it’ll be successful. Modern software development strategies help reduce this risk by leveraging a product team to incrementally test software upfront. This is part three in a series on how senior executive and tech teams can be better allies."
 ---
 _This series examines how teams need to work closer with senior executives as allies. ([see part 1]({{site.baseurl}}/2022/07/20/senior-executives-pt1/))_
 


### PR DESCRIPTION
# Pull request summary
Creates a new post for the blog entitled Senior executives part 3: use short-term initiatives to build confidence in long-term decisions

@jstrothman date for publication is set for tomorrow, 08/09/2022. If that changes the file name and the meta data will need to be updated.

Make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
