### PR TITLE
[WIP] Nightly full pa11y scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       # which satisfies this condition
       - when:
           condition:
-            equal: [ 'scheduled_pipeline', << pipeline.trigger_source >> ]
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
           steps:
             - run:
                 name: Run full pa11y scan
@@ -70,7 +70,7 @@ jobs:
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
           condition:
-            equal: [ 'webhook', << pipeline.trigger_source >> ]
+            equal: [ webhook, << pipeline.trigger_source >> ]
           steps:
             - run:
                 name: Run pa11y scan on changed files
@@ -87,7 +87,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "15 * * * *"
+          cron: "25 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "55 9 * * *"
+          cron: "45 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "15 * * * *"
+          cron: "55 9 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron: "12 * * * *"
+          cron: "56 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,23 +47,34 @@ jobs:
           # that we can make pa11y-ci scan only those changed files
           # in the "Run pa11y scan on changed files" step if it's
           # needed, a full site scan does not use the pa11y_targets file
+          # If this pipeline run is triggered from a GitHub PR commit webhook
+          # we check for the pa11y_targets file
+          #  - if the file exists it means Jekyll found changed files and we will scan that list
+          #  - if the file does not exist it means Jekyll didn't detect any changed files and we skip the pa11y scan
+          # If this pipeline run is triggered by a schedule that's our nightly full pa11y scan
+          # which doesn't need to interact with PA11Y_TARGETS since it runs off the sitemap to do a fulll scan
           command: |
             bundle exec jekyll build
-            if test -f pa11y_targets; then
-              echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-              export DO_PA11Y_SCAN=true >> "$BASH_ENV"
-              echo "Changed files detected, pa11y scan will be performed on those files."
-            else
-              export DO_PA11Y_SCAN=false >> "$BASH_ENV"
-              echo "No changed files detected, pa11y scan will be skipped."
+            if [[ << pipeline.trigger_source >> == "webhook" ]]; then
+              if test -f pa11y_targets; then
+                echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+                export DO_PA11Y_SCAN=true >> "$BASH_ENV"
+                echo "Changed files detected, pa11y scan will be performed on those files."
+              else
+                export DO_PA11Y_SCAN=false >> "$BASH_ENV"
+                echo "No changed files detected, pa11y scan will be skipped."
+              fi
+              source "$BASH_ENV"
             fi
-            source "$BASH_ENV"
+            
+            if [[ << pipeline.trigger_source >> == "schedule" ]]; then
+              echo "Scheduled workflow detected, full pa11y scan will be performed."
+            fi
       - run: npm run htmlproofer
       - run:
           name: Run rspec
           command: bundle exec rspec `pwd`/spec/
-      # The nightly full pa11y scan is triggered from a scheduled pipeline
-      # which satisfies this condition
+      # The nightly full pa11y scan is triggered from a scheduled pipeline which satisfies this condition
       - when:
           condition:
             equal: [ schedule, << pipeline.trigger_source >> ]
@@ -88,7 +99,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "25 * * * *"
+          cron: "15 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron "5 * * * *"
+          cron: "5 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v2-dependencies-bundler-
       - run:
+          name: Check CircleCI values
+          command: "echo << pipeline.trigger_source >>"
+      - run:
           name: Bundle install dependencies
           command: |
             bundle config set path 'vendor/bundle'
@@ -87,7 +90,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "25 * * * *"
+          cron: "40 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ jobs:
             bundle exec jekyll build
             if test -f pa11y_targets; then
               echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+              echo "Changed files detected, pa11y scan will be performed on those files."
               source "$BASH_ENV"
+            else
+              echo "No changed files detected, pa11y scan will be skipped."
             fi
       - run: npm run htmlproofer
       - run:
@@ -65,7 +68,9 @@ jobs:
           steps:
             - run:
                 name: Run full pa11y scan
