### PR TITLE
Cleaning up front matter from the last year or so

### DIFF
--- a/content/posts/2023-03-23-A-check-up-for-agile-teams.md
+++ b/content/posts/2023-03-23-A-check-up-for-agile-teams.md
@@ -8,7 +8,8 @@ tags:
   - best practices
   - how we work
   - modern practices
-excerpt: "Even on the best teams, things need to be monitored and adjusted. If you are doing this for the first time, it can be even harder. In this article, I share some signals of what success looks like and what to do if you are stuck in one of the many common pitfalls."
+excerpt: >
+  Even on the best teams, things need to be monitored and adjusted. If you are doing this for the first time, it can be even harder. In this article, I share some signals of what success looks like and what to do if you are stuck in one of the many common pitfalls.
 ---
 
 Even on the best teams, things need to be monitored and adjusted. If you are doing this for the first time, it can be even harder. In this article, I share some signals of what success looks like and what to do if you are stuck in one of the many common pitfalls.

--- a/content/posts/2023-04-20-hi-from-the-18F-design-chapter.md
+++ b/content/posts/2023-04-20-hi-from-the-18F-design-chapter.md
@@ -4,16 +4,17 @@ title: >
   “Hi” from the 18F design chapter
 
 authors:
- - melissa-braxton
- - ron-bronson
- - amanda-costello
- - laura-nash
+  - melissa-braxton
+  - ron-bronson
+  - amanda-costello
+  - laura-nash
  
 tags:
   - join us
   - culture
   - how we work
   - user-centered design
+  
 excerpt: >
   Designing technology-enabled public services requires deep expertise in how different elements of the experience come together (or don’t!).  The 18F design chapter comprises four discipline-specific cohorts — service design, user experience (UX) design, product design, and content strategy.
 image: 

--- a/content/posts/2023-05-08-andrew-hyder-award.md
+++ b/content/posts/2023-05-08-andrew-hyder-award.md
@@ -8,7 +8,7 @@ authors:
 tags:
   - public service
 excerpt: >
-    TTS annually awards the Andrew Hyder Government Service Improvement Award to one or more federal employees who demonstrate both excellence in their work and a commitment to improving the public's experience with government.
+  TTS annually awards the Andrew Hyder Government Service Improvement Award to one or more federal employees who demonstrate both excellence in their work and a commitment to improving the public's experience with government.
 ---
 TTS annually awards the Andrew Hyder Government Service Improvement Award to one or more federal employees who demonstrate both excellence in their work and a commitment to improving the public's experience with government.
 

--- a/content/posts/2023-06-13-The-four-operating-levels-of-18F-projects.md
+++ b/content/posts/2023-06-13-The-four-operating-levels-of-18F-projects.md
@@ -8,9 +8,10 @@ tags:
   - culture
   - how we work
 excerpt: >
-   At 18F, we partner with government agencies to help them deliver new or modernized digital services. In our experience, we have identified four operating levels that best support successful project outcomes.
+  At 18F, we partner with government agencies to help them deliver new or modernized digital services. In our experience, we have identified four operating levels that best support successful project outcomes.
 ---
 At 18F, we partner with government agencies to help them deliver new or modernized digital services and help set them up for success after we conclude the project. To support these outcomes, we set up our work to track on four levels:
+
 * Project management
 * Product development
 * Post-18F sustainability

--- a/content/posts/2023-08-22-7-tips-on-facilitating-unplanned-topics-in-meetings.md
+++ b/content/posts/2023-08-22-7-tips-on-facilitating-unplanned-topics-in-meetings.md
@@ -6,9 +6,8 @@ authors:
   - qituwra-anderson
 tags: 
 - best practices
-excerpt: > 
+excerpt: >
   Facilitating a workshop can feel like a daunting task. Here at 18F, we’ve identified seven tips to keep your workshop organized and flowing, despite unplanned scenarios.
