### PR TITLE
Update repository_dispatch_create_issue.yml

### DIFF
--- a/.github/workflows/repository_dispatch_create_issue.yml
+++ b/.github/workflows/repository_dispatch_create_issue.yml
@@ -10,15 +10,28 @@ jobs:
     steps:
       - name: Create GH issue
         run: |
-          DECODED_REPORT=$(echo $BODY | base64 --decode)
+          if [[ $CLOSE_PREVIOUS == true ]]; then
+            previous_issue_number=$(gh issue list \
+              --label "$LABELS" \
+              --json number \
+              --jq '.[0].number')
+            if [[ -n $previous_issue_number ]]; then
+              gh issue close "$previous_issue_number"
+            fi
+          fi
           gh issue create \
             --title "Nightly pa11y scan failed" \
             --assignee "$ASSIGNEES" \
             --label "$LABELS" \
-            --body "```$DECODED_REPORT```"
+            --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           ASSIGNEES: caleywoods
-          LABELS: type:accessibility
+          LABELS: type:accessibility,nightly-pa11y-scan-failed
           BODY: ${{ github.event.client_payload.report }}
+          CLOSE_PREVIOUS: false
+          BODY: |
+            ```
+            $(echo $BODY | base64 --decode)
+            ```


### PR DESCRIPTION
# Pull request summary
This pull request updates the GitHub action that is responsible for creating a new issue on the `repository_dispatch` event. This event is currently sent by a cURL POST from the CircleCI script to notify us of a failed pa11y scan. I've added support for closing a previous issue although the exact logic is not yet in place because I'd like to test if the escaping of HTML in the issue body is handled correctly now as a part of this change.