-                command: ./serve-pa11yci && npm run pa11y-sitemap
+                command: |
+                  echo "Doing full pa11y scan."
+                  ./serve-pa11yci && npm run pa11y-sitemap
       # When someone pushes to a branch on GitHub with an open pull request
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
@@ -76,10 +81,10 @@ jobs:
                 name: Run pa11y scan on changed files
                 command: |
                   if [[ -z "${PA11Y_TARGETS}" ]]; then
-                    npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
-                  else
                     echo "The pa11y targets environment variable was not found, no pa11y scan performed."
                     exit 1
+                  else
+                    npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
                   fi
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       # Invoke pa11y-ci and pass in our list of changed files
       - run:
           name: Run pa11yci
-          command: npm run pa11y-sitemap
+          command: ./serve-pa11yci && npm run pa11y-sitemap
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "55 * * * *"
+          cron: "55 9 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       # which satisfies this condition
       - when:
           condition:
-            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            equal: [ schedule, << pipeline.trigger_source >> ]
           steps:
             - run:
                 name: Run full pa11y scan
@@ -90,7 +90,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "40 * * * *"
+          cron: "45 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
                     curl -L \
                     -X POST \
                     -H "Accept: application/vnd.github+json" \
-                    -H "Authorization: Bearer $GITHUB_TEST_TOKEN" \
+                    -H "Authorization: Bearer $GITHUB_TOKEN" \
                     -H "X-GitHub-Api-Version: 2022-11-28" \
                     https://api.github.com/repos/18f/18f.gsa.gov/dispatches \
                     -d $JSON
@@ -118,7 +118,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron: "37 * * * *"
+          cron: "12 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       LANGUAGE: "en_US.UTF-8"
       LC_ALL: "en_US.UTF-8"
     steps:
+      - checkout
       - jq/install:
           version: jq-1.7
       - run:
@@ -19,7 +20,6 @@ jobs:
             sudo locale-gen en_US.UTF-8
             sudo locale-gen en en_US en_US.UTF-8
             sudo dpkg-reconfigure locales
-      - checkout
       - restore_cache:
           keys:
           - v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,43 +44,43 @@ jobs:
       # When the source of the job trigger is the scheduled nightly build
       - when:
           condition:
-            equal: [ 'scheduled_pipeline', pipeline.trigger_source]
+            equal: [ 'scheduled_pipeline', << pipeline.trigger_source >> ]
           steps:
             - run:
-              name: Jekyll build
-              command: |
-                bundle exec jekyll build
+                name: Jekyll build
+                command: |
+                  bundle exec jekyll build
       # When someone pushes to a branch on GitHub it makes a webhook POST
       # to CircleCI and that is the trigger to satisfy this condition
       - when:
           condition:
-            equal: [ 'webhook', pipeline.trigger_source]
+            equal: [ 'webhook', << pipeline.trigger_source >> ]
           steps:
             - run:
-              name: Jekyll build
-              # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
-              command: |
-                bundle exec jekyll build
-                echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-                source "$BASH_ENV"
+                name: Jekyll build and store pa11y_targets
+                # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
+                command: |
+                  bundle exec jekyll build
+                  echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+                  source "$BASH_ENV"
       - run: npm run htmlproofer
       - run:
           name: Run rspec
           command: bundle exec rspec `pwd`/spec/
       - when:
           condition:
-            equal: [ 'scheduled_pipeline', pipeline.trigger_source]
+            equal: [ 'scheduled_pipeline', << pipeline.trigger_source >> ]
           steps:
             - run:
-              name: Run full pa11y scan
-              command: ./serve-pa11yci && npm run pa11y-sitemap
+                name: Run full pa11y scan
+                command: ./serve-pa11yci && npm run pa11y-sitemap
       - when:
           condition:
-            equal: [ 'webhook', pipeline.trigger_source]
+            equal: [ 'webhook', << pipeline.trigger_source >> ]
           steps:
             - run:
-              name: Run pa11y scan on changed files
-              command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
+                name: Run pa11y scan on changed files
+                command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
 workflows:
   version: 2
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ jobs:
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
           condition:
