### PR TITLE
Remove "most popular" blog post widget

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -56,18 +56,6 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
         </li>
         {% endfor %}
       </ul>
-      <div class="sidebar-callout">
-        <h4>Most popular</h4>
-        <ul>
-          {% for item in featured_blog_content.promoted_posts %}
-          <li>
-            <a href="{{ site.baseurl }}{{ item.url }}">
-              {{ item.title }}
-            </a>
-          </li>
-          {% endfor %}
-        </ul>
-      </div>
       <a class="sidebar-icons media_link" href="{{ "/feed.xml" | prepend: site.baseurl }}">
         <img class="sidebar-icon-rss" src="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" alt="RSS">
       </a>


### PR DESCRIPTION
# Pull request summary
Removed "most popular" blog post widget. These aren't the most popular posts overall. The most popular posts are usually going to be very old. The top 10 posts since 2014 are from 2014-2016.

[View preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/rm-not-most-popular-blog-posts/blog/)