### PR TITLE
Replacing Jekyll styles with 11ty-friendly markdown

### DIFF
--- a/content/posts/2022-01-21-what-have-you-learned-from-other-18F-designers.md
+++ b/content/posts/2022-01-21-what-have-you-learned-from-other-18F-designers.md
@@ -13,8 +13,8 @@ excerpt: "We asked 18F designers what they've learned from fellow designers whil
 ---
 
 {% image "assets/blog/team_brainstorming.png" "Image of team brainstorming" %}
-Special thanks to designer Jia Gu for the images in this post
-{: .font-alt-xs }
+
+Special thanks to designer Jia Gu for the images in this post {.font-alt-xs}
 
 18F is a learning organization. We continue learning from each other by regularly communicating, collaborating, and sharing our ideas (in video calls, leaving real-time feedback in docs, everywhere we can) with teammates.
 

--- a/content/posts/2022-01-25-tech-talks.md
+++ b/content/posts/2022-01-25-tech-talks.md
@@ -14,9 +14,9 @@ image_alt: "An older model computer whose screen reads 'Building Trust With Tech
 ---
 
 
-{% image "assets/blog/tech-talks/building-trust.png" "An older model computer whose screen reads &ldquo;Building Trust With Tech Talks&rdquo;" %}
-Special thanks to Jessica Dussault for this image!
-{: .font-alt-xs }
+{% image "assets/blog/tech-talks/building-trust.png" "An older model computer whose screen reads &ldquo;Building Trust With Tech Talks&rdquo;" %} 
+
+Special thanks to Jessica Dussault for this image! {.font-alt-xs}
 
 ## An unlevel playing field
 

--- a/content/posts/2022-08-10-18f-tech-sandwich.md
+++ b/content/posts/2022-08-10-18f-tech-sandwich.md
@@ -19,21 +19,19 @@ We combine a limited set of technologies to make our applications. To explain th
 {% image "assets/blog/eng-sandwich/image2.png" "An array of food vector drawings. For bread, a baguette and slice of white bread; for protein, poultry, t-bone steak, and a cube of tofu; for fillings, mustard, chili, and tomato" %}
 
 ## Bread: cloud-based application hosting
