### PR TITLE
Modernize footer links and link text

### DIFF
--- a/_data/usa_anchor.yml
+++ b/_data/usa_anchor.yml
@@ -27,3 +27,5 @@ anchor_data:
       budget_performance_url: "https://www.gsa.gov/reference/reports/budget-performance"
       accessibility_url: "https://www.gsa.gov/website-information/accessibility-aids"
       usagov_contact_url: "https://www.usa.gov/contact"
+      about_gsa_url: "https://www.gsa.gov/about"
+      privacy_policy_url: "https://www.gsa.gov/website-information/website-policies#privacy"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -134,46 +134,64 @@
         <li class="usa-identifier__required-links-item">
           <a
             class="usa-identifier__required-link usa-link"
-            href="{{ anchor.fraud_waste_abuse_url }}"
-            title="Report fraud, waste, or abuse to the Office of the Inspector General"
+            href="{{ anchor.about_gsa_url }}"
+            title="About GSA"
           >
-            Report fraud, waste, or abuse to the Office of the Inspector General
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a
-            class="usa-identifier__required-link usa-link"
-            href="{{ anchor.foia_request_url }}"
-            title="Submit a Freedom of Information Act (FOIA) request"
-          >
-              Submit a Freedom of Information Act (FOIA) request
-          </a>
-        </li>
-        <li class="usa-identifier__required-links-item">
-          <a
-            class="usa-identifier__required-link usa-link"
-            href="{{ anchor.budget_performance_url }}"
-            title="View budget and performance reports"
-          >
-              View budget and performance reports
+            About GSA
           </a>
         </li>
         <li class="usa-identifier__required-links-item">
           <a
             class="usa-identifier__required-link usa-link"
             href="{{ anchor.accessibility_url }}"
-            title="View accessibility statement"
+            title="Accessibility support"
           >
-            View accessibility statement
+            Accessibility support
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a
+            class="usa-identifier__required-link usa-link"
+            href="{{ anchor.foia_request_url }}"
+            title="FOIA requests"
+          >
+            FOIA requests
           </a>
         </li>
         <li class="usa-identifier__required-links-item">
           <a
             class="usa-identifier__required-link usa-link"
             href="{{ anchor.no_fear_act_url }}"
-            title="View No FEAR Act data"
+            title="No FEAR Act data"
           >
-            View No FEAR Act data
+            No FEAR Act data
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a
+            class="usa-identifier__required-link usa-link"
+            href="{{ anchor.fraud_waste_abuse_url }}"
+            title="Office of the Inspector General"
+          >
+            Office of the Inspector General
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a
+            class="usa-identifier__required-link usa-link"
+            href="{{ anchor.budget_performance_url }}"
+            title="Performance reports"
+          >
+             Performance reports
+          </a>
+        </li>
+        <li class="usa-identifier__required-links-item">
+          <a
+            class="usa-identifier__required-link usa-link"
+            href="{{ anchor.privacy_policy_url }}"
+            title="Privacy Policy"
+          >
+            Privacy Policy
           </a>
         </li>
       </ul>


### PR DESCRIPTION
# Summary

This changes the links in the footer to match the up-to-date requirements of GSA policy. The links match those currently showing on https://derisking-guide.18f.gov/. Included in this change is the added privacy policy link that will close #3601 .

## Reminder - please do the following before assigning reviewer

- [X] update readme
- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introduced