### PR TITLE
Make whole card clickable (including image) for featured projects

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -4,7 +4,7 @@
 
 
 <li class="usa-card tablet:grid-col-4">
-  <a href="{{ card_link }}">
+  <a href="{{ card_link }}" aria-label="{{ project.title }}">
     <div class="usa-card__container shadow-2 hover:shadow-5" tabindex="-1">
       
       <header class="usa-card__header">

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -4,14 +4,15 @@
 
 
 <li class="usa-card tablet:grid-col-4">
-    <div class="usa-card__container shadow-2" tabindex="-1">
+  <a href="{{ card_link }}">
+    <div class="usa-card__container shadow-2 hover:shadow-5" tabindex="-1">
       
       <header class="usa-card__header">
         {% if project.agency %}
           <h6>{{ project.agency }}</h6>
         {% endif %}
         {% if card_link and project.title %}
-          <a href="{{ card_link }}" tabindex="-1" class="card-link-tagline"><h3 class="text-black">{{ project.title }}</h3></a>
+          <h3 class="card-link-tagline">{{ project.title }}</h3>
         {% endif %}        
       </header>
 
@@ -39,16 +40,7 @@
       <div class="usa-card__body">
         <p class="card-description">{{ project.excerpt }}</p>
       </div>
-      
-      <div class="usa-card__footer">
-        <a href="{{ card_link }}" class="link-arrow-right" tabindex="0">
-          Read more
-          <span class="usa-sr-only">about {{ project.title }}</span>
-          {% include svg/icons/arrow-right.svg %}
-        </a>
-      </div>
-
     </div>
   
-  </li>
-
+  </a>
+</li>

--- a/_sass/_components/card.scss
+++ b/_sass/_components/card.scss
@@ -4,6 +4,12 @@
     text-decoration: none;
   }
 
+  .usa-card__container:hover {
+    h3 {
+      color: $color-dark;
+    }
+  }
+
   .usa-card__img {
     height: 200px;
   }
@@ -15,7 +21,7 @@
   }
 
   h3 {
-    color: color('primary-dark');
+    color: $color-medium;
   }
 
   .usa-card__footer {

--- a/_sass/_components/card.scss
+++ b/_sass/_components/card.scss
@@ -24,6 +24,10 @@
     color: $color-medium;
   }
 
+  p.card-description {
+    color: $color-dark;
+  }
+
   .usa-card__footer {
     font-weight: bold;
     font-size: $theme-type-scale-lg;


### PR DESCRIPTION
Closes #3457 

# Pull request summary
- removes "Read More" link in card footer
- wraps entire card container in a link
- styles card H3 to look like a link
- adjusts card hover effects to denote entire card as a link

<img width="1029" alt="Screen Shot 2022-11-17 at 10 18 35 AM" src="https://user-images.githubusercontent.com/4267629/202516914-e558f584-fd47-483f-aa44-c729f1262712.png">

With right card hover:

<img width="1083" alt="Screen Shot 2022-11-17 at 11 33 35 AM" src="https://user-images.githubusercontent.com/4267629/202517109-21ddfbd2-5faf-43df-adb9-192a549e69c5.png">




## Reminder - please do the following before assigning reviewer

- [ ] update readme
- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
