### PR TITLE
Fix: get pa11y running in CircleCI again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,14 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-npm-{{ checksum "package-lock.json" }}
+          - v2-dependencies-npm-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-npm-
+          - v2-dependencies-npm-
       - run: npm install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-npm-{{ checksum "package-lock.json" }}
+          key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
       - run: npm run uswds-build
       - run: bundle exec jekyll build
       - run: npm run htmlproofer

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,9 @@
+{
+    "defaults": {
+        "chromeLaunchConfig": {
+            "args": [
+                "--no-sandbox"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
# Pull request summary

- Adds a chromium headless browser config to get pa11y scanning urls in CircleCI job post ruby 3 upgrade
- Also bust dependency caches for ruby and node from the ruby 3 upgrade

Closes #3773 
