### PR TITLE
Fix reference and link for TTS solutions

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -21,7 +21,7 @@ subnav_items:
 
 In March 2014, a group of [Presidential Innovation Fellows](https://presidentialinnovationfellows.gov/) started 18F to extend their efforts to improve and modernize government technology.
 
-In 2016, 18F became part of the [Technology Transformation Services](https://www.gsa.gov/tts) (TTS), which also includes the Presidential Innovation Fellows program, the Office of Acquisitions, the [Office of Products and Programs](https://www.gsa.gov/portal/content/124174), and the [IT Modernization Centers of Excellence](https://coe.gsa.gov/). 
+In 2016, 18F became part of the [Technology Transformation Services](https://www.gsa.gov/tts) (TTS), which also includes the Presidential Innovation Fellows program, the Office of Acquisitions, TTS [Solutions](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services/tts-solutions), and the [IT Modernization Centers of Excellence](https://coe.gsa.gov/). 
 
 In 2017, TTS became part of GSA's existing [Federal Acquisition Service](https://www.gsa.gov/about-us/organization/federal-acquisition-service).
 


### PR DESCRIPTION
# Pull request summary
This PR updates the link on the about page from the Office of Products and Programs to TTS Solutions. 

👓 [Preview](https://federalist-c58f58dc-a215-4616-a54c-12b5eb011096.sites.pages.cloud.gov/preview/18f/18f.gsa.gov/ik/fix-about-link/about/) 