-image:
 ---
 
 You’re facilitating a workshop and the attendees bring up an important thought, idea or topic that you had not originally incorporated into your planning. Since the topic broached is relevant to the work you want to include it, but are unsure how to keep the workshop feeling organized.  You can try the following tips to keep the workshop flowing.

--- a/content/posts/2023-09-05-first-do-no-harm.md
+++ b/content/posts/2023-09-05-first-do-no-harm.md
@@ -1,15 +1,14 @@
 ---
 date: 2023-09-05
 title: >
- First, do no harm: mistakes to avoid in creating accessible user experiences
+  First, do no harm: mistakes to avoid in creating accessible user experiences
 authors: 
   - jason-nakai
 tags: 
 - best practices
 - accessibility
-excerpt: > 
+excerpt: >
   Accessible design and development practices help us build inclusive experiences. But we can lose sight of the people we serve if we don’t steadily work to better understand our users. To create accessible experiences, avoid these mistakes.
-image:
 ---
 
 # First, do no harm

--- a/content/posts/2023-09-07-catching-up-with-the-tanf-data-portal-project.md
+++ b/content/posts/2023-09-07-catching-up-with-the-tanf-data-portal-project.md
@@ -1,22 +1,25 @@
 ---
-title: "Catching up with the TANF Data Portal project"
+title: Catching up with the TANF Data Portal project
 date: 2023-09-07
 authors: 
-- lauren-frohlich
-- alex-pennington
-- christine-bath
-- alex-soble
-- selena-juneau-vogel
-- laura-gerhardt
+  - lauren-frohlich
+  - alex-pennington
+  - christine-bath
+  - alex-soble
+  - selena-juneau-vogel
+  - laura-gerhardt
 tags:
-- agency work
-- interview
-- public benefits
-- hhs
-- 18f checks in
-excerpt: "Around 800,000 low-income American families receive cash assistance through Temporary Assistance for Needy Families (TANF) each month. 18F and the Administration for Children & Families’ Office of Family Assistance partnered on building a new data portal for TANF. We caught up with Office of Family Assistance leaders to see how their agency is continuing with the work."
+  - agency work
+  - interview
+  - public benefits
+  - hhs
+  - 18f checks in
+excerpt: >
+  Around 800,000 low-income American families receive cash assistance through Temporary Assistance for Needy Families (TANF) each month. 18F and the Administration for Children & Families’ Office of Family Assistance partnered on building a new data portal for TANF. We caught up with Office of Family Assistance leaders to see how their agency is continuing with the work.
+
 image: /assets/blog/tanf-data-portal-catchup/TDP-checkin--banner.png
-image_alt: "Three potted plans in a row. The first is a seedling, followed by one with two leaves, and a larger plant that looks like a tree."
+image_alt: >
+  Three potted plans in a row. The first is a seedling, followed by one with two leaves, and a larger plant that looks like a tree."
 ---
 
 Around 800,000 low-income American families receive cash assistance through Temporary Assistance for Needy Families (TANF) each month. States, tribes, and territories use federal block grant funds to administer the program, and they must report data back to the federal government on a quarterly basis. 

--- a/content/posts/2023-09-21-18f-website-refresh.md
+++ b/content/posts/2023-09-21-18f-website-refresh.md
@@ -1,11 +1,12 @@
 ---
-title: "A website refresh in 3 months"
+title: A website refresh in 3 months
 date: 2023-09-21
 authors: 
-- amelia-wong
+  - amelia-wong
 tags: 
-- how we work
-excerpt: "A website redesign doesn't have to be a big project. By approaching it as a process of iteration, we launched a refreshed site in the span of several weeks."
+  - how we work
+excerpt: >
+  A website redesign doesn't have to be a big project. By approaching it as a process of iteration, we launched a refreshed site in the span of several weeks.
 ---
 
 This past summer, we decided to refresh the 18F website. Since the last big redesign four years ago, we’d made a few tweaks, but not any significant changes. So why now?

