### PR TITLE
CircleCI config syntax fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,17 @@ jobs:
       # - run:
       #     name: Check JavaScript style
       #     command: npx standard
-      - lint: npm run lint
-      - build: npm run build
-      - verify:
-        name: Verify that the build passes HTML validation
-        command: |
-          npm run test:html-validation
-          npm run test:links
+      - run: 
+          name: Lint JavaScript
+          command: npm run lint
+      - run:
+          name: Build the site
+          command: npm run build
+      - run:
+          name: Verify that the build passes HTML validation
+          command: |
+           npm run test:html-validation
+           npm run test:links
       # We export the file list in pa11y_targets so that we can make pa11y-ci scan only those changed files in the "Run pa11yci" step
       # - run:
       #     name: 11ty build


### PR DESCRIPTION
# Pull request summary

I noticed [in the CircleCI dashboard](https://app.circleci.com/pipelines/github/18F/18f.gsa.gov/3485) that the `.circleci/config.yml` file on `main` had syntax issues. I looked at the config file locally and the CircleCI config validator that is part of their CLI toolkit reported the same issues.

I used the CircleCI config editor on their site to help understand what needed to change since both the CLI validator and the error in the CircleCI dashboard are hard to understand. The changes are simple, just moving the lint, build, and verify steps into `run` blocks, their previous syntax looked like maybe it was meant to use commands `lint`, `build`, and `verify` but they weren't being defined in a [commands block](https://circleci.com/docs/configuration-reference/#commands) prior to being used. 
