### PR TITLE
Updating blog sidebar links to match contact page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -47,24 +47,20 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
       </section>
     </div>
     {% assign featured_blog_content = site.data.featured_blog_content %}
-    <aside class="sidebar tablet:grid-col-4">
-      <h4 class="sidebar-heading-topic">Browse by topic</h4>
-      <ul>
-        {% for item in featured_blog_content.topics %}
-        <li>
-          <a href="{{ site.baseurl }}/tags/{{ item.tag }}">{{ item.topic }}</a>
-        </li>
-        {% endfor %}
-      </ul>
-      <a class="sidebar-icons media_link" href="{{ "/feed.xml" | prepend: site.baseurl }}">
-        <img class="sidebar-icon-rss" src="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" alt="RSS">
-      </a>
-      <a class="sidebar-icons media_link" href="https://twitter.com/18F">
-        <img class="sidebar-icon-twitter" src="{{ site.baseurl }}/assets/img/social-icons/svg/twitter16.svg" alt="Twitter">
-      </a>
-      <a class="sidebar-icons media_link" href="https://github.com/18F/">
-        <img class="sidebar-icon-github" src="{{ site.baseurl }}/assets/img/social-icons/svg/github.svg" alt="GitHub">
-      </a>
+  <aside class="usa-section tablet:grid-col-4 col-last">
+        <h4>Follow 18F</h4>
+        <ul class="usa-list usa-list--unstyled">
+          <li>
+            <!-- Inline CSS styles because these are only used this way here -->
+            <a href="https://twitter.com/18F"><img class="sidebar-icon-twitter" style="position: relative; top: 5px; left: -8px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/twitter16.svg" alt="Twitter">@18F on Twitter</a>
+          </li>
+          <li>
+            <a href="https://github.com/18F"><img class="sidebar-icon-github" style="position: relative; top: 5px; margin-right: 25px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/github.svg" alt="GitHub">18F on GitHub</a>
+          </li>
+          <li>
+            <a href="{{ site.baseurl }}/feed.xml"><img class="sidebar-icon-rss" style="position: relative; top: 5px; left: -9px; margin-right: 10px;" src="{{ site.baseurl }}/assets/img/social-icons/svg/rss25.svg" alt="RSS"/>RSS feed</a>
+          </li>
+        </ul>
     </aside>
   </div>
   </section>

--- a/blog/index.html
+++ b/blog/index.html
@@ -47,8 +47,17 @@ redirect_from: "/2016/01/12/hacking-inclusion-by-customizing-a-slack-bot/"
       </section>
     </div>
     {% assign featured_blog_content = site.data.featured_blog_content %}
-  <aside class="usa-section tablet:grid-col-4 col-last">
-        <h4>Follow 18F</h4>
+    <aside class="sidebar tablet:grid-col-4">
+      <h4 class="sidebar-heading-topic">Browse by topic</h4>
+      <ul>
+        {% for item in featured_blog_content.topics %}
+        <li>
+          <a href="{{ site.baseurl }}/tags/{{ item.tag }}">{{ item.topic }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+
+        <h4 class="sidebar-heading-topic">Follow 18F</h4>
         <ul class="usa-list usa-list--unstyled">
           <li>
             <!-- Inline CSS styles because these are only used this way here -->


### PR DESCRIPTION
Updated blog index page sidebar links. Made them consistent with the links on the contact page. This fixes the weird external link behavior.

[Review this change](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/blog-sidebar-links/blog/)
