### PR TITLE
Fix social media link class typo

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -68,7 +68,7 @@
                  class="{% if item.html.class %}{{ item.html.class }}{% endif %}"
                  {% if item.html.rel %}rel="{{ item.html.rel }}"{% endif %}
                  >
-                {% assign img_class = "mmaxw-205 margin-right-1 " | append: item.image.html.class %}
+                {% assign img_class = "maxw-205 margin-right-1 " | append: item.image.html.class %}
                 {% image_with_class item.image.dark img_class %}
                 {{- item.platform -}}
               </a>


### PR DESCRIPTION
# Pull request summary
Inside `templates/footer.html` the max width class being applied to the social media logos had an extra `m` in the class name.


