### PR TITLE
Fix pa11y problems

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -35,9 +35,9 @@ sidenav:
         </div>
       {% endif %}
 
-      <main class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}" id="main-content">
+      <div class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}">
         {{ content }}
-      </main>
+      </div>
     </div>
   </div>
 </div>

--- a/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
+++ b/_posts/2014-11-17-taking-control-of-our-website-with-jekyll-and-webhooks.md
@@ -120,10 +120,6 @@ This way, we can update team names in one place and have it automatically update
 
 Finally, we can use Jekyll to generate an [RSS feed](https://18f.gsa.gov/feed.xml) for our blog so that you can plug it into your feed reader, or into powerful tools like [IFTTT](https://ifttt.com/) and [Yahoo Pipes](http://pipes.yahoo.com/pipes/).
 
-For example, the below IFTTT recipe will email you every time 18F publishes something:
-
-<a href="https://ifttt.com/view_embed_recipe/214709-a-new-18f-blog-post-email-me-a-link-to-go-read-it-right-away" target = "_blank" class="embed_recipe embed_recipe-l_63" id= "embed_recipe-214709"><img src= 'https://ifttt.com/recipe_embed_img/214709' title="IFTTT Recipe: A new 18F blog post?!" alt="IFTTT Recipe: A new 18F blog post?! Email me a link to go read it right away! connects feed to email" width="370px" style="max-width:100%"/></a><script async type="text/javascript" src="https://ifttt.com/assets/embed_recipe.js"></script>
-
 ## Automatic deployment
 
 Even though we're not using GitHub Pages, we really wanted any changes to show up on our staging and live sites immediately and automatically. Automatic deployment changes team behavior, and makes anyone feel empowered to make changes without going through a bottleneck.


### PR DESCRIPTION
# Pull request summary
The pa11y build was failing in CI. To repro the problems, I ran pa11y locally and it surfaced two different issues.

- The styleguide layout was using a `<main>` tag with an id of `main-content` nested inside a `<main>` tag coming from the `uswds-jekyll` template.
- An old blog post was using an embedded IFFT iframe that had an error. 

The fixes:

-  I changed the interior main element in `styleguide.html` into a div. It did not appear to change the layout or style of the element.
- The embedded recipe no longer exists, and if you try clicking on it you get an error. I removed the iframe element and references to it.


And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
