### PR TITLE
Add featured card box-shadow on focus

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -5,7 +5,7 @@
 
 <li class="usa-card tablet:grid-col-4">
   <a href="{{ card_link }}" aria-label="{{ project.title }}">
-    <div class="usa-card__container shadow-2 hover:shadow-5" tabindex="-1">
+    <div class="usa-card__container" tabindex="-1">
       
       <header class="usa-card__header">
         {% if project.agency %}

--- a/_sass/_components/card.scss
+++ b/_sass/_components/card.scss
@@ -5,10 +5,15 @@
   }
 
   a:focus {
-    div {
+
+    .usa-card__container {
       @include u-shadow(5);
       h3 {
         color: $color-dark;
+      }
+
+      .card-link-tagline {
+        text-decoration:underline
       }
     }
   }
@@ -21,6 +26,10 @@
     @include u-shadow(5);
     h3 {
       color: $color-dark;
+    }
+
+    .card-link-tagline {
+      text-decoration:underline
     }
   }
 

--- a/_sass/_components/card.scss
+++ b/_sass/_components/card.scss
@@ -4,7 +4,21 @@
     text-decoration: none;
   }
 
+  a:focus {
+    div {
+      @include u-shadow(5);
+      h3 {
+        color: $color-dark;
+      }
+    }
+  }
+
+  .usa-card__container {
+    @include u-shadow(2);
+  }
+
   .usa-card__container:hover {
+    @include u-shadow(5);
     h3 {
       color: $color-dark;
     }


### PR DESCRIPTION
# Pull request summary
This change:

- Moves box-shadow into css rather than via utility classes on the element directly
- Adds the box-shadow on a featured card when you tab to the element

(Optional) Closes #3642

## Reminder - please do the following before assigning reviewer

- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
