### PR TITLE
Update GitHub action repository_dispatch template

### DIFF
--- a/.github/workflows/repository_dispatch_create_issue.yml
+++ b/.github/workflows/repository_dispatch_create_issue.yml
@@ -15,7 +15,7 @@ jobs:
             --title "Nightly pa11y scan failed" \
             --assignee "$ASSIGNEES" \
             --label "$LABELS" \
-            --body "$DECODED_REPORT"
+            --body "```$DECODED_REPORT```"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
# Pull request summary
Updates the GitHub action that responds to the `repository_dispatch` event (currently sent by CircleCI) and wraps the body in backticks to try and keep it from rendering the HTML that is returned in the event payload which ends up being the body of the PR.


