### PR TITLE
Biz dev

### DIFF
--- a/pages/AI-services.md
+++ b/pages/AI-services.md
@@ -21,7 +21,7 @@ We research and establish best practices for ethical AI usage, ensuring your AI 
 ## Learn more
 In partnership with the 18F, your agency can not only embrace AI innovation but will do so with a clear vision and strategy. Together, we will ensure that your AI initiatives lead to meaningful outcomes for your mission and the public.
 
-Learn if 18F AI services are right for you by emailing us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov).
+Learn if 18F AI services are right for you by emailing us at <a href="mailto:inquiries18F@gsa.gov">inquiries18F@gsa.gov</a>.
 {% endcapture %}
 
 <section class="usa-section bg-base-lightest section-padding-6">

--- a/pages/AI-services.md
+++ b/pages/AI-services.md
@@ -1,0 +1,37 @@
+---
+title: 18F AI Services
+permalink: /AI-services/
+lead: Emerging technology projects can go wrong fast when they become a solution in search of a problem. You may spend a lot of money on new tools only to find out they aren't the right tools for the right purpose, you won't have much to show for it. That is why 18F starts with your mission and objectives and helps you identify the emerging technologies that are going to help you achieve your goals.
+hide_footer_rule: true
+---
+{% capture body %}
+## Embark on your AI journey
+Emerging technology projects can go wrong fast when they become a solution in search of a problem. You may spend a lot of money on new tools only to find out they aren't the right tools for the right purpose, you won't have much to show for it. That is why 18F starts with your mission and objectives and helps you identify the emerging technologies that are going to help you achieve your goals.
+
+How we support your AI initiatives:
+### Use case identification
+We collaborate with you to pinpoint the most impactful applications for AI within your agency. Then we work with you to strategically pilot your new AI projects. Because we look at your success holistically, this approach combines research, implementation and change management.
+### Infrastructure recommendations
+Our team provides tailored advice on enhancing your infrastructure to support AI and data science initiatives. Having the right tools and data governance is an important first step toward implementing AI and next generation solutions.
+### AI maturity assessment
+We evaluate your current AI capabilities and offer insights to advance your maturity in the AI space. We make customized recommendations to identify new opportunities and mitigate risks.
+### Responsible AI practices
+We research and establish best practices for ethical AI usage, ensuring your AI solutions are developed with integrity. Our subject matter experts can help you codify best practices to accelerate responsible adoption of AI technologies.
+
+## Learn more
+In partnership with the 18F, your agency can not only embrace AI innovation but will do so with a clear vision and strategy. Together, we will ensure that your AI initiatives lead to meaningful outcomes for your mission and the public.
+
+Learn if 18F AI services are right for you by emailing us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov).
+{% endcapture %}
+
+<section class="usa-section bg-base-lightest section-padding-6">
+<div class="grid-container">
+  <div class="grid-row">
+    <div class="grid-col">
+      <div class="tablet-lg:grid-col-7">
+        {{ body | markdownify}}
+      </div>
+    </div>
+  </div>
+</div>
+</section>

--- a/pages/website-transformation.md
+++ b/pages/website-transformation.md
@@ -1,0 +1,38 @@
+---
+title: 18F website transformation
+permalink: /website-transformation/
+lead: Make your digital front door work for you. Your website is the primary channel for the public to learn about and interact with your agency. 18F will uplift your customer experience to ensure it is effectively advancing your mission.
+---
+
+{% capture body %}
+## Your website transformation
+By partnering with 18F, you can better understand how and why people use your website. And you can use that understanding to serve them more effectively.
+
+18F specializations Include:
+- <b>Digital strategy and modernization.</b> Leveraging the latest technologies to transform federal services, making them more accessible and efficient for all.
+- <b>User experience design.</b> Crafting digital services with empathy and precision to ensure inclusivity and clarity for users from all walks of life.
+- <b>IDEA Act compliance and advancement.</b> Not only meeting the requirements of the 21st Century IDEA but also pioneering beyond them to set new benchmarks for digital service delivery.
+- <b>Content architecture and governance.</b> Structuring information architecture to facilitate intuitive navigation and robust governance across digital platforms.
+- <b>Visual design and branding.</b> Establishing a visual identity that fosters trust and reflects the government's dedication to serving the public.
+- <b>Usability research and data-driven assessments.</b> Conducting comprehensive research to understand public needs, employing data to enhance the quality and effectiveness of services.
+
+By engaging with 18F, partners gain access to a specialized team focused on the nuances of customer experience in the digital realm, backed by the broad experience and resources of 18F. Together, we create the best outcomes for your mission and the people you serve.
+
+Learn if 18F Web Transformation services are right for you by emailing us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov).
+{% endcapture %}
+
+
+{% include testimonial.html
+    quote="18F helped accelerate modernization of waterdata.usgs.gov, which has been serving real-time water data since 1995! The techniques we learned from 18F have become embedded in our software development approach. When we first started working with 18F, I didn’t realize how profound the impact would be on our team. I thought we just needed some knowledge transfer... We’ve embedded these methods into our software development to reduce the risk of IT investment and learn more about users and technology."
+    attribution="Emily Read"
+    position="Chief for the Web Communications"
+    organization="USGS Water Resources"
+    agency_image=""
+%}
+<section class="usa-section section-padding-6">
+<div class="grid-container">
+  <div>
+    {{ body | markdownify}}
+  </div>
+</div>
+</section>

