### PR TITLE
Update CSS to use correct colors

### DIFF
--- a/_sass/_components/post-details.scss
+++ b/_sass/_components/post-details.scss
@@ -21,7 +21,7 @@
 }
 
 .post-author {
-  @include u-color('secondary-dark');
+  @include u-color('accent-cool');
   text-decoration: none;
 
   &:visited {
@@ -51,7 +51,7 @@
     margin-left: 0;
 
     background-color: color('gray-cool-5');
-    color: color('secondary-dark');
+    color: color('accent-cool');
     display: inline-block;
     font-size: font-size($theme-body-font-family, 'xs');
     line-height: 1;


### PR DESCRIPTION
# Pull request summary

- changes the post-author and post-tags link colors to #046B99 (["accent-cool" reference](https://github.com/18F/18f.gsa.gov/blob/main/_sass/_theme/_uswds-theme-color.scss#L80))

Closes #3410

- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
