### PR TITLE
Delete extra quote

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
       </a>
     </div>
     <div class="tablet:grid-col-8">
-      <article id="main-content" "class="post-article" itemscope itemtype="http://schema.org/BlogPosting">
+      <article id="main-content" class="post-article" itemscope itemtype="http://schema.org/BlogPosting">
         <header>
           <h1 itemprop="name headline">{{ page.title }}</h1>
           <p class="post-byline">


### PR DESCRIPTION
# Pull request summary
Removes quote typo.


# Details
"In a world where punctuation has run amok...."

[:boom: CUT TO EXPLOSIONS :boom:]

"...one stands alone..."

[CUT TO **Asterisk** (villan, surrounded by army of **Tildés**.)]

**ASTERISK**: "Rogue, your time of ending quotations are... OVER!"

[CUT TO VIEW OF REARVIEW MIRROR - CAR FLIPPING IN MID AIR, WITH **Period** SCREAMING]
 
**ROGUE QUOTE** (looking at rearview): "Consider that statement over. Period!"

"A rebel takes on the forces of the Lint Brigade."

**ROGUE QUOTE**: "Put me in, Dr A. Anywhere. I don't care. I will go unnoticed.... like a ninja shadow."  

**DR AMPERSAND**: "That's what I'm afraid of. It could be years!"

**ROGUE QUOTE**: "Even better."

[ CUT TO A HELICOPTER EXPLODING 🚁 💥 , BUILDING EXPLODING 🏨 :boom: , A SANDWICH EXPLODING. 🥪 💥 ] 

[ Music and SFX cuts out ]

**SEMICOLON**: "Can I help? ...Maybe? ...Please? ...Yes?"

**DR AMPERSAND and ROGUE TOGETHER **: "Oh... um... maybe." "We'll get back to you."

[CUT TO **Rogue** WALKING AWAY FROM SLOW MOTION EXPLOSIONS :boom: ... "]

**ASTERISK**: "I... want... EVERYTHING!"

[ CUT TO RANDOM CHARACTERS BEING SUCKED INTO **ASTERISK** ]

[ Music and SFX cuts out, cut to black screen ]

**ROGUE QUOTE**: "Can I quote you on that?"

[ Music resumes, graphics appear ]

**SPRING**

**2023**

:boom: ***ROGUE QUOTE:SYNTACTICALLY INCORRECT*** :boom:

:boom: " :bomb: & :boomerang: ; :boom: *