--- a/pages/website-transformation.md
+++ b/pages/website-transformation.md
@@ -18,7 +18,7 @@ By partnering with 18F, you can better understand how and why people use your we
 
 By engaging with 18F, partners gain access to a specialized team focused on the nuances of customer experience in the digital realm, backed by the broad experience and resources of 18F. Together, we create the best outcomes for your mission and the people you serve.
 
-Learn if 18F Web Transformation services are right for you by emailing us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov).
+Learn if 18F Web Transformation services are right for you by emailing us at <a href="mailto:inquiries18F@gsa.gov">inquiries18F@gsa.gov</a>.
 {% endcapture %}
 
 

--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -20,7 +20,7 @@ We partner with government agencies to:
 - Find the right vendor to set you up for long-term success
 - [Create AI service strategies]({{ site.baseurl }}/AI-services)
 
-To take the next step, email us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov) and tell us what your needs are.
+To take the next step, email us at <a href="mailto:inquiries18F@gsa.gov">inquiries18F@gsa.gov</a> and tell us what your needs are.
 {% endcapture %}
 
 {% capture mission-path %}

--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -1,19 +1,19 @@
 ---
 title: Work with us
 permalink: /work-with-us/
-lead: As federal employees, we share your dedication to serving the American&nbsp;public. 
+lead: As federal employees, we share your dedication to serving the American&nbsp;public.
 redirect_from: /how-we-work/
 hide_footer_rule: true
 ---
 
 {% capture intro %}
