### PR TITLE
Removed unneeded ARIA role attributes from nav and footer elements

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="usa-footer site-footer" role="contentinfo">
+<footer class="usa-footer site-footer">
   <div class="footer-section-bottom bg-base-lightest">
     <div class="grid-container">
       <div class="grid-row grid-gap padding-y-4">
@@ -109,7 +109,6 @@
               class="usa-identifier__logo-img"
               src="{{ site.baseurl }}{{ anchor.agency_logo }}"
               alt="GSA logo"
-              role="img"
             />
           </a>
         </div>

--- a/_includes/navigation/sidenavnew.html
+++ b/_includes/navigation/sidenavnew.html
@@ -1,7 +1,7 @@
 {% assign nav_class_suffix = include.nav_class_suffix | default: '' %}
 
 
-<nav class="usa-nav nav-accordion position-fixed z-500" role="navigation" aria-label="Primary Side Navigation">
+<nav class="usa-nav nav-accordion position-fixed z-500" aria-label="Primary Side Navigation">
   <button class="usa-nav__close">
     <img src="{{ '/assets/img/close.svg' | prepend: site.baseurl }}" alt="close">
   </button>

--- a/_includes/navigation/subnav.html
+++ b/_includes/navigation/subnav.html
@@ -1,7 +1,7 @@
 {% assign subnav_items = include.subnav_items | default: page.subnav_items %}
 
 {% if subnav_items %}
-<nav role="navigation" class="subnav sticky usa-accordion" aria-label="Secondary navigation">
+<nav class="subnav sticky usa-accordion" aria-label="Secondary navigation">
   {% assign title_slug = page.title | slugify %}
   <ul class="usa-sidenav">
     <li class="usa-sidenav__item">


### PR DESCRIPTION
This PR completes TLC Ticket [#212 Remediate 18f website global a11y issues](https://github.com/18F/TLC-crew/issues/212)
Resolved last issue on ticket, the removal of unneeded ARIA `role` attributes. 
The `navigation` role was removed from the `nav` elements. The `contentinfo` role was removed from the `footer` element.