### PR TITLE
Fix de-risking guide links on work with us page

### DIFF
--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -115,7 +115,7 @@ Instead, we involve your team in creating solutions and ensure they have everyth
       {% include card-with-image.html 
          card_color="dark"
          image_path="/assets/img/guides/state-guide-lightest.svg"
-         link_url="https://accessibility.18f.gov/"
+         link_url="https://derisking-guide.18f.gov/state-field-guide/"
          text_content="State Software Budgeting Handbook"
       %}
       </div>
@@ -124,7 +124,7 @@ Instead, we involve your team in creating solutions and ensure they have everyth
       {% include card-with-image.html 
          card_color="dark"
          image_path="/assets/img/guides/federal-guide-lightest.svg"
-         link_url="https://agile.18f.gov/"
+         link_url="https://derisking-guide.18f.gov/federal-field-guide/"
          text_content="Federal Field Guide"
       %}
       </div>


### PR DESCRIPTION
# Pull request summary
This PR corrects the links to the two de-risking guides, which were linking to the wrong guides.

👓 [Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/ik/fix-dersiking-links)