--- a/content/posts/2023-12-05-Sharing-artifacts-and-outputs-from-research.md
+++ b/content/posts/2023-12-05-Sharing-artifacts-and-outputs-from-research.md
@@ -1,11 +1,12 @@
 ---
-title: "Sharing artifacts and outputs from research"
+title: Sharing artifacts and outputs from research
 date: 2023-12-05
 authors: 
-- qituwra-anderson
+  - qituwra-anderson
 tags: 
-- how we work
-excerpt: "Have you conducted user research and are now wondering what artifacts or outputs you can share and with whom? Here's a guide."
+  - how we work
+excerpt: >
+  Have you conducted user research and are now wondering what artifacts or outputs you can share and with whom? Here's a guide.
 ---
 Have you conducted user research and are now wondering what artifacts or outputs you can share and with whom? Artifacts and outputs are generally shareable as long as sharing the data does not violate:
 

--- a/content/posts/2024-01-12-andrew-hyder-award.md
+++ b/content/posts/2024-01-12-andrew-hyder-award.md
@@ -5,7 +5,7 @@ authors:
   - amanda-costello
 tags:
   - public service
-excerpt: |
+excerpt: >
   TTS is proud to present the 2023 Andrew Hyder Government Service Improvement Award to Lalitha Jonnalagadda. This is awarded annually to one or more federal employees who demonstrate both excellence in their work and a commitment to improving the public's experience with government.
 ---
 

--- a/content/posts/2024-02-01-gathering-feedback-with-customer-panels.md
+++ b/content/posts/2024-02-01-gathering-feedback-with-customer-panels.md
@@ -1,15 +1,13 @@
 ---
 date: 2024-02-01
-title: >
- Gathering feedback with customer panels
+title: Gathering feedback with customer panels
 authors: 
   - boon-sheridan
 tags: 
-- 18f
-- how we work
+  - 18f
+  - how we work
 excerpt: >
- Ever wondered how the federal government, cities, towns and other groups get a .gov domain for their sites? The Cybersecurity and Infrastructure Security Agency (CISA) manages all these domains across the web. Learn how we helped CISA build a customer panel to gather feedback from current customers as part of our partnership in building a new website for the .gov registrar.
-image:
+  Ever wondered how the federal government, cities, towns and other groups get a .gov domain for their sites? The Cybersecurity and Infrastructure Security Agency (CISA) manages all these domains across the web. Learn how we helped CISA build a customer panel to gather feedback from current customers as part of our partnership in building a new website for the .gov registrar.
 ---
 
 # Recruiting customers with feedback panels

--- a/content/posts/2024-03-05-customer-experience-beyond-surveys.md
+++ b/content/posts/2024-03-05-customer-experience-beyond-surveys.md
@@ -1,16 +1,15 @@
 ---
 date: 2024-03-05
 title: >
- Customer experience: beyond surveys
+  Customer experience: beyond surveys
 authors: 
   - amanda-kennedy
 tags: 
-- 18f
-- how we work
-- user-centered design
+  - 18f
+  - how we work
+  - user-centered design
 excerpt: >
- Want to measure customer experience? Surveys aren’t the only way! Consider these guiding questions to help your team select an approach based on what you want to learn.
-image:
+  Want to measure customer experience? Surveys aren’t the only way! Consider these guiding questions to help your team select an approach based on what you want to learn.
 ---
 
 # Customer experience: beyond surveys

--- a/content/posts/2024-03-19-18f-at-ten.md
+++ b/content/posts/2024-03-19-18f-at-ten.md
@@ -1,17 +1,17 @@
 ---
 date: 2024-03-19
 title: >
- 18F at ten
+  18F at ten
 authors: 
   - ron-bronson
 tags: 
-- 18f
-- anniversary
-- how we work
+  - 18f
+  - anniversary
+  - how we work
 excerpt: >
