### PR TITLE
Clean up styles

### DIFF
--- a/content/pages/author.liquid
+++ b/content/pages/author.liquid
@@ -1,11 +1,8 @@
----js
-{
-  pagination: {
-    data: "team_members",
-    size: 1,
-    alias: "author",
-  },
-  permalink: "author/{{ author.id | slugify }}/",
-  layout: "author"
-}
+---
+pagination:
+  data: "team_members"
+  size: 1
+  alias: "author"
+permalink: "author/{{ author.id | slugify }}/"
+layout: "author"
 ---

--- a/content/pages/home.html
+++ b/content/pages/home.html
@@ -119,7 +119,8 @@ title: Home
   <div class="grid-container">
     <h2 class="margin-bottom-3">Some agencies we’ve worked with</h2>
     <ul class="grid-row grid-gap usa-list--unstyled">
-      {% for agency in agencies | where: "featured", true %}
+      {% assign featured_agencies = agencies | where: "featured" %}
+      {% for agency in featured_agencies %}
       <li class="tablet:grid-col-4 display-flex flex-align-center margin-top-4">
         {% image_with_class agency.logo "margin-right-105 maxw-7" "" %}
         {% if agency.url %}

--- a/content/pages/our-work.html
+++ b/content/pages/our-work.html
@@ -1,6 +1,7 @@
 ---
 title: Our work
 permalink: /our-work/
+layout: primary
 lead: See how we’ve helped agencies deliver value to the American people.
 hide_footer_rule: true
 redirect_from:

--- a/content/pages/work-with-us.html
+++ b/content/pages/work-with-us.html
@@ -4,7 +4,7 @@ permalink: /work-with-us/
 lead: As federal employees, we share your dedication to serving the American&nbsp;public.
 redirect_from: /how-we-work/
 hide_footer_rule: true
-layout: default
+layout: primary
 ---
 
 {% capture intro %}

--- a/content/posts/2019-10-29-culture-climate-survey.md
+++ b/content/posts/2019-10-29-culture-climate-survey.md
@@ -79,8 +79,8 @@ When we analyzed the responses, we found results that made us proud, and
 others that showed where our culture needs improvement. Some questions
 had dramatically positive results:
 
-<div aria-hidden="true" markdown="1">
-{% image "assets/blog/culture-climate-survey-2019/chart-easy-to-ask-for-help.svg" "Chart - "It is easy to ask other members of this team for help"" %}
+<div aria-hidden="true">
+{% image "assets/blog/culture-climate-survey-2019/chart-easy-to-ask-for-help.svg" "Chart - 'It is easy to ask other members of this team for help'" %}
 </div>
 
 <table class="usa-sr-only">
@@ -111,8 +111,8 @@ had dramatically positive results:
   </tbody>
 </table>
 
-<div aria-hidden="true" markdown="1">
-{% image "assets/blog/culture-climate-survey-2019/chart-contrary-opinion.svg" "Chart - "On this team, I can voice a contrary opinion without fear of negative consequences"" %}
+<div aria-hidden="true">
+{% image "assets/blog/culture-climate-survey-2019/chart-contrary-opinion.svg" "Chart - 'On this team, I can voice a contrary opinion without fear of negative consequences'" %}
 </div>
 
 <table class="usa-sr-only">
@@ -146,11 +146,11 @@ had dramatically positive results:
 Other questions also showed strengths, but with more room for
 improvement — trending at 5 instead of 7.
 
-<div aria-hidden="true" markdown="1">
-{% image "assets/blog/culture-climate-survey-2019/chart-satisfied-with-my-work.svg" "Chart - "I am satisfied with my work"" %}
+<div aria-hidden="true">
+{% image "assets/blog/culture-climate-survey-2019/chart-satisfied-with-my-work.svg" "Chart - 'I am satisfied with my work'" %}
 </div>
 
-<div class="usa-sr-only" markdown="1">
+<div class="usa-sr-only">
 </div>
 
 <table class="usa-sr-only">
@@ -181,8 +181,8 @@ improvement — trending at 5 instead of 7.
   </tbody>
 </table>
 
-<div aria-hidden="true" markdown="1">
-{% image "assets/blog/culture-climate-survey-2019/chart-growing-as-engineer.svg" "Chart - "I feel I am growing as an engineer"" %}
+<div aria-hidden="true">
+{% image "assets/blog/culture-climate-survey-2019/chart-growing-as-engineer.svg" "Chart - 'I feel I am growing as an engineer'" %}
 </div>
 
 <table class="usa-sr-only">
@@ -219,8 +219,8 @@ patterns.
 
 For example:
 
