### PR TITLE
Update ruby dependency with approximately greater than operator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '~> 3.2.2'
 
 gem 'html-proofer', '~> 5.0.8'
 gem 'jekyll', '~> 4.3'


### PR DESCRIPTION
# Pull request summary

We shouldn't lock specific ruby versions ([3.2.3 was released earlier this month](https://www.ruby-lang.org/en/news/2024/01/18/ruby-3-2-3-released/)) so I added an `~>` operator which will only upgrade to patch semver, e.g., `3.2.x` versions. We probably can be more permissive here with ruby versions but this will do for now.