### PR TITLE
Update dynamic urls for content, derisking, ux guide

### DIFF
--- a/_data/guides.yml
+++ b/_data/guides.yml
@@ -11,13 +11,13 @@
     dark: "/assets/img/guides/agile-darker.svg"
 
 - name: "Content"
-  link: "https://content-guide.18f.gov"
+  link: "https://guides.18f.gov/content-guide/"
   image:
     light: "/assets/img/guides/content-lightest.svg"
     dark: "/assets/img/guides/content-darker.svg"
 
 - name: "De-risking"
-  link: "https://derisking-guide.18f.gov"
+  link: "https://guides.18f.gov/derisking/"
   image:
     light: ""
     dark: "/assets/img/guides/derisking-darker.svg"
@@ -41,7 +41,7 @@
     dark: "/assets/img/guides/product-darker.svg"
 
 - name: "User Experience"
-  link: "https://ux-guide.18f.gov"
+  link: "https://guides.18f.gov/ux-guide/"
   image:
     light: "/assets/img/guides/ux-lightest.svg"
     dark: "/assets/img/guides/ux-darker.svg"


### PR DESCRIPTION
# Pull request summary
Updates dynamic URL's for the Content, Derisking, and UX Guides. 
This means the guides landing page will use the updated URL's. 

This is part of TLC Crew's work to [finish migrating the guides](https://github.com/18F/guides/issues/156) to 11ty. 

## Reminder - please do the following before assigning reviewer

- [ ] update readme
- [ ] For frontend changes, ensure design review

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued
