### PR TITLE
Revert to using posts.json

### DIFF
--- a/content/posts/posts.json
+++ b/content/posts/posts.json
@@ -1,0 +1,4 @@
+{
+  "layout": "post",
+  "permalink": "/{{ page.date | toDatePath }}/{{ page.fileSlug }}/"
+}

--- a/content/posts/posts.liquid
+++ b/content/posts/posts.liquid
@@ -1,4 +1,0 @@
----
-layout: post
-permalink: "/{{ page.date | toDatePath }}/{{ page.fileSlug }}/"
----


### PR DESCRIPTION
 Revert to using posts.json

It's a bit of a mystery to me why posts.liquid and posts.json differ when using the same syntax, but it appears the site doesn't build most posts when it's posts.liquid, but it works fine when it's posts.json. Maybe it's something to do with how the data pipeline works.

So, we'll leave it as JSON.