### PR TITLE
Replace h4 with h2 in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="grid-container">
       <div class="grid-row grid-gap padding-y-4">
         <div class="tablet:grid-col-3">
-          <h4>Work with us</h4>
+          <h2>Work with us</h2>
           <ul class="add-list-reset">
             <li>
               <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/about/">About 18F</a>
@@ -20,7 +20,7 @@
           </ul>
         </div>
         <div class="tablet:grid-col-3">
-          <h4>Resources</h4>
+          <h2>Resources</h2>
           <ul class="add-list-reset">
             <li>
               <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/blog/">Blog</a>
@@ -34,7 +34,7 @@
           </ul>
         </div>
         <div class="tablet:grid-col-3">
-          <h4>Policies</h4>
+          <h2>Policies</h2>
           <ul class="add-list-reset">
             <li>
                 <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/linking-policy/">Linking policy</a>
@@ -51,7 +51,7 @@
           </ul>
         </div>
         <div class="tablet:grid-col-3">
-          <h4>Contact us</h4>
+          <h2>Contact us</h2>
           <ul class="add-list-reset">
             <li>
                 <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/contact/">Get in touch</a>

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -91,7 +91,7 @@ a {
 //footer
 .usa-footer {
 
-  h4 {
+  h2 {
     font-size: font-size($theme-font-role-heading, 'lg');
     margin-bottom: 1rem;
     margin-top: units(3);


### PR DESCRIPTION
# Pull request summary
Bump `h4` headings to `h2` in page footer. This corrects the hierarchy of page content.

Per the ticket: [Improper heading order for headings of the lists of links on 18F home page](https://github.com/18F/TLC-crew/issues/199)