-{% image "assets/blog/eng-sandwich/image4.png" "" %}
-{: .float-left.padding-right-2.padding-bottom-2 }
+{% image "assets/blog/eng-sandwich/image4.png" "graphic of a baguette and a slice of bread" %}{.float-left .padding-right-2 .padding-bottom-2}
+
 Bread represents commercial or government cloud hosting options. We use cloud computing to be [agile and resilient](https://18f.gsa.gov/2019/02/07/the-cloud-is-not-a-virtue/) and so that we can integrate security with our development. We host several of our applications on a government cloud provider called [cloud.gov](http://cloud.gov) which [meets many compliance requirements](https://cloud.gov/docs/compliance/ato-process/). We also have experience using our partner agencies' commercial cloud providers.
 
 ## Protein: open-source programming languages
-{% image "assets/blog/eng-sandwich/image3.png" "" %}
-{: .float-left.padding-right-2.padding-bottom-2 }
+{% image "assets/blog/eng-sandwich/image3.png" "graphic of chicken, steak, and tofu" %}{.float-left .padding-right-2 .padding-bottom-2}
 
 The protein is what makes our sandwich tasty. These are the open-source programming languages with which we have experience. We use well-supported open source languages with active communities, which helps us to ensure security support, develop language-specific practices, and write reusable code. These days, we develop mostly in Python, Ruby,  and JavaScript. We also have some experience developing with C# in the .NET Core ecosystem.
 
 Our commitment to open source languages and tools allows us to work in the open, and help ensure public input to our work.
 
 ## Fillings and condiments: features driven by user needs
-{% image "assets/blog/eng-sandwich/image5.png" "graphic of a mustard and peppers" %}
-{: .float-left.padding-right-2.padding-bottom-2 }
+{% image "assets/blog/eng-sandwich/image5.png" "graphic of a jar of mustard, pepper, and tomato" %}{.float-left .padding-right-2 .padding-bottom-2}
 
 What really makes a sandwich great are the fillings and condiments that meet individual preference and taste. In our metaphor, they represent application features that are based on the user needs we have discovered through research. The most common features we implement are user interfaces that are specific to our partner agencies' needs. We often integrate authentication, authorization, and user management. We frequently connect to notification services to send email to users. Sometimes we build integrations to transfer data to existing systems.
 

--- a/content/posts/2023-02-24-18f-checks-in-with-emily-read-and-the-usgs-water-resources-mission-area-projects.md
+++ b/content/posts/2023-02-24-18f-checks-in-with-emily-read-and-the-usgs-water-resources-mission-area-projects.md
@@ -19,8 +19,8 @@ excerpt: >
 _This is the second in a series of blog posts where 18F checks in with our partners throughout the government. Previously in this series: [18F Checks In With Jerome Lee and the eAPD Project](https://18f.gsa.gov/2022/11/29/18f-checks-in-with-jerome-lee-and-the-eapd-project/)._
 
 {% image "assets/blog/usgs-wma-checkin/20210722_150403.jpg" "USGS hydrologic technician Travis Gibson confirms Great Salt Lake water levels at the SaltAire gauge." %}
-USGS hydrologic technician Travis Gibson confirms Great Salt Lake water levels at the SaltAire gauge. Source: [USGS Multimedia Gallery](https://www.usgs.gov/media/images/great-salt-lake-reaches-new-historic-low)
-{: .font-alt-xs }
+
+USGS hydrologic technician Travis Gibson confirms Great Salt Lake water levels at the SaltAire gauge. Source: [USGS Multimedia Gallery](https://www.usgs.gov/media/images/great-salt-lake-reaches-new-historic-low) {.font-alt-xs}
 
 18F partnered with the U.S. Geological Survey (USGS) on a few different projects from March 2020 to June 2022. We worked on a wide variety of projects together, including: [Water Resources Mission Area Platform Modernization Path Analysis](https://18f.gsa.gov/2020/08/06/doing-user-research-to-design-the-next-gen-wdfn/), Experiment & Iterate, and Acquisition Consulting; National Groundwater Monitoring Network Path Analysis; and National Water Information System Data Delivery Strategy.
 

--- a/content/posts/2023-04-25-18f-checks-in-with-the-dawson-project-at-the-us-tax-court.md
+++ b/content/posts/2023-04-25-18f-checks-in-with-the-dawson-project-at-the-us-tax-court.md
@@ -22,8 +22,8 @@ excerpt: >
 _This is the third in a series of blog posts where 18F checks in with our partners throughout the government. Previously in this series: [18F Checks In With Emily Read and the USGS Water Resources Mission Area Projects](https://18f.gsa.gov/2023/02/24/18f-checks-in-with-emily-read-and-the-usgs-water-resources-mission-area-projects/)._
 
 {% image "assets/blog/ustc-dawson-checkin/dawson-home.png" "The U.S. Tax Court DAWSON electronic case file system's homepage" %}
-This is the current home page for DAWSON. The Tax Court’s electronic filing and case management system, launched in 2020, is named for the Court’s longest-serving judge, Howard A. Dawson, Jr. This system is entirely web-based and open source.
-{: .font-alt-xs }
+
+This is the current home page for DAWSON. The Tax Court’s electronic filing and case management system, launched in 2020, is named for the Court’s longest-serving judge, Howard A. Dawson, Jr. This system is entirely web-based and open source. {.font-alt-xs}
 
 The United States Tax Court is an independent federal court that settles disputes between taxpayers and the Internal Revenue Service. Since the 1980s, the Court has used a modified commercial software product to manage its operations. In December 2020, the Court introduced [DAWSON](https://www.dawson.ustaxcourt.gov), a modern open-source case management system developed with assistance from an industry partner and 18F. DAWSON streamlined Court operations and changed the way the public interacts with the Court.
 


### PR DESCRIPTION
# Pull request summary
Replaces Jekyll inline styles with 11ty-friendly HTML classes, using [markdown-it](https://github.com/markdown-it/markdown-it) (which is already included in the project). 

Related to TLC ticket https://github.com/18F/18f.gsa.gov/issues/3971