-<div aria-hidden="true" markdown="1">
-![Chart - "Administrative or clerical tasks that don’t have a specific owner are
+<div aria-hidden="true">
+![Chart - 'Administrative or clerical tasks that don’t have a specific owner are
 fairly divided"]({{site.baseurl}}/assets/blog/culture-climate-survey-2019/chart-administrative-tasks-fairly-divided.svg)
 </div>
 

--- a/content/posts/2022-01-21-what-have-you-learned-from-other-18F-designers.md
+++ b/content/posts/2022-01-21-what-have-you-learned-from-other-18F-designers.md
@@ -16,7 +16,7 @@ excerpt: "We asked 18F designers what they've learned from fellow designers whil
 Special thanks to designer Jia Gu for the images in this post
 {: .font-alt-xs }
 
-18F is a learning organization. We continue learning from each other by regularly communicating, collaborating, and sharing our ideas (in video calls, leaving real-time feedback in docs, everywhere we can) with teammates. 
+18F is a learning organization. We continue learning from each other by regularly communicating, collaborating, and sharing our ideas (in video calls, leaving real-time feedback in docs, everywhere we can) with teammates.
 
 In a design chapter meeting, we asked the team: “What have you learned from others at 18F?” Here’s what our designers had to say.
 
@@ -34,62 +34,50 @@ In a design chapter meeting, we asked the team: “What have you learned from ot
 
 ### Actively make space for others to contribute and grow.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I’m grateful for the diversity of working styles I’ve observed at 18F, which has allowed me to grow professionally. What I found most important is really making space for others—in actions, not just words. Make room for others in meetings, presentations, and The Work. Even though I’m naturally on the quiet side, my teammates were full of encouragement and trust to let me actually put into practice skills I learned. I’m so much better for it and now I’m working on paying it forward and making room for others. 
-<span>– Jacklynn Pham, UX designer (now alum) </span>
-</blockquote>
+> I’m grateful for the diversity of working styles I’ve observed at 18F, which has allowed me to grow professionally. What I found most important is really making space for others—in actions, not just words. Make room for others in meetings, presentations, and The Work. Even though I’m naturally on the quiet side, my teammates were full of encouragement and trust to let me actually put into practice skills I learned. I’m so much better for it and now I’m working on paying it forward and making room for others.
+> <span>– Jacklynn Pham, UX designer (now alum)</span>
 
 ### Check in on the team’s feels.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-It’s natural to check in about how the project tasks are going but what about the people —how are they actually doing and feeling? I learned about this thoughtful exercise from my project teammate Jacklynn Pham, which helps to check in on the well-being of the people moving the project forward.
-
-Each person on the team independently answers a set of questions and then shares and discusses their answers with the rest of the team:
-
-- **Energy.** What is and what isn’t bringing you energy while working on the project?
-- **Focus.** What would you like to do more of and how can you make room for that?
-- **Growth.** What is one thing you’re looking to be better at?
-
-This is an opportunity to deepen working relationships and give people a chance to discuss how to adjust the way they work to support the strengths, energy levels, and growth opportunities of everyone on the team.   
-<span>– Malaika Carpenter, Content strategist </span>
-</blockquote>
+> It’s natural to check in about how the project tasks are going but what about the people —how are they actually doing and feeling? I learned about this thoughtful exercise from my project teammate Jacklynn Pham, which helps to check in on the well-being of the people moving the project forward.
+>
+> Each person on the team independently answers a set of questions and then shares and discusses their answers with the rest of the team:
+>
+> - **Energy.** What is and what isn’t bringing you energy while working on the project?
+> - **Focus.** What would you like to do more of and how can you make room for that?
+> - **Growth.** What is one thing you’re looking to be better at?
+>
+> This is an opportunity to deepen working relationships and give people a chance to discuss how to adjust the way they work to support the strengths, energy levels, and growth opportunities of everyone on the team.
+> <span>– Malaika Carpenter, Content strategist</span>
 
 ### How do you want people to feel after a meeting?
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Ask questions like, “what do you want to get out of this meeting?” or “what do we want to accomplish in our time together?” to elicit the team’s response, and ask yourself, _‘How do we want them to feel at the end of this meeting?’_ This builds trust and empowerment. Doing self-reflection first and sharing it later with others helps people talk about their “feels,” which can otherwise be hard to say out loud.  
-<span>– Malaika Carpenter, Content strategist </span>
-</blockquote>
+> Ask questions like, “what do you want to get out of this meeting?” or “what do we want to accomplish in our time together?” to elicit the team’s response, and ask yourself, _‘How do we want them to feel at the end of this meeting?’_ This builds trust and empowerment. Doing self-reflection first and sharing it later with others helps people talk about their “feels,” which can otherwise be hard to say out loud.
+> <span>– Malaika Carpenter, Content strategist</span>
 
 ### Avoid meeting overload and preserve uninterrupted focus time.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Meetings can be a great way to collaborate, get the team aligned, and just check in and chat with coworkers, but do you ever look at your calendar and get scared? _Help help help, meeting overload._ (Me, too.) It’s important to preserve some uninterrupted time to find a focus flow and make progress on tasks. Feeling productive is not only good for your work, it also contributes to daily joy, motivation, and a sense of progress.
-
-Fellow 18F content designers Malaika Carpenter and Amanda Costello had both mentioned to me at various points, “try doing a meeting audit.” This means: list out all your meetings and ask yourself a few questions about each meeting to make sure they’re still a good use of everyone’s time, and restructure them or even consider dropping them if they’re not.
-
-- What’s most useful about this meeting? 
-- What’s less useful about this meeting? 
-- Do we want to keep it at this time? Reschedule to a different time? Make it shorter/longer? 
-- Anything else you’re wishing for this meeting?
-
-You can do this solo or as a team. My project team ran this exercise after about nine months of working together (so we had plenty of time to judge whether our regular meetings were best serving us) and it was really helpful. We dropped a weekly meeting that was no longer necessary, made one shorter, made one optional for certain folks, and it magically freed up longer focus blocks for our whole team. We even considered a no-meetings Friday to really maximize focus time.
-<span>– Erin Zimmer Strenio, Content strategist </span>
-</blockquote>
+> Meetings can be a great way to collaborate, get the team aligned, and just check in and chat with coworkers, but do you ever look at your calendar and get scared? _Help help help, meeting overload._ (Me, too.) It’s important to preserve some uninterrupted time to find a focus flow and make progress on tasks. Feeling productive is not only good for your work, it also contributes to daily joy, motivation, and a sense of progress.
+>
+> Fellow 18F content designers Malaika Carpenter and Amanda Costello had both mentioned to me at various points, “try doing a meeting audit.” This means: list out all your meetings and ask yourself a few questions about each meeting to make sure they’re still a good use of everyone’s time, and restructure them or even consider dropping them if they’re not.
+>
+> - What’s most useful about this meeting?
+> - What’s less useful about this meeting?
+> - Do we want to keep it at this time? Reschedule to a different time? Make it shorter/longer?
+> - Anything else you’re wishing for this meeting?
+>
+> You can do this solo or as a team. My project team ran this exercise after about nine months of working together (so we had plenty of time to judge whether our regular meetings were best serving us) and it was really helpful. We dropped a weekly meeting that was no longer necessary, made one shorter, made one optional for certain folks, and it magically freed up longer focus blocks for our whole team. We even considered a no-meetings Friday to really maximize focus time.
+> <span>– Erin Zimmer Strenio, Content strategist</span>
 
 ### One team, one dream.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Our teams are cross-functional by design. Everybody and their perspective matters to the success of the team. Clear communication and regular feedback are vital to make sure we stay in sync as a team.
-<span>– Ben Peterson, UX designer </span>
-</blockquote>
+> Our teams are cross-functional by design. Everybody and their perspective matters to the success of the team. Clear communication and regular feedback are vital to make sure we stay in sync as a team.
+> <span>– Ben Peterson, UX designer</span>
 
 ### Foster relationships, over-communicate, and be ready to pass the baton to the next person.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I learned from fellow UX designer Melissa Braxton how to foster relationships and how to over-communicate. This means regular 1:1s with teammates but also research session debriefs, weekly ships, biweekly retros, and regular project health checks (we do them biweekly for all 18F projects as a quick 5-minute form to flag any issues). We’ve documented many of these practices in the [TTS Handbook](https://handbook.tts.gsa.gov/general-information-and-resources/how-we-collaborate/). I also came to understand that our work isn’t going away. It’s a relay race: take it as far as you can but be ready to pass the baton to the next person.
-<span>– Mark Trammell, UX designer </span>
-</blockquote>
+> I learned from fellow UX designer Melissa Braxton how to foster relationships and how to over-communicate. This means regular 1:1s with teammates but also research session debriefs, weekly ships, biweekly retros, and regular project health checks (we do them biweekly for all 18F projects as a quick 5-minute form to flag any issues). We’ve documented many of these practices in the [TTS Handbook](https://handbook.tts.gsa.gov/general-information-and-resources/how-we-collaborate/). I also came to understand that our work isn’t going away. It’s a relay race: take it as far as you can but be ready to pass the baton to the next person.
+> <span>– Mark Trammell, UX designer</span>
 
 {% image "assets/blog/woman_thinking.png" "Image of woman thinking" %}
 
@@ -97,107 +85,79 @@ I learned from fellow UX designer Melissa Braxton how to foster relationships an
 
 ### Our job is facilitation, not production.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-We have a big design team at 18F, and we get to see how different people approach a problem. I’m grateful for getting to see so many ways of working, especially around facilitation. Our job is _facilitation_ not production; facilitation gets you to production. At 18F I’ve learned how we can bring our partners and their users  into the design process and share that design responsibility. That’s the real work.
-<span>– Christine Bath, Product designer </span>
-</blockquote>
+> We have a big design team at 18F, and we get to see how different people approach a problem. I’m grateful for getting to see so many ways of working, especially around facilitation. Our job is _facilitation_ not production; facilitation gets you to production. At 18F I’ve learned how we can bring our partners and their users  into the design process and share that design responsibility. That’s the real work.
+> <span>– Christine Bath, Product designer</span>
 
 ### Make people feel comfortable before user interviews.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I learned the importance of making people feel comfortable before user interviews from fellow UX designer Melissa Braxton. We want people to feel comfortable so that they’ll speak candidly about their experiences. We rely on their candor and openness in order to properly assess and address their challenges and needs so we can offer the appropriate solutions.
-<span>– Qituwra Anderson, UX designer </span>
-</blockquote>
+> I learned the importance of making people feel comfortable before user interviews from fellow UX designer Melissa Braxton. We want people to feel comfortable so that they’ll speak candidly about their experiences. We rely on their candor and openness in order to properly assess and address their challenges and needs so we can offer the appropriate solutions.
+> <span>– Qituwra Anderson, UX designer</span>
 
 ### Start a workshop with an icebreaker.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I picked up some workshop facilitation tips from fellow UX designer Ben Peterson. One tip is to start with an icebreaker. It’s a low pressure way to get everyone in the room working together. Another tip is to have guidelines and rules visible throughout the workshop. Bring a few of your own and ask folks at the beginning of the workshop if they have any to add to the list. Here are a couple of examples: share all of your ideas, speak up if you don’t agree, no one leaves the room unhappy with the outcome/direction.
-<span>– Qituwra Anderson, UX designer </span>
-</blockquote>
+> I picked up some workshop facilitation tips from fellow UX designer Ben Peterson. One tip is to start with an icebreaker. It’s a low pressure way to get everyone in the room working together. Another tip is to have guidelines and rules visible throughout the workshop. Bring a few of your own and ask folks at the beginning of the workshop if they have any to add to the list. Here are a couple of examples: share all of your ideas, speak up if you don’t agree, no one leaves the room unhappy with the outcome/direction.
+> <span>– Qituwra Anderson, UX designer</span>
 
 ### Be impartial without being impersonal.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I’ve learned how to model facilitation during user interviews; how to stay engaged with the conversation and how to be impartial without appearing impersonal or disinterested. I give verbal cues, ask follow-up questions, and reflect back what I heard from participants. The goal is to make participants feel heard and to communicate that we truly value their time and the experiences they share with us.
-<span>– Igor Korenfeld, Product designer </span>
-</blockquote>
+> I’ve learned how to model facilitation during user interviews; how to stay engaged with the conversation and how to be impartial without appearing impersonal or disinterested. I give verbal cues, ask follow-up questions, and reflect back what I heard from participants. The goal is to make participants feel heard and to communicate that we truly value their time and the experiences they share with us.
+> <span>– Igor Korenfeld, Product designer</span>
 
 ## On human-centered design
 
 ### Foster a safe space and be curious.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Fostering a safe space lets us check our ego and ask questions that help us learn and grow. To be truly human centered in your work requires being curious and open. Read more about [our partnership principles](https://18f.gsa.gov/partnership-principles/) and collaboration approaches to help your project succeed.
-<span>– Ben Peterson, UX designer </span>
-</blockquote>
+> Fostering a safe space lets us check our ego and ask questions that help us learn and grow. To be truly human centered in your work requires being curious and open. Read more about [our partnership principles](https://18f.gsa.gov/partnership-principles/) and collaboration approaches to help your project succeed.
+> <span>– Ben Peterson, UX designer</span>
 
 ### Asking for help is a sign of strength.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Power does not come from being the only one who knows. Be enthusiastic about sharing and showing—this is such a big part of the 18F culture. When there's something you don't know and want to learn, or when you ask for help understanding something, our colleagues are generally happy to teach you, share their knowledge, and show you how it's done.
-<span>– Melissa Braxton, UX designer </span>
-</blockquote>
+> Power does not come from being the only one who knows. Be enthusiastic about sharing and showing—this is such a big part of the 18F culture. When there's something you don't know and want to learn, or when you ask for help understanding something, our colleagues are generally happy to teach you, share their knowledge, and show you how it's done.
+> <span>– Melissa Braxton, UX designer</span>
 
 ### There’s power, humility, and equity within not knowing something.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Many of my colleagues at 18F have demonstrated to me (and our partners) that there’s power, humility, and equity within not knowing something. User-centered design fundamentally depends upon a designer constantly acknowledging and re-acknowledging what they don’t know, and using their expertise to ask better questions, not to assume answers. A strong team values ‘knowing the answer’ less and ‘learning the answer’ more.
-<span>– Mike Gintz, Designer </span>
-</blockquote>
+> Many of my colleagues at 18F have demonstrated to me (and our partners) that there’s power, humility, and equity within not knowing something. User-centered design fundamentally depends upon a designer constantly acknowledging and re-acknowledging what they don’t know, and using their expertise to ask better questions, not to assume answers. A strong team values ‘knowing the answer’ less and ‘learning the answer’ more.
+> <span>– Mike Gintz, Designer</span>
 
 ## On leadership and consulting
 
 ### Great leaders empower others.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-At 18F, leadership roles are framed not as positions to ascend to once you have attained a certain level of expertise, but rather as opportunities to serve your colleagues, support the organization, and grow as an individual. I’ve learned so much from my colleagues in the Design Chapter as they exemplify the principles of servant leadership: using their positions to empower others, foster inclusion and cohesion, and support their teams in achieving their goals.
-<span>– Julia Lindpaintner, UX designer </span>
-</blockquote>
+> At 18F, leadership roles are framed not as positions to ascend to once you have attained a certain level of expertise, but rather as opportunities to serve your colleagues, support the organization, and grow as an individual. I’ve learned so much from my colleagues in the Design Chapter as they exemplify the principles of servant leadership: using their positions to empower others, foster inclusion and cohesion, and support their teams in achieving their goals.
+> <span>– Julia Lindpaintner, UX designer</span>
 
 ### Think like a consultant.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-As a UX designer, it’s easy to go into projects looking for new things to design. During my time at 18F, I’ve learned how to approach the work from a consulting mindset which has helped me to recognize hidden opportunities. For example, on some partner-facing projects it may be most effective to do a deep dive into their organization and power structure, or investigate who owns which technologies and why. Rather than designing a new system, sometimes the best solutions for our partners have to do with connecting two separated teams and making introductions or simply helping them document an internal process. To me, thinking like a consultant means focusing on what’s going to be the most impactful to our partners.
-<span>– Laura Poncé, UX designer </span>
-</blockquote>
+> As a UX designer, it’s easy to go into projects looking for new things to design. During my time at 18F, I’ve learned how to approach the work from a consulting mindset which has helped me to recognize hidden opportunities. For example, on some partner-facing projects it may be most effective to do a deep dive into their organization and power structure, or investigate who owns which technologies and why. Rather than designing a new system, sometimes the best solutions for our partners have to do with connecting two separated teams and making introductions or simply helping them document an internal process. To me, thinking like a consultant means focusing on what’s going to be the most impactful to our partners.
+> <span>– Laura Poncé, UX designer</span>
 
 ### Here’s a sticky-noting trick you should know!
 
-<blockquote class="testimonial-blockquote" markdown=1>
-While working on an [affinity mapping](https://methods.18f.gov/decide/affinity-mapping/) exercise in person with one of my project partners, I learned that there’s a trick to getting sticky notes to stay on the wall. The best way to use them is to peel a new note from side-to-side off of the stack instead of from bottom-to-top. It’ll lay flat on the wall and won’t fall off as easily!
-<span>– Laura Poncé, UX designer </span>
-</blockquote>
+> While working on an [affinity mapping](https://methods.18f.gov/decide/affinity-mapping/) exercise in person with one of my project partners, I learned that there’s a trick to getting sticky notes to stay on the wall. The best way to use them is to peel a new note from side-to-side off of the stack instead of from bottom-to-top. It’ll lay flat on the wall and won’t fall off as easily!
+> <span>– Laura Poncé, UX designer</span>
 
 ## On working in government
 
 ### Get excited instead of intimidated!
 
-<blockquote class="testimonial-blockquote" markdown=1>
-When I started working on a project with the Office of Management and Budget (OMB) at the White House, they introduced me to [The Reg Map (informal rulemaking)](https://www.reginfo.gov/public/reginfo/Regmap/regmap.pdf) that outlines the rulemaking process. I’d learned how a bill becomes a law in high school civics class, but I was in the dark about rulemaking (how a law becomes policy). The nine step multi-level diagram made my head spin at first, but it was a great tool to help me learn key concepts quickly and, most importantly, ask better questions of the subject-matter experts I was working with at OMB.
-
-Government is complex because its work is complex, but even complex processes can be clear. Sometimes this means stating that a process is complex—nobody may have ever acknowledged that in plain language before! We have the opportunity to bring this clarity to so many areas of the government, and I think that’s more exciting than intimidating. 
-<span>– Amanda Costello, Content strategist </span>
-</blockquote>
+> When I started working on a project with the Office of Management and Budget (OMB) at the White House, they introduced me to [The Reg Map (informal rulemaking)](https://www.reginfo.gov/public/reginfo/Regmap/regmap.pdf) that outlines the rulemaking process. I’d learned how a bill becomes a law in high school civics class, but I was in the dark about rulemaking (how a law becomes policy). The nine step multi-level diagram made my head spin at first, but it was a great tool to help me learn key concepts quickly and, most importantly, ask better questions of the subject-matter experts I was working with at OMB.
+>
+> Government is complex because its work is complex, but even complex processes can be clear. Sometimes this means stating that a process is complex—nobody may have ever acknowledged that in plain language before! We have the opportunity to bring this clarity to so many areas of the government, and I think that’s more exciting than intimidating.
+> <span>– Amanda Costello, Content strategist</span>
 
 ### Working in the open is valuable for current and future teams.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I learned from 18F designer/researcher alum Colin MacArthur and our Chief of Staff Alan Brouilette the value of working in the open. This shared [synthesis of usability testing on Github](https://github.com/USDAForestService/fs-open-forest/wiki/Usability-Testing-Special-Uses-(Non-Commercial-and-Outfitters-modules)) with login.gov is so broadly helpful. I reference it when speaking at conferences, and to a ton of potential new colleagues when having virtual caffeines (informal video chats) with people interested in working here. Early on, when I would ask a question via direct message, I got redirected to ask it in an open channel so others could also benefit. And I often go back and reference those answers to others.
-<span>– Anne Petersen, Designer</span>
-</blockquote>
+> I learned from 18F designer/researcher alum Colin MacArthur and our Chief of Staff Alan Brouilette the value of working in the open. This shared [synthesis of usability testing on Github](https://github.com/USDAForestService/fs-open-forest/wiki/Usability-Testing-Special-Uses-(Non-Commercial-and-Outfitters-modules)) with login.gov is so broadly helpful. I reference it when speaking at conferences, and to a ton of potential new colleagues when having virtual caffeines (informal video chats) with people interested in working here. Early on, when I would ask a question via direct message, I got redirected to ask it in an open channel so others could also benefit. And I often go back and reference those answers to others.
+> <span>– Anne Petersen, Designer</span>
 
 ### Regional offices are a powerful vector to interact with an agency.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-I learned from fellow designer Mark Trammell that the Forest Service has 9 regions numbered 1 through 10 (7 is missing: [here’s why](https://www.fs.usda.gov/detail/r9/learning/history-culture/?c#:~:text=In%20response%20to%20the%20span,among%20Regions%208%20and%209.).) It’s a huge way to do research closer to home, in ‘ride-alongs’ or contextual inquiry: what do customer service folks have posted up on their monitors that they reference often? Regional Town Halls at GSA are also a huge way to have a bigger impact, demonstrate what we do, spread the word.
-<span>– Anne Petersen, Designer </span>
-</blockquote>
+> I learned from fellow designer Mark Trammell that the Forest Service has 9 regions numbered 1 through 10 (7 is missing: [here’s why](https://www.fs.usda.gov/detail/r9/learning/history-culture/?c#:~:text=In%20response%20to%20the%20span,among%20Regions%208%20and%209.).) It’s a huge way to do research closer to home, in ‘ride-alongs’ or contextual inquiry: what do customer service folks have posted up on their monitors that they reference often? Regional Town Halls at GSA are also a huge way to have a bigger impact, demonstrate what we do, spread the word.
+> <span>– Anne Petersen, Designer</span>
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Ideas rarely succeed based purely on their own inherent value—this concept of ripeness I learned from former 18F strategist Ed Mullen. Even the best, most revolutionary, creative idea needs an appropriate environment in which to take root and flourish. Is the time right for this idea? Is the climate right? Are people ready? If not, what should we do instead, rather than bashing our idea into a wall over and over again? Should we divert some/more/all of our energy towards designing the environment rather than the idea?
-<span>– Mike Gintz, Designer </span>
-</blockquote>
+> Ideas rarely succeed based purely on their own inherent value—this concept of ripeness I learned from former 18F strategist Ed Mullen. Even the best, most revolutionary, creative idea needs an appropriate environment in which to take root and flourish. Is the time right for this idea? Is the climate right? Are people ready? If not, what should we do instead, rather than bashing our idea into a wall over and over again? Should we divert some/more/all of our energy towards designing the environment rather than the idea?
+> <span>– Mike Gintz, Designer</span>
 
 ## Join us!
 

--- a/content/posts/2023-04-25-18f-checks-in-with-the-dawson-project-at-the-us-tax-court.md
+++ b/content/posts/2023-04-25-18f-checks-in-with-the-dawson-project-at-the-us-tax-court.md
@@ -45,10 +45,8 @@ Ultimately, to me this project is about how to make engaging with the Court  - w
 
 **Mike Marcotte:** I’m proud of DAWSON’s stability. There have been a few bugs here and there, but compared to the early months after launch, the bugs that we have had to tackle at one time have been few and quickly solved. Deployments are very predictable, and we are marching forward at what seems like a healthy rate. Knock on wood, the application has had only one outage in the last two years due to our service provider’s unexpected outage in one region. DAWSON came out of it more resilient than before. If a similar outage occurred  today, we would stay up and running. We owe much of this to the automated tests that improve with each deployment.
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Every week we think of new opportunities to bring to the system - it’s been great to be able to think outside the box.
-<span>– Stephanie Servoss, Clerk of the Court</span>
-</blockquote>
+> Every week we think of new opportunities to bring to the system - it’s been great to be able to think outside the box.
+> <span>– Stephanie Servoss, Clerk of the Court</span>
 
 ### _What are some recent challenges or interesting problems that you have been working on?_
 

--- a/content/posts/2023-09-07-catching-up-with-the-tanf-data-portal-project.md
+++ b/content/posts/2023-09-07-catching-up-with-the-tanf-data-portal-project.md
@@ -31,10 +31,8 @@ We caught up with Office of Family Assistance leaders Lauren Frohlich (product o
 
 **Alex Pennington**: The system is in use; that’s huge! Not only do we have the system up, but OFA is operating and maintaining the system, and [regularly pushing new updates to the code.](https://github.com/HHS/TANF-app) 
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Designing the contract and the system the way we did — for OFA to have control and input and be so involved in the development — I think it facilitates the ability to be responsive. It’s just 180 degrees from our past experience. It's so refreshing.
-<span>–Lauren Frohlich, Product Owner for the TANF Data Portal</span>
-</blockquote>
+> Designing the contract and the system the way we did — for OFA to have control and input and be so involved in the development — I think it facilitates the ability to be responsive. It’s just 180 degrees from our past experience. It's so refreshing.
+> <span>–Lauren Frohlich, Product Owner for the TANF Data Portal</span>
 
 ### _Yeah, that's a huge deal! We know there were certain things about the legacy system that were challenging. Can you talk a little bit about what's changing with the new system?_
 

--- a/content/posts/2024-02-01-gathering-feedback-with-customer-panels.md
+++ b/content/posts/2024-02-01-gathering-feedback-with-customer-panels.md
@@ -55,10 +55,8 @@ Thanks to the panel, we were able to:
 - Make usability updates to the design system and form functionality
 - Generate ideas for future features around domain management and updates
 
-<blockquote class="testimonial-blockquote" markdown=1>
-Getting feedback from real users is critical to building the right thing. By creating a customer panel, we’ve been able to hear from users shortly after they complete their first use of our product, and that’s produced some really useful insights as we build new features.
-<span>–Cameron Dixon, CISA</span>
-</blockquote>
+> Getting feedback from real users is critical to building the right thing. By creating a customer panel, we’ve been able to hear from users shortly after they complete their first use of our product, and that’s produced some really useful insights as we build new features.
+> <span>–Cameron Dixon, CISA</span>
 
 ## Key points when considering a customer panel
 

--- a/content/posts/2024-04-03-18f-practices-in-action.md
+++ b/content/posts/2024-04-03-18f-practices-in-action.md
@@ -19,9 +19,7 @@ Spoiler alert: These practices really work!
 
 ## User-centered design
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “All software development should be [centered on the needs of the software's actual end users](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#user-centered-design), the specific people who are expected to use it."
-</blockquote>
+> 18F recommendation: “All software development should be [centered on the needs of the software's actual end users](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#user-centered-design), the specific people who are expected to use it."
 
 We conducted user research during each phase of this project. We interviewed users, conducted usability testing sessions, and reviewed metrics reports and help desk reports. Team members from all disciplines participated in our research with new users (those who were eligible for a .gov domain, but didn’t yet have one) and existing users (those who already managed one or more .gov domains). We created a [customer panel](https://18f.gsa.gov/2024/02/01/gathering-feedback-with-customer-panels/) to get feedback from existing users.
 
@@ -29,9 +27,7 @@ We’re grateful to the users, from [all levels of government](https://get.gov/d
 
 ## Agile software development
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “Instead of relying on years of costly planning and ‘requirements gathering’ before beginning to write actual software, [agile development projects](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#agile-software-development) are planned only in broad strokes, with a well defined description of the overall project goal and a strong preference for just getting started…By coupling agile with user-centered design, a development team can constantly iterate toward solving the needs of end users in ways that would have been impossible to learn about up front.”
-</blockquote>
+> 18F recommendation: “Instead of relying on years of costly planning and ‘requirements gathering’ before beginning to write actual software, [agile development projects](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#agile-software-development) are planned only in broad strokes, with a well defined description of the overall project goal and a strong preference for just getting started…By coupling agile with user-centered design, a development team can constantly iterate toward solving the needs of end users in ways that would have been impossible to learn about up front.”
 
 We practiced agile development to continually improve our product. We operated on two-week sprint cycles, releasing improvements to production a few times per week. We conducted sprint planning, retros, and backlog refinement sessions. 
 
@@ -42,17 +38,13 @@ The registrar and website we developed are open source. You can follow the work 
 
 ## Product ownership
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “The [product owner is the key person](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#product-ownership) for any software project, and must be a government employee…A strong product owner ensures that the vision is clear, the strategy is clear, there is space for teams building the software to learn, and that they are building or buying the right thing to incrementally show value to users.”
-</blockquote>
+> 18F recommendation: “The [product owner is the key person](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#product-ownership) for any software project, and must be a government employee…A strong product owner ensures that the vision is clear, the strategy is clear, there is space for teams building the software to learn, and that they are building or buying the right thing to incrementally show value to users.”
 
 Our CISA product owner had the authority to speak for the .gov program, communicate directly with users and stakeholders, make decisions, prioritize, assign work, and hire staff. He had a clear vision and established a professional and respectful team culture. He made it possible for the team to focus on user needs, work in the open, and communicate using the same tools (even though team members were from different agencies and companies).
 
 ## DevOps
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “Under [DevOps](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#devops), testing software quality is automatic, testing software security is automatic, merging multiple developers' work is automatic, and moving completed software to servers is automatic.”
-</blockquote>
+> 18F recommendation: “Under [DevOps](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#devops), testing software quality is automatic, testing software security is automatic, merging multiple developers' work is automatic, and moving completed software to servers is automatic.”
 
 Our infrastructure included staging and production environments, developer sandboxes used for testing and previewing code changes, and automated testing. Automated testing included field input tests and website accessibility tests. Every source code change had to pass automated tests and had to be reviewed by another team member.
 
@@ -60,9 +52,7 @@ Because we’re committed to working in the open, our [source code commits are p
 
 # Building with loosely coupled parts
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “In this model, each component communicates with other components through [simple, modular standards](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#building-with-loosely-coupled-parts), so that any one piece can be swapped out at any time.”
-</blockquote>
+> 18F recommendation: “In this model, each component communicates with other components through [simple, modular standards](https://guides.18f.gov/derisking/federal-field-guide/basic-principles/#building-with-loosely-coupled-parts), so that any one piece can be swapped out at any time.”
 
 The .gov registrar and the get.gov public website use several components and shared services. Here are a few examples.
 
@@ -76,9 +66,7 @@ The .gov registrar and the get.gov public website use several components and sha
 
 ## Modular contracting
 
-<blockquote class="testimonial-blockquote" markdown=1>
-18F recommendation: “With the [agile contract template](https://guides.18f.gov/derisking/federal-field-guide/deciding-what-to-buy/#use-the-agile-contract-format-to-procure-agile-software-development-services)…agencies should procure developers' time, as prioritized by the government product owner through an agile cadence. Any contract must secure sufficient data rights for the agency in the work product or result of the development effort based on their mission needs.”
-</blockquote>
+> 18F recommendation: “With the [agile contract template](https://guides.18f.gov/derisking/federal-field-guide/deciding-what-to-buy/#use-the-agile-contract-format-to-procure-agile-software-development-services)…agencies should procure developers' time, as prioritized by the government product owner through an agile cadence. Any contract must secure sufficient data rights for the agency in the work product or result of the development effort based on their mission needs.”
 
 Our vision statement described the work we planned to do at a high level. This vision supported our [agile contracting](https://guides.18f.gov/derisking/federal-field-guide/deciding-what-to-buy/#use-the-agile-contract-format-to-procure-agile-software-development-services) goal by focusing on the purpose of the work. This contracting method allowed us to acquire agile software development services.
 

--- a/content/posts/posts.json
+++ b/content/posts/posts.json
@@ -1,4 +1,0 @@
-{
-  "layout": "post",
-  "permalink": "/{{ page.date | toDatePath }}/{{ page.fileSlug }}/"
-}

--- a/content/posts/posts.liquid
+++ b/content/posts/posts.liquid
@@ -1,0 +1,4 @@
+---
+layout: post
+permalink: "/{{ page.date | toDatePath }}/{{ page.fileSlug }}/"
+---


### PR DESCRIPTION
# Pull request summary

- Fix blockquote formatting. All the blockquotes that were rendered with HTML are now rendered with Markdown. Jekyll would render HTML with a `markdown=1` or `markdown="1"` attribute, but 11ty does not. Changing the HTML blockquotes to Markdown now renders with the correct styles.
- Reformat paginators so they all use regular liquid/YAML syntax
- Add or edit layout attributes. Previously, `/our-work` had no layout (so had no styling), and `/work-with-us` used `default` when it should use `primary`.
- Render only featured agencies on the homepage. Previously, the liquid syntax wasn't working as expected, so we needed to add an extra `assign` clause.