### PR TITLE
Update Agile guide links

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -5,7 +5,7 @@
     dark: "/assets/img/guides/accessibility-darker.svg"
 
 - name: "Agile"
-  link: "https://agile.18f.gov"
+  link: "https://guides.18f.gov/agile/"
   image:
     light: "/assets/img/guides/agile-lightest.svg"
     dark: "/assets/img/guides/agile-darker.svg"

--- a/_posts/2018-03-13-win-big-by-going-small.md
+++ b/_posts/2018-03-13-win-big-by-going-small.md
@@ -34,7 +34,7 @@ In our work with the State of Alaska on the [overhaul of their legacy public ben
 
 ## Agile development
 
-More and more agencies report familiarity with or adoption of [agile practices](https://agile.18f.gov/), but this exposure to agile practices can sometimes be one dimensional. There may be a lack of clarity on the interconnection between some of the core ideas of agile and other strategies that agencies need to overhaul large legacy systems.
+More and more agencies report familiarity with or adoption of [agile practices](https://guides.18f.gov/agile/), but this exposure to agile practices can sometimes be one dimensional. There may be a lack of clarity on the interconnection between some of the core ideas of agile and other strategies that agencies need to overhaul large legacy systems.
 
 One of the key tenets of agile is to build in small, minimally viable increments to get working features to users more quickly, so that assumptions can be tested and feedback can be incorporated into future iterations. Breaking work down into smaller chunks helps focus a team’s efforts on delivery of specific items that have been deemed a high priority by a product owner.
 

--- a/_posts/2018-07-26-what-we-learned-from-building-a-pool-of-agile-vendors.md
+++ b/_posts/2018-07-26-what-we-learned-from-building-a-pool-of-agile-vendors.md
@@ -27,7 +27,7 @@ update their digital services.
 ## What we tried
 
 18F’s goal was to create a pool of vendors capable of delivering
-software in an [agile way](https://agile.18f.gov/). Once we selected
+software in an [agile way](https://guides.18f.gov/agile/). Once we selected
 these vendors they would be placed into a contracting vehicle called the
 Agile Delivery Services Blanket Purchase Agreement, or Agile BPA for
 short. Then, agencies could work with 18F to select vendors from this

--- a/_posts/2019-02-28-prerequisites-for-modular-contracting.md
+++ b/_posts/2019-02-28-prerequisites-for-modular-contracting.md
@@ -42,7 +42,7 @@ working effectively, and it’s easy for a new development team to pick up
 where a prior one left off. By dividing a big project into smaller,
 stand-alone projects, each of those can be completed by a single agile
 team, and those teams can even be at different vendors under different
-contracts. By having somebody within the agency serve as the [product owner](https://agile.18f.gov/agile-lexicon/#roles), and thus as the fulcrum for all work, key knowledge and decisions remain within the
+contracts. By having somebody within the agency serve as the [product owner](https://guides.18f.gov/agile/agile-lexicon/#roles), and thus as the fulcrum for all work, key knowledge and decisions remain within the
 government, making it easier to end contracts that aren’t performing,
 knowing that a replacement team can pick up where the prior one left
 off. It is crucial that agencies always be able to cancel a contract if

--- a/_posts/2020-03-10-ask-18f-po-vs-cor.md
+++ b/_posts/2020-03-10-ask-18f-po-vs-cor.md
@@ -70,7 +70,7 @@ responsibilities to a government employee’s primary job.
 
 ## What is a PO?
 
-A [product owner](https://agile.18f.gov/agile-lexicon/) is a key
+A [product owner](https://guides.18f.gov/agile/agile-lexicon/) is a key
 leadership role in agile software development that advocates for the
 business stakeholders and users to the software development team. The
 product owner must be empowered to make decisions in response to

--- a/_posts/2020-03-31-building-a-collaborative-culture.md
+++ b/_posts/2020-03-31-building-a-collaborative-culture.md
@@ -65,7 +65,7 @@ Just as we advise our partners to be agile and adaptable, we expect our
 teams to embody that adaptability.
 
 We generally espouse the tenets of the [Agile
-Manifesto](https://agile.18f.gov/) and model these behaviors to adapt
+Manifesto](https://guides.18f.gov/agile/) and model these behaviors to adapt
 to the needs, strengths, weaknesses and dynamics of the full team—both
 the 18F side and partner side—and the project itself, in order to
 deliver value to our partners.

--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -63,32 +63,16 @@ Instead, we involve your team in creating solutions and ensure they have everyth
     <h3 class="text-normal"> Feel empowered to continue with our guides</h3>
     <p class="font-sans-lg"> We want agencies to be able to do the work themselves. Here are some free guides that help. </p>
     <div class="grid-row grid-gap-md">
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
-         card_color="dark"
-         text_content="Accessibility"
-         link_url="https://accessibility.18f.gov/"
-         image_path="/assets/img/guides/accessibility-lightest.svg"
-      %}
-      </div>
-     
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
-         card_color="dark"
-         text_content="Agile"
-         link_url="https://agile.18f.gov/"
-         image_path="/assets/img/guides/agile-lightest.svg"
-      %}
-      </div>
-    
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
-         card_color="dark"
-         image_path="/assets/img/guides/content-lightest.svg"
-         link_url="https://content-guide.18f.gov/"
-         text_content="Content"
-      %}
-      </div>
+      {% for guide in site.data.guides limit:3 %}
+        <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
+          {% include card-with-image.html 
+            card_color="dark"
+            text_content=guide.name
+            link_url=guide.link
+            image_path=guide.image.light
+          %}
+        </div>
+      {% endfor %}
     </div>
    <a href="{{ site.baseurl }}/guides/" class="usa-button usa-button--outline margin-top-3">
      Browse our guides 


### PR DESCRIPTION
# Pull request summary
This PR updates the various links to the Agile guide to use the new URL/address (ie, from `agile.18f.gov` to `guides.18f.gov/agile`)

## Reminder - please do the following before assigning reviewer

- [X] update readme
- [X] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
