### PR TITLE
Add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ web_modules/
 .env.production.local
 .env.local
 
+# VSCode files, for example debugger launch profiles
+.vscode
+
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 


### PR DESCRIPTION
# Pull request summary

Configure git to ignore the `.vscode` directory, which stores some IDE-specific local files for VSCode users (for example, debugger launch profiles) that shouldn't be in source control.

## Reminder - please do the following before assigning reviewer

- [x] Update readme
- [x] For frontend changes, ensure design review
- [x] For content changes beyond typos, add Ron Bronson as a reviewer

And make sure that automated checks are ok

- fix houndci feedback
- ensure tests pass
- federalist builds
- no new SNYK vulnerabilities are introduced


