### PR TITLE
Change to legacy content: remove broken oembed of tweet from private account

### DIFF
--- a/_posts/2015-07-15-openfec-api-update.md
+++ b/_posts/2015-07-15-openfec-api-update.md
@@ -102,6 +102,4 @@ To fetch the next page of results, append `last_index=230880619&last_contributor
 
 Our goal is to display as much data as possible. For the bulk of candidate and committee information, we’re displaying data starting with the 1980 cycle. For performance and expense reasons, we are limiting Schedule A and B data to the last four years. If you need older data, it is still available in the [FEC’s extensive bulk data offerings](http://www.fec.gov/finance/disclosure/ftpdet.shtml).
 
-{% oembed https://twitter.com/mheadd/status/619098677710340096 %}
-
 If you make something with the FEC API, be sure to share your creations with us on [Twitter](https://twitter.com/18f). We would like to highlight some of your great work.


### PR DESCRIPTION
# Pull request summary
The page https://18f.gsa.gov/2015/07/15/openfec-api-update/ embeds a [tweet](https://twitter.com/mheadd/status/619098677710340096) from an account which is now private. This tweet doesn't end up in the published page, but I noticed this error in a build log when using this site to test something for cloud.gov Pages:

```
INFO [build-jekyll] @branch: main @buildid: 1 @owner: 18F @repository: 18f.gsa.gov @message: OEmbedError: The url, https://twitter.com/mheadd/status/619098677710340096, is not available as an oembed. Consider using an HTML embed instead.
```
## Reminder - please do the following before assigning reviewer

- [x] update readme (N/A)
- [x] For frontend changes, ensure design review (N/A)

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
