### PR TITLE
Manually correct social media external links

### DIFF
--- a/data/social_media.yml
+++ b/data/social_media.yml
@@ -1,18 +1,27 @@
 -
   platform: GitHub
   link: https://github.com/18F
+  html:
+    class: usa-link--external
+    rel:   noreferrer
   image:
     light: assets/img/social-icons/svg/github-lightest.svg
     dark: assets/img/social-icons/svg/github-darkest.svg
 -
   platform: Twitter
   link: https://twitter.com/18F
+  html:
+    class: usa-link--external
+    rel:   noreferrer
   image:
     light: assets/img/social-icons/svg/twitter-lightest.svg
     dark: assets/img/social-icons/svg/twitter-darkest.svg
 -
   platform: LinkedIn
   link: https://www.linkedin.com/company/gsa18f
+  html:
+    class: usa-link--external
+    rel:   noreferrer
   image:
     light: assets/img/social-icons/svg/linkedin-lightest.svg
     dark: assets/img/social-icons/svg/linkedin-darkest.svg

--- a/templates/social-media.html
+++ b/templates/social-media.html
@@ -4,7 +4,8 @@
     {% for item in social_media %}
     <li class="margin-bottom-2">
       <a href="{{ item.link | url }}"
-         class="usa-link--alt"
+         class="usa-link--alt {{ item.html.class }}"
+         rel="{{ item.html.rel }}"
          >
          {% image_with_class item.image.light "maxw-3 margin-right-2 text-sub" "" %}
          {%- unless item.platform == "RSS feed" -%}18F on {% endunless %}{{ item.platform }}


### PR DESCRIPTION
Solution options here were:

1. spend a long time figuring out why the Markdown renderer that's supposed to handle links isn't seeing the "18F on {platform}" links in the social media sidebar, or
2. manually mark them external

I opted for 2 just to get the migration done for now.

I've listed a task in #3864 to handle this more systematically — our renderers not in good condition to be maintainable in the long run, so this is pennies on top of an already hefty technical debt.

Fixes #4053 
