### PR TITLE
Post index image alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repository houses the 18F website. We use the [U.S. Web Design System](http
 
 The style guide, located at [18f.gsa.gov/styleguide/](https://18f.gsa.gov/styleguide/) documents the patterns and components used to create this theme.
 
+## Add a blog post
+
+See the [blogpost example file](examples/blog-post.md) for a template and instructions on how to create a new post.
+
 ## Local development
 
 __*Note:*__ _The Federalist platform does not support the use of a predefined `SHOME` environment variable which impacts the installation of the site's testing dependency [`pry`](https://github.com/pry/pry) (See the [issue](https://github.com/pry/pry/issues/2139)).  In order to build the Federalist deployment and keep the tests working in CI, a Federalist specific gemfile ([`GemfileFederalist`](./GemfileFederalist)) was created to exclude the testing and development groups during install. The Federalist script in the `package.json` is run during the build time a creates a bundler config to install the `GemfileFederalist` dependencies and not the default `Gemfile`.  Any updates to the production builds `Gemfile` should be included in the `GemfileFederalist` until a better fix is in place for the `pry` dependency or the Federalist platform._

--- a/_includes/tag-results.html
+++ b/_includes/tag-results.html
@@ -26,7 +26,7 @@
         <a class="post-click-target" href="{{ post.url | prepend: site.baseurl }}" title="link to post" tabindex="-1">
           {% if post.image.size > 0 %}
           <div class="usa-width-one-third post-excerpt">
-            <img src="{{ site.baseurl }}{{ post.image }}" alt="">
+            <img src="{{ site.baseurl }}{{ post.image }}" alt="{{post.image_alt}}">
           </div>
           <div class="usa-width-two-thirds">
           {% else %}

--- a/examples/blog-post.md
+++ b/examples/blog-post.md
@@ -10,6 +10,7 @@ tags:
 - see tests/schema/tags.yml if you need a list
 excerpt: "Excerpt, possibly lightly edited, about 300-400 characters. This should help potential readers understand what the article is about and make them want to keep reading. This will be shown on the 18F homepage, tag and author rollup pages, and sometimes project pages. You can't use any Markdown here."
 image: /assets/blog/[post-folder]/[filename]
+image_alt: Alt text for the image
 hero: false (if the image above should not be used full-width on the post page)
 published: false
 ---


### PR DESCRIPTION
# Pull request summary

Adds alt text for images on the blogpost feed page. 

(No existing issue for this bug)

- [ ] Design review

Current website:

![image](https://user-images.githubusercontent.com/2480492/187774037-55ec9c9c-71aa-4b79-b7f5-f05d8e448380.png)

Note there is no alt text for the image.
