### PR TITLE
Fix url for featured posts

### DIFF
--- a/_includes/featured-posts.html
+++ b/_includes/featured-posts.html
@@ -15,7 +15,7 @@
       {% break %} 
     {% endif %}
     <li class="grid-col-12 tablet:grid-col-6 tablet-lg:grid-col-4 margin-bottom-5 "> 
-      <a href="{{ site.baseurl }}/{{ post.url }}" class="text-no-underline">
+      <a href="{{ site.baseurl }}{{ post.url }}" class="text-no-underline">
         <h3 class="border-top-05 {{border_color}} {{ hover_color }} padding-top-3 margin-bottom-3 text-bold {{ text_color }}">
           {{ post.title }}
         </h3>


### PR DESCRIPTION
# Pull request summary
This PR removes an extra forward slash from featured posts links which was breaking the post links. 

👓 [Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/ik/fix-blog-links/)