-          and:
-            equal: [ webhook, << pipeline.trigger_source >> ]
-            equal: [ true, $DO_PA11Y_SCAN ]
+            and:
+              - equal: [ webhook, << pipeline.trigger_source >> ]
+              - equal: [ true, $DO_PA11Y_SCAN ]
           steps:
             - run:
                 name: Run pa11y scan on changed files
@@ -88,7 +88,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "0 * * * *"
+          cron: "25 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       LC_ALL: "en_US.UTF-8"
     steps:
       - run:
+          name: Test env secret
+          command: echo $FOOBAR
+      - run:
           name: Fix locales
           command: |
             sudo locale-gen en_US.UTF-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2.1
 
+orbs:
+  jq: circleci/jq@3.0.0
 jobs:
  build:
     docker:
@@ -9,6 +11,8 @@ jobs:
       LANGUAGE: "en_US.UTF-8"
       LC_ALL: "en_US.UTF-8"
     steps:
+      - jq/install:
+          version: jq-1.7
       - run:
           name: Fix locales
           command: |
@@ -81,7 +85,20 @@ jobs:
           steps:
             - run:
                 name: Run full pa11y scan
-                command: ./serve-pa11yci && npm run pa11y-sitemap
+                command: |
+                  ./serve-pa11yci && npm run pa11y-sitemap 2> >(tee pa11y-errors >&2)
+                  if [[ $PIPESTATUS -eq 2 ]]; then
+                    set +o history
+                    JSON=$(echo '{"event_type":"failed-pa11y-scan","client_payload":{"report":"'"$(cat pa11y-errors | base64)"'"}}' | jq -c -r '.|tojson')
+                    curl -L \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $GITHUB_TEST_TOKEN" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/18f/18f.gsa.gov/dispatches \
+                    -d $JSON
+                    set -o history
+                  fi
       # When someone pushes to a branch on GitHub with an open pull request
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
@@ -99,7 +116,8 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "59 9 * * *"
+          #cron: "59 9 * * *"
+          cron "5 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,6 @@ workflows:
           filters:
             branches:
               only:
-                - caley/nightly-pa11y-run
+                - caley/nightly-pa11y-scan
     jobs:
       - full_scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
 
 workflows:
   version: 2
-  nightly:
+  commit:
     triggers:
       - schedule:
-          cron: "35 * * * *"
+          cron: "40 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-        cron: "15 * * * *"
+          cron: "50 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,10 @@ jobs:
           # needed, a full site scan does not use the pa11y_targets file
           command: |
             bundle exec jekyll build
-            echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-            source "$BASH_ENV"
+            if test -f pa11y_targets; then
+              echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
       - run: npm run htmlproofer
       - run:
           name: Run rspec
@@ -72,14 +74,20 @@ jobs:
           steps:
             - run:
                 name: Run pa11y scan on changed files
-                command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
+                command: |
+                  if [[ -z $"{PA11Y_TARGETS}" ]]; then
+                    npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
+                  else
+                    echo "The pa11y targets environment variable was not found, no pa11y scan performed."
+                    exit 1
+                  fi
 workflows:
   version: 2
   nightly:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "20 * * * *"
+          cron: "10 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "59 9 * * *"
+          cron: "55 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,32 +41,22 @@ jobs:
             - node_modules
           key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
       - run: npm run uswds-build
-      # When the source of the job trigger is the scheduled nightly build
-      - when:
-          condition:
-            equal: [ 'scheduled_pipeline', << pipeline.trigger_source >> ]
-          steps:
-            - run:
-                name: Jekyll build
-                command: |
-                  bundle exec jekyll build
-      # When someone pushes to a branch on GitHub it makes a webhook POST
-      # to CircleCI and that is the trigger to satisfy this condition
-      - when:
-          condition:
-            equal: [ 'webhook', << pipeline.trigger_source >> ]
-          steps:
-            - run:
-                name: Jekyll build and store pa11y_targets
-                # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
-                command: |
-                  bundle exec jekyll build
-                  echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-                  source "$BASH_ENV"
+      - run:
+          name: Jekyll build and store pa11y_targets
+          # We export the changed file list in pa11y_targets source
+          # that we can make pa11y-ci scan only those changed files
+          # in the "Run pa11y scan on changed files" step if it's
+          # needed, a full site scan does not use the pa11y_targets file
+          command: |
+            bundle exec jekyll build
+            echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+            source "$BASH_ENV"
       - run: npm run htmlproofer
       - run:
           name: Run rspec
           command: bundle exec rspec `pwd`/spec/
