### PR TITLE
Fix author alert message

### DIFF
--- a/_authors/matt-cloyd.md
+++ b/_authors/matt-cloyd.md
@@ -1,0 +1,7 @@
+---
+name: matt-cloyd
+first_name: Matt
+last_name: Cloyd
+full_name: Matt Cloyd
+published: true
+---

--- a/_authors/qituwra-anderson
+++ b/_authors/qituwra-anderson
@@ -1,7 +1,0 @@
----
-name: qituwra-anderson 
-first_name: Qituwra
-last_name: Anderson 
-full_name: Qituwra Anderson 
-published: true
----

--- a/_authors/qituwra-anderson.md
+++ b/_authors/qituwra-anderson.md
@@ -3,6 +3,6 @@ name: qituwra-anderson
 first_name: Qituwra
 last_name: Anderson
 full_name: Qituwra Anderson
-published: false
+published: true
 ---
 


### PR DESCRIPTION
There were two conflicting files for qituwra-anderson. The most recent (plaintext) had published=true, the older one (Markdown) had published=false.

Every time the site gets built, there's a little warning in the logs about this conflict.

# Pull request summary
This PR deletes the plaintext file and sets the markdown file to published=true (the most recent value).

## Reminder - please do the following before assigning reviewer

- [x] Update readme
- [x] For frontend changes, ensure design review
- [x] For content changes beyond typos, add Ron Bronson as a reviewer

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introdcued


