### PR TITLE
Replatform: fix checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,6 @@ jobs:
             sudo locale-gen en en_US en_US.UTF-8
             sudo dpkg-reconfigure locales
       - checkout
-      - save_cache:
-          paths:
-            - vendor/bundle
-          key: v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
-
       - restore_cache:
           keys:
           - v2-dependencies-npm-{{ checksum "package-lock.json" }}
@@ -31,9 +26,6 @@ jobs:
           paths:
             - node_modules
           key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
-      - run:
-          name: Check Ruby style
-          command: bundle exec standardrb
       - run:
           name: Check JavaScript style
           command: npx standard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,13 @@ jobs:
       # - run:
       #     name: Check JavaScript style
       #     command: npx standard
-      - run: npm run build
+      - build: npm run build
+      - lint: npm run lint
+      - verify:
+        name: Verify that the build passes HTML validation
+        command: |
+          npm run test:html-validation
+          npm run test:links
       # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
       # - run:
       #     name: 11ty build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,17 +31,17 @@ jobs:
       #     command: npx standard
       - run: npm run build
       # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
-      - run:
-          name: 11ty build
-          command: |
-            npm run build
-            echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
-            source "$BASH_ENV"
-      - run: npm run htmlproofer
-      # Invoke pa11y-ci and pass in our list of changed files
-      - run:
-          name: Run pa11yci
-          command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
+      # - run:
+      #     name: 11ty build
+      #     command: |
+      #       npm run build
+      #       echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
+      #       source "$BASH_ENV"
+      # - run: npm run htmlproofer
+      # # Invoke pa11y-ci and pass in our list of changed files
+      # - run:
+      #     name: Run pa11yci
+      #     command: npm run pa11y-ci -- $(echo $PA11Y_TARGETS | base64 --decode)
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.2-browsers
+      - image: cimg/node:lts-browsers
     environment:
       LANG: "en_US.UTF-8"
       LANGUAGE: "en_US.UTF-8"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,21 +26,18 @@ jobs:
           paths:
             - node_modules
           key: v2-dependencies-npm-{{ checksum "package-lock.json" }}
-      - run:
-          name: Check JavaScript style
-          command: npx standard
-      - run: npm run uswds-build
+      # - run:
+      #     name: Check JavaScript style
+      #     command: npx standard
+      - run: npm run build
       # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
       - run:
-          name: Jekyll build
+          name: 11ty build
           command: |
-            bundle exec jekyll build
+            npm run build
             echo "export PA11Y_TARGETS=$(cat pa11y_targets | base64 --wrap=0)" >> "$BASH_ENV"
             source "$BASH_ENV"
       - run: npm run htmlproofer
-      - run:
-          name: Run rspec
-          command: bundle exec rspec `pwd`/spec/
       # Invoke pa11y-ci and pass in our list of changed files
       - run:
           name: Run pa11yci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ jobs:
       # - run:
       #     name: Check JavaScript style
       #     command: npx standard
-      - build: npm run build
       - lint: npm run lint
+      - build: npm run build
       - verify:
         name: Verify that the build passes HTML validation
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,6 @@ jobs:
             sudo locale-gen en en_US en_US.UTF-8
             sudo dpkg-reconfigure locales
       - checkout
-      - restore_cache:
-          keys:
-          - v2-dependencies-bundler-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v2-dependencies-bundler-
-      - run:
-          name: Bundle install dependencies
-          command: |
-            bundle config set path 'vendor/bundle'
-            bundle install --jobs=4 --retry=3
       - save_cache:
           paths:
             - vendor/bundle

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,23 +34,23 @@ jobs:
           ELEVENTY_ENV: production
         run: npm run build
 
-  pa11y-scan:
-    # Pinned to 20.04 because pa11y-ci fails to run on 22.04
-    # See the discussion on https://github.com/pa11y/pa11y-ci/issues/198
-    # and https://github.com/pa11y/pa11y/issues/651
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Install node dependencies
-        run: npm install
-      - name: Refresh assets
-        run: npm run assets:refresh
-      - name: Accessibility scan
-        run: npm run test:pa11y-ci
+  # pa11y-scan:
+  #   # Pinned to 20.04 because pa11y-ci fails to run on 22.04
+  #   # See the discussion on https://github.com/pa11y/pa11y-ci/issues/198
+  #   # and https://github.com/pa11y/pa11y/issues/651
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Use Node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 18
+  #     - name: Install node dependencies
+  #       run: npm install
+  #     - name: Refresh assets
+  #       run: npm run assets:refresh
+  #     - name: Accessibility scan
+  #       run: npm run test:pa11y-ci
 
   validate_html:
     needs: [build]


### PR DESCRIPTION
Fixing check failures as we go along.

- [Cloud.gov pages for 18f.gsa.gov](https://pages.cloud.gov/sites/3/builds) now builds properly, allowing us to have previews
- Github workflows are [temporarily disabled](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow) so we aren't indundated with emails 
- Removed CircleCI checks that have to do with ruby/bundler
- Disabled pa11y checks until we are in a place to get it to work again with @caleywoods' newer work
- Added build, lint, html validation, and link testing to the build steps so that checks are immediately useful and reflective of build quality in the PR