+      # The nightly full pa11y scan is triggered from a scheduled pipeline
+      # which satisfies this condition
       - when:
           condition:
             equal: [ 'scheduled_pipeline', << pipeline.trigger_source >> ]
@@ -74,6 +64,8 @@ jobs:
             - run:
                 name: Run full pa11y scan
                 command: ./serve-pa11yci && npm run pa11y-sitemap
+      # When someone pushes to a branch on GitHub with an open pull request
+      # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
           condition:
             equal: [ 'webhook', << pipeline.trigger_source >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "55 9 * * *"
+          cron: "0 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "*/10 * * * *"
+          cron: "35 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "0 * * * *"
+        cron: "15 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  build:
+ build:
     docker:
       - image: cimg/ruby:3.2-browsers
     environment:
@@ -41,84 +41,59 @@ jobs:
             - node_modules
           key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
       - run: npm run uswds-build
-      # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
-      - run:
-          name: Jekyll build
-          command: |
-            bundle exec jekyll build
-            echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-            source "$BASH_ENV"
+      # When the source of the job trigger is the scheduled nightly build
+      - when:
+          condition:
+            equal: [ 'scheduled_pipeline', pipeline.trigger_source]
+          steps:
+            - run:
+              name: Jekyll build
+              command: |
+                bundle exec jekyll build
+      # When someone pushes to a branch on GitHub it makes a webhook POST
+      # to CircleCI and that is the trigger to satisfy this condition
+      - when:
+          condition:
+            equal: [ 'webhook', pipeline.trigger_source]
+          steps:
+            - run:
+              name: Jekyll build
+              # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
+              command: |
+                bundle exec jekyll build
+                echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+                source "$BASH_ENV"
       - run: npm run htmlproofer
       - run:
           name: Run rspec
           command: bundle exec rspec `pwd`/spec/
-      # Invoke pa11y-ci and pass in our list of changed files
-      - run:
-          name: Run pa11yci
-          command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
-  full_scan:
-    docker:
-      - image: cimg/ruby:3.2-browsers
-    environment:
-      LANG: "en_US.UTF-8"
-      LANGUAGE: "en_US.UTF-8"
-      LC_ALL: "en_US.UTF-8"
-    steps:
-      - run:
-          name: Fix locales
-          command: |
-            sudo locale-gen en_US.UTF-8
-            sudo locale-gen en en_US en_US.UTF-8
-            sudo dpkg-reconfigure locales
-      - checkout
-      - restore_cache:
-          keys:
-          - v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v2-dependencies-bundler-
-      - run:
-          name: Bundle install dependencies
-          command: |
-            bundle config set path 'vendor/bundle'
-            bundle install --jobs=4 --retry=3
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
-      - restore_cache:
-          keys:
-          - v2-dependencies-npm-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v2-dependencies-npm-
-      - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
-      - run: npm run uswds-build
-      # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
-      - run:
-          name: Jekyll build
-          command: |
-            bundle exec jekyll build
-      - run: npm run htmlproofer
-      - run:
-          name: Run rspec
-          command: bundle exec rspec `pwd`/spec/
-      # Invoke pa11y-ci and pass in our list of changed files
-      - run:
-          name: Run pa11yci
-          command: ./serve-pa11yci && npm run pa11y-sitemap
-
+      - when:
+          condition:
+            equal: [ 'scheduled_pipeline', pipeline.trigger_source]
+          steps:
+            - run:
+              name: Run full pa11y scan
+              command: ./serve-pa11yci && npm run pa11y-sitemap
+      - when:
+          condition:
+            equal: [ 'webhook', pipeline.trigger_source]
+          steps:
+            - run:
+              name: Run pa11y scan on changed files
+              command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
 workflows:
   version: 2
   nightly:
     triggers:
       - schedule:
-          cron: "48 * * * *"
+          # Run nightly at 10am UTC / 5am ET
+          cron: "20 * * * *"
           filters:
             branches:
               only:
                 - caley/nightly-pa11y-scan
     jobs:
-      - full_scan
+      - build
+  commit:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v2-dependencies-bundler-
       - run:
-          name: Check CircleCI values
-          command: "echo << pipeline.trigger_source >>"
-      - run:
           name: Bundle install dependencies
           command: |
             bundle config set path 'vendor/bundle'
@@ -90,7 +87,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "45 * * * *"
+          cron: "0 10 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ jobs:
           paths:
             - vendor/bundle
           key: v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
-
       - restore_cache:
           keys:
           - v2-dependencies-npm-{{ checksum "package-lock.json" }}
@@ -57,8 +56,69 @@ jobs:
       - run:
           name: Run pa11yci
           command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
+  full_scan:
+    docker:
+      - image: cimg/ruby:3.2-browsers
+    environment:
+      LANG: "en_US.UTF-8"
+      LANGUAGE: "en_US.UTF-8"
+      LC_ALL: "en_US.UTF-8"
+    steps:
+      - run:
+          name: Fix locales
+          command: |
+            sudo locale-gen en_US.UTF-8
+            sudo locale-gen en en_US en_US.UTF-8
+            sudo dpkg-reconfigure locales
+      - checkout
+      - restore_cache:
+          keys:
+          - v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v2-dependencies-bundler-
+      - run:
+          name: Bundle install dependencies
+          command: |
+            bundle config set path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
+      - save_cache:
+          paths:
+            - vendor/bundle
+          key: v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
+      - restore_cache:
+          keys:
+          - v2-dependencies-npm-{{ checksum "package-lock.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v2-dependencies-npm-
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
+      - run: npm run uswds-build
+      # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
+      - run:
+          name: Jekyll build
+          command: |
+            bundle exec jekyll build
+      - run: npm run htmlproofer
+      - run:
+          name: Run rspec
+          command: bundle exec rspec `pwd`/spec/
+      # Invoke pa11y-ci and pass in our list of changed files
+      - run:
+          name: Run pa11yci
+          command: npm run pa11y-sitemap
+
 workflows:
   version: 2
-  commit:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "*/10 * * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
-      - build
+      - full_scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "0 10 * * *"
+          cron: "45 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             - run:
                 name: Run pa11y scan on changed files
                 command: |
-                  if [[ -z $"{PA11Y_TARGETS}" ]]; then
+                  if [[ -z "${PA11Y_TARGETS}" ]]; then
                     npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
                   else
                     echo "The pa11y targets environment variable was not found, no pa11y scan performed."
@@ -87,7 +87,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "10 * * * *"
+          cron: "15 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
                   ./serve-pa11yci && npm run pa11y-sitemap 2> >(tee pa11y-errors >&2)
                   if [[ $PIPESTATUS -eq 2 ]]; then
                     set +o history
-                    JSON=$(echo '{"event_type":"failed-pa11y-scan","client_payload":{"report":"'"$(cat pa11y-errors | base64)"'"}}' | jq -c -r '.|tojson')
+                    JSON=$(echo '{"event_type":"failed-pa11y-scan","client_payload":{"report":"'"$(cat pa11y-errors | base64 -w0)"'"}}' | jq -c -r '.|tojson')
                     curl -L \
                     -X POST \
                     -H "Accept: application/vnd.github+json" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "15 * * * *"
+          cron: "59 9 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,20 @@ jobs:
             - run:
                 name: Run full pa11y scan
                 command: |
+                  set +e
                   ./serve-pa11yci && npm run pa11y-sitemap 2> >(tee pa11y-errors >&2)
+                  if [[ $PIPESTATUS -eq 2 ]]; then
+                    set +o history
+                    JSON=$(echo '{"event_type":"failed-pa11y-scan","client_payload":{"report":"'"$(cat pa11y-errors | base64 -w0)"'"}}' | jq -c -r '.|tojson')
+                    curl -L \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer $GITHUB_TEST_TOKEN" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/18f/18f.gsa.gov/dispatches \
+                    -d $JSON
+                    set -o history
+                  fi
       # When someone pushes to a branch on GitHub with an open pull request
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
@@ -105,7 +118,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron: "12 * * * *"
+          cron: "37 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,13 @@ jobs:
             bundle exec jekyll build
             if test -f pa11y_targets; then
               echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+              export DO_PA11Y_SCAN=true >> "$BASH_ENV"
               echo "Changed files detected, pa11y scan will be performed on those files."
-              source "$BASH_ENV"
             else
+              export DO_PA11Y_SCAN=false >> "$BASH_ENV"
               echo "No changed files detected, pa11y scan will be skipped."
             fi
+            source "$BASH_ENV"
       - run: npm run htmlproofer
       - run:
           name: Run rspec
@@ -68,30 +70,25 @@ jobs:
           steps:
             - run:
                 name: Run full pa11y scan
-                command: |
-                  echo "Doing full pa11y scan."
-                  ./serve-pa11yci && npm run pa11y-sitemap
+                command: ./serve-pa11yci && npm run pa11y-sitemap
       # When someone pushes to a branch on GitHub with an open pull request
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
           condition:
+          and:
             equal: [ webhook, << pipeline.trigger_source >> ]
+            equal: [ true, $DO_PA11Y_SCAN ]
           steps:
             - run:
                 name: Run pa11y scan on changed files
-                command: |
-                  if [[ -z "${PA11Y_TARGETS}" ]]; then
-                    echo "The pa11y targets environment variable was not found, no pa11y scan performed."
-                  else
-                    npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
-                  fi
+                command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
 workflows:
   version: 2
   nightly:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "45 * * * *"
+          cron: "0 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron: "5 * * * *"
+          cron: "21 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,13 +112,13 @@ jobs:
 
 workflows:
   version: 2
-  commit:
+  nightly:
     triggers:
       - schedule:
-          cron: "40 * * * *"
+          cron: "48 * * * *"
           filters:
             branches:
               only:
-                - main
+                - caley/nightly-pa11y-run
     jobs:
       - full_scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          #cron: "59 9 * * *"
-          cron: "56 * * * *"
+          cron: "59 9 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
       LC_ALL: "en_US.UTF-8"
     steps:
       - run:
-          name: Test env secret
-          command: echo $FOOBAR
-      - run:
           name: Fix locales
           command: |
             sudo locale-gen en_US.UTF-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "50 * * * *"
+          cron: "55 9 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,18 +87,6 @@ jobs:
                 name: Run full pa11y scan
                 command: |
                   ./serve-pa11yci && npm run pa11y-sitemap 2> >(tee pa11y-errors >&2)
-                  if [[ $PIPESTATUS -eq 2 ]]; then
-                    set +o history
-                    JSON=$(echo '{"event_type":"failed-pa11y-scan","client_payload":{"report":"'"$(cat pa11y-errors | base64 -w0)"'"}}' | jq -c -r '.|tojson')
-                    curl -L \
-                    -X POST \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "Authorization: Bearer $GITHUB_TEST_TOKEN" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    https://api.github.com/repos/18f/18f.gsa.gov/dispatches \
-                    -d $JSON
-                    set -o history
-                  fi
       # When someone pushes to a branch on GitHub with an open pull request
       # it makes a webhook POST to CircleCI that satisfies this condition
       - when:
@@ -117,7 +105,7 @@ workflows:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
           #cron: "59 9 * * *"
-          cron: "21 * * * *"
+          cron: "12 * * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ jobs:
                 command: |
                   if [[ -z "${PA11Y_TARGETS}" ]]; then
                     echo "The pa11y targets environment variable was not found, no pa11y scan performed."
-                    exit 1
                   else
                     npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
                   fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
     triggers:
       - schedule:
           # Run nightly at 10am UTC / 5am ET
-          cron: "45 * * * *"
+          cron: "15 * * * *"
           filters:
             branches:
               only:

--- a/_about/index.md
+++ b/_about/index.md
@@ -17,6 +17,8 @@ subnav_items:
     permalink: /about/#for-press
 ---
 
+<h2 id="test">Duplicate</h2>
+<h2 id="test">ID</h2>
 
 ## History
 

--- a/_about/index.md
+++ b/_about/index.md
@@ -17,9 +17,6 @@ subnav_items:
     permalink: /about/#for-press
 ---
 
-<h2 id="test">Duplicate</h2>
-<h2 id="test">ID</h2>
-
 ## History
 
 In March 2014, a group of [Presidential Innovation Fellows](https://presidentialinnovationfellows.gov/) started 18F to extend their efforts to improve and modernize government technology.

--- a/_about/index.md
+++ b/_about/index.md
@@ -16,8 +16,6 @@ subnav_items:
   - text: For press
     permalink: /about/#for-press
 ---
-<h2 id="test">Duplicate</h2>
-<h2 id="test">ID</h2>
 
 ## History
 

--- a/_about/index.md
+++ b/_about/index.md
@@ -17,8 +17,6 @@ subnav_items:
     permalink: /about/#for-press
 ---
 
-<h2 id="test">Duplicate</h2>
-<h2 id="test">ID</h2>
 
 ## History
 

--- a/_about/index.md
+++ b/_about/index.md
@@ -17,6 +17,9 @@ subnav_items:
     permalink: /about/#for-press
 ---
 
+<h2 id="test">Duplicate</h2>
+<h2 id="test">ID</h2>
+
 ## History
 
 In March 2014, a group of [Presidential Innovation Fellows](https://presidentialinnovationfellows.gov/) started 18F to extend their efforts to improve and modernize government technology.

--- a/_about/index.md
+++ b/_about/index.md
@@ -16,6 +16,8 @@ subnav_items:
   - text: For press
     permalink: /about/#for-press
 ---
+<h2 id="test">Duplicate</h2>
+<h2 id="test">ID</h2>
 
 ## History
 


### PR DESCRIPTION
# Pull request summary
#3829 Changed how pa11y scans are handled in CI so that instead of full site scans using the sitemap it only scans the files that were changed. Part of that scope of work was to create a scheduled full site scan with pa11y since that now never occurs otherwise.

There are three parts to completing this work, only the first step is complete currently:

1. Modify the CircleCI config so that it supports both a scheduled full scan and the normal "run a changed files scan when a commit to a branch that has a pull request open" scan [ ✅ ]
2. Create a GitHub action that listens for the `repository_dispatch` event and creates a GitHub issue from the pa11y failures, those pa11y failures are provided in the event that will be sent to GitHub from our CircleCI step listed in step 3 [ ✅ ]
3. Make the scheduled nightly scan create a GitHub issue if there's a pa11y failure. The current plan is to add a step to the CircleCI config that uses cURL to send an event through the GitHub API to the `18f/18f.gsa.gov` repo that triggers the `repository_dispatch` GitHub action [ ✅ ]

You can see a successful run of the scheduled "nightly" execution [here on CircleCI](https://app.circleci.com/pipelines/github/18F/18f.gsa.gov/2467/workflows/a7c70471-5247-4bd7-b165-97a8521851ec/jobs/6669).

Attempts to close #3832 

Current status: tweaking the logic in our GitHub action responsible for creating the GH issue when a scan fails so that it tries to handle issue creation intelligently. The goal is to have it not open a new issue if there's an issue already open and the scan result between the two runs was identical.

