### PR TITLE
Upgrade node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "pa11y-ci": "^3.1.0"
       },
       "engines": {
-        "node": ">=10.14"
+        "node": ">=18.7",
+        "npm": ">=7.24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "engines": {
-    "node": ">=10.14"
+    "node": ">=18.7",
+    "npm": ">=7.24"
   },
   "scripts": {
     "federalist": "npm run uswds-build && mkdir ./.bundle && echo '---\nBUNDLE_GEMFILE: \"GemfileFederalist\"' > ./.bundle/config",


### PR DESCRIPTION
# Pull request summary

Previously, the Node version specified in package.json was too low for the lockfileVersion. This caused problems like the styles not rendering in development.

This specifies a higher version of Node, as well as a higher version of NPM, to ensure lockfile compatibility.

Closes #3818 