### PR TITLE
Update get in touch button html

### DIFF
--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -8,14 +8,12 @@
       @if variable-exists(header-title) {
         color: color($header-title);
       }
-      align-items: center;
-      display: flex;
     }
 
     .usa-logo-img {
       float: left;
       height: units(3);
-      margin-right: units(1);
+      margin-right: 0;
 
       @include at-media($theme-header-min-width) {
         margin-top: 0;

--- a/_sass/_components/header.scss
+++ b/_sass/_components/header.scss
@@ -59,7 +59,12 @@
 // ---------------------------------
 
 .usa-header--basic {
+  #header-logo {
+    display: flex;
+  }
+  
   @include at-media($theme-header-min-width) {
+   
     .usa-navbar {
       position: relative;
       width: $theme-header-logo-text-width; // TODO: review this more

--- a/pages/home.html
+++ b/pages/home.html
@@ -18,11 +18,12 @@ redirect_from: /developer/
           18F partners with agencies to improve the user experience of
           government services by helping them build and buy technology.
         </h2>
-        <a class="hero__contact-button" href="{{ site.baseurl }}/contact/" tabindex="-1" class="margin-y-3 display-block">
-          <button class="usa-button usa-button--secondary usa-button--big">
+        <div class="hero__contact-button">
+          <a class="hero__contact-button usa-button usa-button--secondary usa-button--big"
+              href="{{ site.baseurl }}/contact/" tabindex="-1" class="margin-y-3 display-block">
             Get in touch
-          </button>
-        </a>
+          </a>
+        </div>
         <img class="hero__graphic" src="{{ site.baseurl }}/assets/img/homepage-graphic-2021.svg" alt="">
       </div>
     </div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,7 @@ redirect_from: /developer/
         </h2>
         <div class="hero__contact-button">
           <a class="hero__contact-button usa-button usa-button--secondary usa-button--big"
-              href="{{ site.baseurl }}/contact/" tabindex="-1" class="margin-y-3 display-block">
+              href="{{ site.baseurl }}/contact/" class="margin-y-3 display-block">
             Get in touch
           </a>
         </div>


### PR DESCRIPTION
# Pull request summary
This PR addresses a bug where the "get in touch" button and the logo click areas were extending past the boundaries of the viewable element. To solve this bug I:

- Changed an anchor tag wrapping a button element into an anchor tag with button classes and;
- Added a `display: flex` to the `header-logo` element. USWDS default header assumes a logo image with clickable text next to it; since 18F's logo does not need extra text, the alignment of the clickable element was getting messed up. 


<img width="313" alt="Screen Shot 2022-12-30 at 9 45 51 AM" src="https://user-images.githubusercontent.com/5473830/210082647-5926cd38-311b-4099-b67f-1575b8a4b6c4.png">

<img width="330" alt="Screen Shot 2022-12-30 at 9 46 12 AM" src="https://user-images.githubusercontent.com/5473830/210082678-5c3e9788-b44f-4d25-808a-d2074016c5d3.png">


(Optional) Closes #3456 

## Reminder - please do the following before assigning reviewer

- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