- We’re celebrating all the ways we continue to realize our founding vision: bringing technologists into government, launching shared digital services, and helping partner agencies build user-centered technology.
+  We’re celebrating all the ways we continue to realize our founding vision: bringing technologists into government, launching shared digital services, and helping partner agencies build user-centered technology.
 image: /assets/blog/10-anniversary/10-anniv-dark.jpg
-image_alt: "The number 10 surrounded by confetti"
+image_alt: The number 10 surrounded by confetti
 ---
 
 It’s been [a <i>decade</i> since we launched 18F](https://www.gsa.gov/about-us/newsroom/news-releases/at-10-years-gsas-tech-consulting-team-18f-cele-03192024) with a [“Hello, world”](https://18f.gsa.gov/2014/03/19/hello-world-we-are-18f/) blog post about our vision for change, in the midst of the growth in national interest in government technology. We’ve come a long way since then, we’ve grown a lot, and we’ve learned a lot about how to build user-centered technology in government.

--- a/content/posts/2024-08-20-andrew-hyder-award.md
+++ b/content/posts/2024-08-20-andrew-hyder-award.md
@@ -1,11 +1,12 @@
 ---
-title: Andrew Hyder Government Service Improvement Award recognizes commitment to serving the public
+title: >
+  Andrew Hyder Government Service Improvement Award recognizes commitment to serving the public
 date: 2024-08-20
 authors:
   - amanda-costello
 tags:
   - public service
-excerpt: |
+excerpt: >
   TTS is proud to present the 2024 Andrew Hyder Government Service Improvement Award to Ryan Ahearn.
 ---
 

--- a/content/posts/2024-09-12-derisking-guide-update.md
+++ b/content/posts/2024-09-12-derisking-guide-update.md
@@ -1,15 +1,15 @@
 ---
-title: A revised and expanded guide for de-risking government technology projects
+title: >
+  A revised and expanded guide for de-risking government technology projects
 date: 2024-09-12
 authors: 
-- amelia-wong
+  - amelia-wong
 tags:  
-- best practices
-- how we work
-- lessons learned
-excerpt: |
+  - best practices
+  - how we work
+  - lessons learned
+excerpt: >
   New content on vendor management and a streamlined structure make one of 18F's most popular guides even more useful for government staff.
-image: 
 ---
 
 Today we launch a new version of the [De-risking Government Technology Guide](https://guides.18f.gov/derisking-government-tech/), its first update since being published in 2020. Find all the recommendations from the original guide’s two parts—the State Software Budgeting Handbook and the Federal Field Guide—now in one unified package. Plus, there's a new, in-depth section on vendor management! 

--- a/content/posts/2024-10-08-18f-year-of-launches.md
+++ b/content/posts/2024-10-08-18f-year-of-launches.md
@@ -3,15 +3,16 @@ title: 18F’s year of launches
 date: 2024-10-08
 authors: 
 - 18F
-excerpt: "Over the past year, 18F has helped amazing partner agencies launch new software products to better serve their users.
+excerpt: >
+  Over the past year, 18F has helped amazing partner agencies launch new software products to better serve their users.
 
-Here are six launches that 18F has supported this year."
+  Here are six launches that 18F has supported this year.
 image: /assets/blog/year-of-launches/header.png
 image_alt: "An image of six rocket ships launching into space"
-# tags:
-# - 18f
-# - agency-work
-# - product-launch
+tags:
+  - 18f
+  - agency work
+  - product launch
 ---
 
 18F works to improve the user experience of government. Over the past year, 18F has helped amazing partner agencies launch new software products to better serve their users. Each successful launch depends on solid user research, careful product thinking, and strong team-building.


### PR DESCRIPTION
I noticed that the "year of launches" post has no tags — they're all commented out, even though they look quite relevant.

The tags that were commented out are written using dashes, which is the wrong tag format — they need to be space-separated. So, my guess is that they were commented out because they were causing build errors.

This commit:

- Adds back commented-out tags
- Cleans up title and excerpt formats from posts from the last year or so