-Because [87% of large government IT projects fail](https://derisking-guide.18f.gov/), government’s approach to this work needs to change. We believe that projects have the best chance for success when agency leaders and staff themselves are closely involved in developing the solutions they need. We can help.
+Because [87% of large government IT projects don't succeed](https://derisking-guide.18f.gov/), government’s approach to this work needs to change. We believe that projects have the best chance for success when agency leaders and staff themselves are closely involved in developing the solutions they need. We can help.
 {% endcapture %}
 
 {% capture ask-qs %}
 ## Ask the right questions, solve the right problems
 
-We take the time and have the experience to understand the specific mission of your organization. In an 18F engagement, we work together to understand what problem you need to solve. 
+We take the time and have the experience to understand the specific mission of your organization. In an 18F engagement, we work together to understand what problem you need to solve.
 
 18F has [deep expertise in _talking to people_](https://18f.gov/guides). When you talk to users and staff, you get to the heart of the problem by learning how people use your services and technology. That's how we uncover insights and find new solutions.
 {% endcapture %}
@@ -29,7 +29,7 @@ Some software projects are the right size and shape for 18F to build with you; o
 {% capture tech-adapt %}
 ## Tech that adapts and grows with your needs
 
-18F engagements are designed to end. Since we're part of the federal government, we don't have a vested interest in extending engagements unnecessarily or selling you things you don't need. 
+18F engagements are designed to end. Since we're part of the federal government, we don't have a vested interest in extending engagements unnecessarily or selling you things you don't need.
 
 Instead, we involve your team in creating solutions and ensure they have everything they need to maintain and improve systems long after we're gone.
 {% endcapture %}
@@ -40,7 +40,7 @@ Instead, we involve your team in creating solutions and ensure they have everyth
   <div class="grid-row">
     <div class="grid-col">
       <h2>Transform the way you work</h2>
-      <div class="font-sans-lg"> 
+      <div class="font-sans-lg">
         {{ intro | markdownify}}
       </div>
     </div>
@@ -48,41 +48,41 @@ Instead, we involve your team in creating solutions and ensure they have everyth
 </div>
 </section>
 
-<section class="usa-section bg-base-lightest"> 
-  <div class="grid-container"> 
+<section class="usa-section bg-base-lightest">
+  <div class="grid-container">
     <div class="grid-row grid-gap">
       <div class="tablet-lg:grid-col-7">
         {{ ask-qs | markdownify }}
       </div>
       <div class="tablet-lg:grid-col-5">
-        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-1.svg" 
+        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-1.svg"
         alt=""
         >
       </div>
-    </div> 
+    </div>
     <h3 class="text-normal"> Feel empowered to continue with our guides</h3>
     <p class="font-sans-lg"> We want agencies to be able to do the work themselves. Here are some free guides that help. </p>
     <div class="grid-row grid-gap-md">
       <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
+      {% include card-with-image.html
          card_color="dark"
          text_content="Accessibility"
          link_url="https://accessibility.18f.gov/"
          image_path="/assets/img/guides/accessibility-lightest.svg"
       %}
       </div>
-     
+
       <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
+      {% include card-with-image.html
          card_color="dark"
          text_content="Agile"
          link_url="https://agile.18f.gov/"
          image_path="/assets/img/guides/agile-lightest.svg"
       %}
       </div>
-    
+
       <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
+      {% include card-with-image.html
          card_color="dark"
          image_path="/assets/img/guides/content-lightest.svg"
          link_url="https://content-guide.18f.gov/"
@@ -91,19 +91,19 @@ Instead, we involve your team in creating solutions and ensure they have everyth
       </div>
     </div>
    <a href="{{ site.baseurl }}/guides/" class="usa-button usa-button--outline margin-top-3">
-     Browse our guides 
+     Browse our guides
    </a>
   </div>
 </section>
 
-<section class="usa-section"> 
+<section class="usa-section">
   <div class="grid-container">
     <div class="grid-row">
       <div class="tablet-lg:grid-col-7">
          {{ mission-path | markdownify }}
       </div>
       <div class="tablet-lg:grid-col-5">
-        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-2.svg" 
+        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-2.svg"
         alt=""
         >
       </div>
@@ -112,16 +112,16 @@ Instead, we involve your team in creating solutions and ensure they have everyth
     <p class="font-sans-lg"> We want agencies to be able to do the work themselves. Here are some free guides that help. </p>
     <div class="grid-row grid-gap-md">
       <div class="grid-col-12 tablet:grid-col-6 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
+      {% include card-with-image.html
          card_color="dark"
          image_path="/assets/img/guides/state-guide-lightest.svg"
          link_url="https://derisking-guide.18f.gov/state-field-guide/"
          text_content="State Software Budgeting Handbook"
       %}
       </div>
-      
+
       <div class="grid-col-12 tablet:grid-col-6 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html 
+      {% include card-with-image.html
          card_color="dark"
          image_path="/assets/img/guides/federal-guide-lightest.svg"
          link_url="https://derisking-guide.18f.gov/federal-field-guide/"
@@ -129,19 +129,19 @@ Instead, we involve your team in creating solutions and ensure they have everyth
       %}
       </div>
     </div> <a href="{{ site.baseurl }}/guides/" class="usa-button usa-button--outline margin-top-3">
-     Browse our guides 
+     Browse our guides
    </a>
   </div>
 </section>
 
-<section class="usa-section bg-base-lightest"> 
+<section class="usa-section bg-base-lightest">
   <div class="grid-container">
     <div class="grid-row">
       <div class="tablet-lg:grid-col-7">
          {{ tech-adapt | markdownify }}
       </div>
       <div class="tablet-lg:grid-col-5">
-        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-3.svg" 
+        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-3.svg"
         alt=""
         >
       </div>
@@ -150,12 +150,12 @@ Instead, we involve your team in creating solutions and ensure they have everyth
     <p class="font-sans-lg">Read short project summaries demonstrating how we’ve helped some of the largest federal agencies.</p>
     <div class="grid-row grid-gap-md">
     {% assign projects = 'fec-gov, treasury-data-act' | split: ", " %}
-    {% for project in projects %} 
+    {% for project in projects %}
       {% assign project_details = site | find_collection: 'services_projects' | where: 'slug', project | first %}
       {% assign project_agency = site.data.agencies | where: "name", project_details.agency | first %}
       {% assign project_link = site.baseurl | append: project_details.permalink %}
       <div class="grid-col-12 tablet:grid-col-6 margin-top-3 tablet:margin-top-0">
-        {% include card-with-image.html 
+        {% include card-with-image.html
            image_path=project_agency.logo
            image_alt_text=project_agency.name
            image_size="md"

--- a/pages/work-with-us.md
+++ b/pages/work-with-us.md
@@ -11,11 +11,16 @@ Because [87% of large government IT projects don't succeed](https://derisking-gu
 {% endcapture %}
 
 {% capture ask-qs %}
-## Ask the right questions, solve the right problems
+## Service Offerings
 
-We take the time and have the experience to understand the specific mission of your organization. In an 18F engagement, we work together to understand what problem you need to solve.
+18F supports you with a custom team of designers, engineers, product managers, and procurement specialists. In each engagement, we take the time to understand your mission and the challenges you confront. Then, we draw from our expertise to create practical solutions to deliver the best outcomes for you and the people you serve.
+We partner with government agencies to:
+- [Make your website work for you]({{ site.baseurl }}/website-transformation)
+- Design processes to implement mandates and initiatives
+- Find the right vendor to set you up for long-term success
+- [Create AI service strategies]({{ site.baseurl }}/AI-services)
 
-18F has [deep expertise in _talking to people_](https://18f.gov/guides). When you talk to users and staff, you get to the heart of the problem by learning how people use your services and technology. That's how we uncover insights and find new solutions.
+To take the next step, email us at [inquiries18F@gsa.gov](inquiries18F@gsa.gov) and tell us what your needs are.
 {% endcapture %}
 
 {% capture mission-path %}
@@ -55,44 +60,11 @@ Instead, we involve your team in creating solutions and ensure they have everyth
         {{ ask-qs | markdownify }}
       </div>
       <div class="tablet-lg:grid-col-5">
-        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-1.svg"
+        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-2.svg"
         alt=""
         >
       </div>
     </div>
-    <h3 class="text-normal"> Feel empowered to continue with our guides</h3>
-    <p class="font-sans-lg"> We want agencies to be able to do the work themselves. Here are some free guides that help. </p>
-    <div class="grid-row grid-gap-md">
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html
-         card_color="dark"
-         text_content="Accessibility"
-         link_url="https://accessibility.18f.gov/"
-         image_path="/assets/img/guides/accessibility-lightest.svg"
-      %}
-      </div>
-
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html
-         card_color="dark"
-         text_content="Agile"
-         link_url="https://agile.18f.gov/"
-         image_path="/assets/img/guides/agile-lightest.svg"
-      %}
-      </div>
-
-      <div class="grid-col-12 tablet:grid-col-4 margin-top-3 tablet:margin-top-0">
-      {% include card-with-image.html
-         card_color="dark"
-         image_path="/assets/img/guides/content-lightest.svg"
-         link_url="https://content-guide.18f.gov/"
-         text_content="Content"
-      %}
-      </div>
-    </div>
-   <a href="{{ site.baseurl }}/guides/" class="usa-button usa-button--outline margin-top-3">
-     Browse our guides
-   </a>
   </div>
 </section>
 
@@ -103,7 +75,7 @@ Instead, we involve your team in creating solutions and ensure they have everyth
          {{ mission-path | markdownify }}
       </div>
       <div class="tablet-lg:grid-col-5">
-        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-2.svg"
+        <img src="{{ site.baseurl }}/assets/img/work-with-us/work-with-us-illo-1.svg"
         alt=""
         >
       </div>


### PR DESCRIPTION
# Pull request summary
Add some content and links to "[work with us](https://18f.gsa.gov/work-with-us/)" page with some stand-alone offerings pages that link from there. 

Replaces section "Ask the right questions, solve the right problems" link to pages about specific offerings. Edits this page so it explains what our engagements look like and what to do if you want to work with us.

Adds pages:
- Explain AI offering to help people implement AI memo
- Explain website redesign offering

Tangential note - "87% of large government IT projects fail" Isn't true. We can say, "87% of large government IT projects don't succeed," "29% of large government IT projects fail," or "Only 13% of large government IT projects succeed". [The[ underlying data](https://www.standishgroup.com/sample_research_files/Haze4.pdf) is:  13% successful, 58% challenged and 29% failed] This is also from 2015 so I feel like it is getting stale.

We would like to get the new content up ASAP.  It would be great if we could follow up with some design improvements.

There was also a lot of extra whitespace that was automatically linted by my text editor.  

## Reminder - please do the following before assigning reviewer

- [ ] update readme
- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
