### PR TITLE
Fix what we deliver project page a11y issues

### DIFF
--- a/_includes/side-cta.html
+++ b/_includes/side-cta.html
@@ -1,6 +1,6 @@
-<div class="bg-accent-cool margin-y-4 padding-2">
+<div class="bg-accent-cool margin-y-4 padding-2 side-cta">
       <h3>Want to see if 18F can help your agency?</h3>
       <div>
-        <a href="{{ site.baseurl }}/contact/"><button class="usa-button usa-button--secondary">Contact us</button></a>
+        <a href="{{ site.baseurl }}/contact/" class="usa-button usa-button--secondary">Contact us</a>
       </div>
   </div>

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -64,21 +64,21 @@ header_border: true
           <blockquote>
             <p>&ldquo;{{ page.quote }}&rdquo;</p>
             {% if page.quote_source %}
-              <h5>{{ page.quote_source | prepend: '– ' | markdownify }}</h5>
+              <h3>{{ page.quote_source | prepend: '– ' | markdownify }}</h3>
             {% endif %}
           </blockquote>
         {% endif %}
 
         {% if page.agency %}
         <li class="agency-partner-name">
-          <h5>Agency partner</h5>
+          <h3>Agency partner</h3>
           {{ page.agency }}
         </li>
         {% endif %}
 
         {% if page.project_url %}
         <li>
-          <h5>See our work</h5>
+          <h3>See our work</h3>
           <ul class="usa-sidenav__sublist">
             <li> {{ page.project_url | markdownify }} </li>
           </ul>
@@ -87,7 +87,7 @@ header_border: true
 
         {% if page.github_repo %}
         <li>
-          <h5>See the code on GitHub</h5>
+          <h3>See the code on GitHub</h3>
             <ul class="usa-sidenav__sublist">
             {% for repo in page.github_repo %}
               <li>{{ repo | markdownify }}</a></li>
@@ -98,7 +98,7 @@ header_border: true
 
         {% if page.product_clients.size > 0 %}
         <li>
-          <h5>Agency partners</h5>
+          <h3>Agency partners</h3>
           <ul class="{% if page.product_clients.size > 1 %}usa-sidenav__sublist{% endif %}">
           {% for client in page.product_clients %}
             <li>{{ client }}</li>
@@ -109,7 +109,7 @@ header_border: true
 
         {% if page.start_date or page.expiration_date %}
         <li>
-          <h5>When</h5>
+          <h3>When</h3>
           <div>
           {% if page.start_date and page.expiration_date %}
             {{ page.start_date }} – {{ page.expiration_date }}
@@ -124,7 +124,7 @@ header_border: true
 
         {% if page.resources.size > 0 %}
         <li>
-          <h5>Resources</h5>
+          <h3>Resources</h3>
           <ul class="{% if page.resources.size > 1 %}usa-sidenav__sublist{% endif %}">
             {% for resource in page.resources %}
               <li >{{ resource | markdownify }}</li>

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -61,14 +61,19 @@ header_border: true
     <aside class="grid-container usa-section grid-container-reversed-right tablet:grid-col-4">
       <ul class="usa-sidenav partner-info thick-accent-border">
         {% if page.quote %}
-          <blockquote>
-            <p>&ldquo;{{ page.quote }}&rdquo;</p>
+        <li>
+          <blockquote class="border-0 margin-x-0 margin-y-1 padding-x-0">
+            <p class="font-sans-md text-light text-no-italic">
+              &ldquo;{{ page.quote }}&rdquo;
+            </p>
             {% if page.quote_source %}
-              <h3>{{ page.quote_source | prepend: '– ' | markdownify }}</h3>
+            <figcaption class="font-sans-xs margin-top-1 text-bold text-base-dark">
+              {{ page.quote_source | prepend: '– ' | markdownify }}
+            </figcaption>
             {% endif %}
           </blockquote>
+        </li>
         {% endif %}
-
         {% if page.agency %}
         <li class="agency-partner-name">
           <h3>Agency partner</h3>

--- a/_sass/_components/cta.scss
+++ b/_sass/_components/cta.scss
@@ -1,0 +1,16 @@
+.side-cta .usa-button {
+  &:visited {
+    color: color('ink');
+  }
+
+  &:focus,
+  &:hover {
+    background-color: color('primary-dark'); 
+    color: color('white');
+  }
+
+  &:active {
+    background-color: color('blue-90');
+    color: color('white');
+  }
+}

--- a/_sass/_components/lists.scss
+++ b/_sass/_components/lists.scss
@@ -63,7 +63,7 @@
   }
 
   .usa-sidenav__sublist a {
-    padding: units('05') 0;
+    padding: 0 0 units(1);
     text-decoration: underline;
 
     &:hover {

--- a/_sass/_components/lists.scss
+++ b/_sass/_components/lists.scss
@@ -72,7 +72,8 @@
     }
   }
 
-  h5 {
+  h3 {
+    font-size:size('heading', 'xs');
     padding-top: units(2);
     padding-bottom: units(1);
   }

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -2,6 +2,7 @@
 // 18F site components
 @import '_components/blockquotes';
 @import '_components/card';
+@import '_components/cta';
 @import '_components/hero';
 @import '_components/lists';
 @import '_components/post-list';


### PR DESCRIPTION
# Pull request summary
This PR addresses the a11y issues noted in the [a11y audit doc](https://docs.google.com/document/d/1ijBREMLbH6a0NoWaS0BM94vc81z3mfcuJ2yNMOn4Pi0/view)

- Updates the `H5` headings in the sidebar to `H3`s while maintaining the same visual style
- Replaces the CTA mixed button and link element with button
- Moves the `blockquote` in the sidebar inside an `li` so that the `blockquote` is not a direct descendent of a `ul`

In addition the the items noted in the audit doc, this PR updates the above elements so that:
- The hover state in the CTA button contrasts more against the background
- Updates the styling of the `blockquote` so that is not so narrow in the sidebar and more closely matches the style of the quotes on the home page


Closes TLC #[217](https://github.com/18F/TLC-crew/issues/217)

👓 [Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/ik/217-wwd-a11y/) 