### PR TITLE
Add hyphen to user-centered design tag

### DIFF
--- a/_posts/2023-02-13-looking-back-and-forward.md
+++ b/_posts/2023-02-13-looking-back-and-forward.md
@@ -8,7 +8,7 @@ tags:
   - join us
   - culture
   - how we work
-  - user centered design
+  - user-centered design
 excerpt: >
   We asked our design team what they learned in 2022, and what they are looking forward to in 2023. Here’s what some of our team members had to say.
 ---

--- a/_posts/2023-04-20-hi-from-the-18F-design-chapter.md
+++ b/_posts/2023-04-20-hi-from-the-18F-design-chapter.md
@@ -13,7 +13,7 @@ tags:
   - join us
   - culture
   - how we work
-  - user centered design
+  - user-centered design
 excerpt: >
   Designing technology-enabled public services requires deep expertise in how different elements of the experience come together (or don’t!).  The 18F design chapter comprises four discipline-specific cohorts — service design, user experience (UX) design, product design, and content strategy.
 image: 


### PR DESCRIPTION
Adds a hyphen in "user-centered design" in the tag that pulls blog posts on the website together. Currently two blog post have the tags listed without hyphens, which prevents all posts from being shown. 