### PR TITLE
Remove read more links from featured blog posts

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -9,21 +9,13 @@ default: post.url %} {% assign hide_date = include.hide_date | default: false %}
     <p class="post-date">{{ post_date | date: "%B %-d, %Y" }}</p>
     {% endif %}
     <h3 class="featured-posts__heading">
-      <a href="{{ site.baseurl }}{{ post.url }}">{{ post_title }}
+      <a class="link-arrow-right" href="{{ site.baseurl }}{{ post.url }}">{{ post_title }}
       {% if post.series %}
         (Series: {{ post.series }})
       {% endif %}
       </a>
     </h3>
     <p>{{ post.excerpt }}</p>
-    <p>
-      <a class="link-arrow-right post-link-continue_reading" 
-        href="{{ post.url | prepend: site.baseurl }}">
-        Read more
-        <span class="usa-sr-only">about {{ post_title }}</span>
-        {% include svg/icons/arrow-right.svg %}
-      </a>
-    </p>
     {% if include.show_tags %}
     <span class="post-tags" itemprop="keywords">
       {% for tag in post.tags %}

--- a/_sass/_components/featured-posts.scss
+++ b/_sass/_components/featured-posts.scss
@@ -30,6 +30,13 @@
     a {
       text-decoration: none;
     }
+
+    h3 {
+      a:hover {
+        text-decoration: underline;
+      }
+    }
+
   }
 
   .post {


### PR DESCRIPTION
# Pull request summary

-  Removes Read More links at the bottom of featured blog posts
- Adds underline to header links when user hovers above them to make it clearer they are links

(Optional) Closes #3627

## Reminder - please do the following before assigning reviewer

- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
