### PR TITLE
Add id main-content to make skip navigation work

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
       </a>
     </div>
     <div class="tablet:grid-col-8">
-      <article class="post-article" itemscope itemtype="http://schema.org/BlogPosting">
+      <article id="main-content" "class="post-article" itemscope itemtype="http://schema.org/BlogPosting">
         <header>
           <h1 itemprop="name headline">{{ page.title }}</h1>
           <p class="post-byline">


### PR DESCRIPTION
# Pull request summary

Add the `id="main-content"` to the blog post template so that the code in `_includes/skipnav.html` from the `uswds-jekyll` theme will know where to skip on the page in a blog post. 

Closes #3510.

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
