### PR TITLE
Fix the Guides home page's heading order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/_includes/card-with-image-guides.html
+++ b/_includes/card-with-image-guides.html
@@ -40,7 +40,7 @@ hero.url - for guides where "promoted" = true, this will be the hero image for t
       {% endcapture %}
 
       {% capture card_text %}
-      <h3 class="text-bold margin-y-0">{{ include.text_content }}</h3>
+      <h2 class="text-bold margin-y-0">{{ include.text_content }}</h2>
       {% endcapture %}
 
     {% if include.image_side == "right" %}

--- a/_sass/_components/card-with-image-guides.scss
+++ b/_sass/_components/card-with-image-guides.scss
@@ -9,6 +9,12 @@
   border-radius: radius-lg;
   flex-grow: 0;
   min-height: 260px;
+
+  h2 {
+    font-size: 1.58rem;
+    line-height: 1.3;
+    letter-spacing: .0125em;
+  }
 }
 
 .card-content{


### PR DESCRIPTION
# Pull request summary
Closes  https://github.com/18F/TLC-crew/issues/724 for fixing heading order on the [Guides home page](https://18f.gsa.gov/guides/). 

## Changes proposed in this pull request: 

- Changed card `h3`s to `h2`s to keep proper heading order.
- Copied font styles from `h3` and applied to card `h2`s only.
  - Makes no visible change and still matches the design file.

## Reminder - please do the following before assigning reviewer

- [ ] Update readme
- [x] For frontend changes, ensure design review
- [ ] For content changes beyond typos, add Ron Bronson as a reviewer

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introduced


