### PR TITLE
Add GH action for creating issues when a nightly pa11y scan fails

### DIFF
--- a/.github/workflows/repository_dispatch_create_issue.yml
+++ b/.github/workflows/repository_dispatch_create_issue.yml
@@ -1,0 +1,24 @@
+name: Create GH Issue from CircleCI
+on: repository_dispatch
+
+jobs:
+  create_issue:
+    name: Create failed pa11y scan issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create GH issue
+        run: |
+          DECODED_REPORT=$(echo $BODY | base64 --decode)
+          new_issue_url=$(gh issue create \
+            --title "Nightly pa11y scan failed" \
+            --assignee "$ASSIGNEES" \
+            --label "$LABELS" \
+            --body "$BODY")
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ASSIGNEES: caleywoods
+          LABELS: failed-pa11y-scan, a11y
+          BODY: ${{ github.event.client_payload.report }}

--- a/.github/workflows/repository_dispatch_create_issue.yml
+++ b/.github/workflows/repository_dispatch_create_issue.yml
@@ -15,7 +15,7 @@ jobs:
             --title "Nightly pa11y scan failed" \
             --assignee "$ASSIGNEES" \
             --label "$LABELS" \
-            --body "$BODY")
+            --body "$DECODED_REPORT")
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
# Pull request summary
This PR adds a new GitHub action that kicks off when a [`repository_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) webhook event is received. This webhook is currently only called from CircleCI if there are failure(s) encountered during the scheduled nightly pa11y scan.

I'm separating this workflow file/action out into a new branch/PR because the action needs to exist on the default branch (`main`) in order for me to test my webhook call.


