### PR TITLE
docs: clarify contribution starting point

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 The 18F website and blog serve as 18F's primary outreach tool, communicating about 18F's way of working and value proposition to prospective partners, the broader digital services community, and the general public.
 
-## I’d like to make a contribution, how do I update this content?
+## Contributing
+
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) for project policies, licensing, and contributor expectations. If you're an 18F team member adding a blog post or updating site content, use the existing files in `content/posts/` and `content/pages/` as examples, then follow the [development docs](docs/development.md) to preview and test your changes locally.
 
 All team members are encouraged to submit blog posts and suggest website improvements that benefit the organization.
 
@@ -10,7 +12,7 @@ Though this website and blog carry the 18F brand, the intention is to spread the
 
 By developing this material in the open, we hope to encourage expert review and contributions from members of the tech community outside of government, furthering our goal of improving how government works through increased civic engagement of tech specialists. We hope this material and the means by which it is developed will attract new recruits to government technology positions, but for those who are not inclined to do so, helping cultivate the guides is a potentially high-visibility, high-impact contribution to government work that doesn’t require a major life change.
 
-The [CODEOWNERS file](.github/CODEOWNERS) keeps track of who is in review & approver roles for content in the guides — if you’re not receiving a timely (within two weeks) review or notice the list is outdated, reach out to 18F’s Outreach coordinator for assistance. These reviewers will be automatically tagged appropriately when opening pull requests. Read [CONTRIBUTING](CONTRIBUTING.md) for more information.
+The [CODEOWNERS file](.github/CODEOWNERS) keeps track of who is in review & approver roles for content in the guides — if you’re not receiving a timely (within two weeks) review or notice the list is outdated, reach out to 18F’s Outreach coordinator for assistance. These reviewers will be automatically tagged appropriately when opening pull requests.
 
 Issues opened in this repo are automatically added to the [18F TLC project board](https://github.com/orgs/18F/projects/41/views/1) for prioritization for 18F staff in between projects to work on.
 

--- a/config/filters/teamLink.js
+++ b/config/filters/teamLink.js
@@ -2,5 +2,5 @@ const { findPerson, fullName } = require('../../lib/team');
 
 module.exports = async (slug) => {
   const name = fullName(findPerson(slug))
-  return `<a href="/author/${slug.toLowerCase()}/" itemprop="name">${name}</a>`
+  return `<span itemprop="name">${name}</span>`
 }

--- a/content/posts/2015-08-10-18f-design-methods.md
+++ b/content/posts/2015-08-10-18f-design-methods.md
@@ -158,22 +158,22 @@ love to hear how we could make the method cards even more useful to you.
 
 Project team:
 
--   [Jeremy Canfield]({{ "/author/jeremy/" | url }})
+-   Jeremy Canfield
 
--   [Elizabeth Goodman]({{ "/author/egoodman/" | url }})
+-   Elizabeth Goodman
 
--   [James Hupp]({{ "/author/jameshupp/" | url }})
+-   James Hupp
 
--   [Jeannine Hunter]({{ "/author/jhunter/" | url }})
+-   Jeannine Hunter
 
--   [Colin MacArthur]({{ "/author/colinmacarthur/" | url }})
+-   Colin MacArthur
 
--   [Andrew Maier]({{ "/author/andrewmaier/" | url }})
+-   Andrew Maier
 
--   [Brad Nunnally]({{ "/author/bradnunnally/" | url }})
+-   Brad Nunnally
 
--   [Jennifer Thibault]({{ "/author/jthibault/" | url }})
+-   Jennifer Thibault
 
--   [Russ Unger]({{ "/author/russ/" | url }})
+-   Russ Unger
 
--   [Victor Zapanta]({{ "/author/victor/" | url }})
+-   Victor Zapanta

--- a/content/posts/2016-01-08-18f-new-years-resolution-be-even-more-open.md
+++ b/content/posts/2016-01-08-18f-new-years-resolution-be-even-more-open.md
@@ -92,13 +92,13 @@ to](https://github.com/18F/18f.gsa.gov/issues/1445):
  those tools, write about them more, and identify the parts of our
  work that are generic. Decoupling them from the applications we
  developed them for will make it easier for others to reuse them.
- (h/t [**Eric Mill**]({{ "/author/eric/" | url }}))
+ (h/t **Eric Mill**)
 
 -   **Learn from previous contributors.** We’d like to reach out to
  previous contributors to see what they liked and didn’t like. If
  they contributed once and never returned, we’d like to find out
- why. Are there ways we can invite them back? (h/t [**Maya
- Benari**]({{ "/author/maya/" | url }}))
+ why. Are there ways we can invite them back? (h/t **Maya
+ Benari**)
 
 -   **Make it worthwhile** to contribute. Unpaid work on government
  projects is public service, requiring time, effort, and skill, and
@@ -120,7 +120,7 @@ to](https://github.com/18F/18f.gsa.gov/issues/1445):
  etiquette**. For example, you should always explain why you're
  closing an issue or pull request — and we shouldn't expect new
  hires to know that on their first day. (h/t
- [**Leah Bannon**]({{ "/author/leah/" | url }}))
+ **Leah Bannon**)
 
 -   **Address user needs.** Here’s a specific user need: "I have a lot
  of experience with open source, and I heard about 18F. Can you

--- a/content/posts/2016-04-25-lean-on-me-asking-for-help-on-the-content-team.md
+++ b/content/posts/2016-04-25-lean-on-me-asking-for-help-on-the-content-team.md
@@ -18,7 +18,7 @@ collaboration.*
 
 {% image "assets/blog/content/collaborate-content.jpg" "A circle of head shots of the Content Team with lines connecting them" %}
 
-[Emileigh]({{ "/author/emileigh/" | url }})
+Emileigh
 ------------------------------------------------
 
 One of my projects involves a substantial content migration. I’ve done
@@ -35,7 +35,7 @@ content](https://insidegovuk.blog.gov.uk/2015/03/12/gov-uk-now-has-an-archiving-
 an especially useful tool in a project like the one I’m working on — a
 website with more than 20 years of information on it.
 
-[Corey]({{ "/author/corey-mahoney/" | url }})
+Corey
 --------------------------------------------------
 
 Recently, I got stuck while writing some instructions to help users
@@ -49,7 +49,7 @@ find other applications that had solved the same problem and figure out
 the right terminology. The version we came up with was clear and
 consistent — and we got to do user testing to validate that it worked!
 
-[Britta]({{ "/author/britta-gustafson/" | url }})
+Britta
 ------------------------------------------------------
 
 I made a lot of progress on a blog post by bringing it to our weekly
@@ -61,7 +61,7 @@ overthinking, and which parts needed revising (such as starting the post
 with a summary and making the headings much shorter). If seven fellow
 content people say something looks fine, you know it’s fine.
 
-[Jeannine]({{ "/author/jhunter/" | url }})
+Jeannine
 -----------------------------------------------
 
 I value how our team’s culture facilitates immediate requests for help,
@@ -78,7 +78,7 @@ off big-picture ideas regarding content strategy and how we can
 capitalize on the brain power of content strategists across 18F. Her
 insight and ideas are invaluable and creative.
 
-[Ryan]({{ "/author/ryan-sibley/" | url }})
+Ryan
 -----------------------------------------------
 
 I collaborated with James on a content audit to determine what content
@@ -99,7 +99,7 @@ the task is*. That kind of shift seems small, but the way a reader
 reacts to something often hinges on something small. And it meant I
 could write the email for everyone, not just a few users.
 
-[Nicole]({{ "/author/nicole-fenton/" | url }})
+Nicole
 ---------------------------------------------------
 
 I asked Kate for help with a presentation about our design capabilities.
@@ -108,7 +108,7 @@ and panache in the right places. I’ve also been working with Ryan,
 Britta, and Corey on some new internal documentation about what we do as
 content designers.
 
-[Kate]({{ "/author/kate/" | url }})
+Kate
 ----------------------------------------
 
 Every day, I’m grateful to be working with such a talented team that’s

--- a/content/posts/2016-05-06-the-day-90-kids-came-to-code-with-18f.md
+++ b/content/posts/2016-05-06-the-day-90-kids-came-to-code-with-18f.md
@@ -21,8 +21,8 @@ models out of Legos, and visiting electric cars from the GSA Fleet.
 
 How could we impress them after that? Turns out, it was kind of hard.
 
-“Coding isn’t a new concept for kids anymore,” said [Elaine
-Kamlley]({{ "/author/elaine/" | url }}), a developer at 18F who
+“Coding isn’t a new concept for kids anymore,” said Elaine
+Kamlley, a developer at 18F who
 helped organize their visit. “Most of them who sat down to code with us
 said they played these games in school before.”
 

--- a/content/posts/2016-09-06-nicole-fenton-a-wordsmith-joins-government.md
+++ b/content/posts/2016-09-06-nicole-fenton-a-wordsmith-joins-government.md
@@ -74,11 +74,11 @@ reflecting on my own needs and interests, here I am at 18F.
 
 **MK: How did you find out about 18F?**
 
-**NF:** I first heard about 18F through [Jesse Taggert]({{ "/author/jtag/" | url }}). We were friends
+**NF:** I first heard about 18F through Jesse Taggert. We were friends
 in San Francisco before I moved to New York. We always keep an eye on
 what the other person is doing.
 
-I would occasionally read the blog, and I also know [Meghana]({{ "/author/meghana/" | url }}) from my work
+I would occasionally read the blog, and I also know Meghana from my work
 at the School for Visual Arts, so I was curious about the team.
 
 As a strategist, I do a lot of thinking about goals and next steps, and

--- a/content/posts/2018-02-28-ask-18f-data-collection.md
+++ b/content/posts/2018-02-28-ask-18f-data-collection.md
@@ -17,7 +17,7 @@ To get this column started, we have answers from two of our data experts to a qu
 
 ## My office gathers data from a wide variety of sources. How can I make this process easier for our office and our sources? Where should I start?
 
-### [Lindsay Young]({{ "/author/lindsay/" | url }}) - 18F Developer working with the Federal Election Commission 
+### Lindsay Young - 18F Developer working with the Federal Election Commission
 
 Collecting data and making it available to the public is no easy feat. With any large project, I recommend starting small. You may be able to collect data by email or use spreadsheet software to make a prototype. Make sure to document the format you need and logic you use to update your data so you can scale prototypes into larger solutions as needed. 
 
@@ -27,7 +27,7 @@ While this may seem daunting, the good news is that you’re not alone. Many age
 
 My recommendation is to start small, understand the risks, and reach out for support. Good luck!
 
-### [Tony Garvan]({{ "/author/anthony-garvan/" | url }}) - Data Lead at 18F 
+### Tony Garvan - Data Lead at 18F
 
 Easing data ingest for the public and for your office is a big undertaking — you likely won’t be able to tackle it all at once. The good news is that things that lessen the burden for the public usually also lessen the burden for your office: less back and forth and more validation up front helps both parties. Digitizing a paper form into a responsive website is generally a good first step. Choose the form that has the biggest impact and that can be deployed in less than six months (generally one with less than five pages). Don’t reinvent the wheel: consider using tools like [login.gov](https://www.login.gov/), [cloud.gov](https://cloud.gov/) and the [U.S. Web Design System](https://designsystem.digital.gov/) to accelerate development and deployment. Once you’ve had success with that, you can move on to bigger fish!
 

--- a/content/posts/2021-09-16-a_day_in_the_life_-_ingeniero_en_18f.md
+++ b/content/posts/2021-09-16-a_day_in_the_life_-_ingeniero_en_18f.md
@@ -68,6 +68,6 @@ Al evaluar la diferencia entre este trabajo y mis experiencias previas en el sec
 En eso enfoco mis esfuerzos dentro de 18F. Además creo que parte de mejorar esa accesibilidad es tener más y mejores servicios digitales en español. Para eso necesitamos personas como tú, con la experiencia técnica y el dominio de los idiomas inglés y español, entre otros, que nos ayuden a crear mejores servicios digitales y más accesibles.
 
 ## Comienza
-¿Interesado en unirse a [nuestro equipo?]({{ "/2021/05/11/we_asked_our_coworkers_why_did_you_join_18f/" | url }}) Consulte las posiciones abiertas y cómo postularse en la [página de TTS](https://join.tts.gsa.gov/)(en inglés).
+¿Interesado en unirse a [nuestro equipo?]({{ "/2016/03/21/we-asked-100-of-our-coworkers-why-did-you-join-18f/" | url }}) Consulte las posiciones abiertas y cómo postularse en la [página de TTS](https://join.tts.gsa.gov/)(en inglés).
 
 [**English version.**]({{ "/2021/09/30/a_day_in_the_life_of_an_18f_engineer/" | url }})

--- a/content/posts/2021-09-28-a_day_in_the_life_of_an_18f_engineer.md
+++ b/content/posts/2021-09-28-a_day_in_the_life_of_an_18f_engineer.md
@@ -68,4 +68,4 @@ That is where I focus my efforts within 18F. I also think that part of improving
 
 ## Get Started
 
-Interested in joining [our team]({{ "/2021/05/11/we_asked_our_coworkers_why_did_you_join_18f/" | url }})? Check out open positions and how to apply [on the TTS join page](https://join.tts.gsa.gov/).
+Interested in joining [our team]({{ "/2016/03/21/we-asked-100-of-our-coworkers-why-did-you-join-18f/" | url }})? Check out open positions and how to apply [on the TTS join page](https://join.tts.gsa.gov/).

--- a/lib/team.js
+++ b/lib/team.js
@@ -1,30 +1,23 @@
-const fs = require('fs');
-const { parse } = require('csv-parse/sync');  /* eslint-disable-line import/no-unresolved */
+const titleizeSlug = (id) => id
+  .split('-')
+  .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+  .join(' ');
 
-// const teamData = parse(
-//   fs.readFileSync('./data/team_members.csv', 'utf8'), {
-//     columns: true,
-//     skip_empty_lines: true
-//   }
-// );
-
-const findPerson = (id) => {
-  const maybePerson = teamData.find((person) => person.id === id);
-  if (maybePerson === undefined) {
-    console.warn(id, 'is undefined') /* eslint-disable-line no-console */
-  }
-  return maybePerson
-}
+const findPerson = (id) => ({
+  id,
+  first_name: titleizeSlug(id),
+  last_name: '',
+  full_name: titleizeSlug(id),
+});
 
 const fullName = (person) => {
   if (person.full_name !== '') {
     return person.full_name;
   }
-    return `${person.first_name} ${person.last_name}`
-
-}
+  return `${person.first_name} ${person.last_name}`;
+};
 
 module.exports = {
   findPerson,
   fullName,
-}
+};

--- a/templates/featured-posts.html
+++ b/templates/featured-posts.html
@@ -29,8 +29,12 @@
 
       {% endcomment %}
       {% assign post_with_url = collections.posts | where: "inputPath", post.inputPath | first %}
+      {% if post_with_url and post_with_url.url %}
       <a href="{{ post_with_url.url | url }}" class="text-no-underline">
         <h3 class="border-top-05 {{ border_color }} {{ hover_color }} padding-top-3 margin-bottom-3 text-bold {{ text_color }}">
+      {% else %}
+        <h3 class="border-top-05 {{ border_color }} padding-top-3 margin-bottom-3 text-bold {{ text_color }}">
+      {% endif %}
           {% comment %}
             This featured-posts partial renders two different types of posts:
               - regular posts
@@ -45,7 +49,9 @@
             {{ post.data.title }}
           {{ end }}
         </h3>
+      {% if post_with_url and post_with_url.url %}
       </a>
+      {% endif %}
       {% if show_excerpt %}
         {{ if type == "related" }}
           {{ post.excerpt }}

--- a/test/config/filters/team_link_test.js
+++ b/test/config/filters/team_link_test.js
@@ -1,0 +1,11 @@
+const chai = require('chai')
+
+const { expect } = chai
+
+const teamLink = require('../../../config/filters/teamLink')
+
+describe('teamLink filter', () => {
+  it('returns the team member name without linking to missing author pages', async () => {
+    expect(await teamLink('melody')).to.equal('<span itemprop="name">Melody</span>')
+  })
+})


### PR DESCRIPTION
## Summary
- add a conventional Contributing section to the README with direct links for policies, content examples, and local development docs
- fix team helper fallbacks now that `data/team_members.csv` no longer exists, and avoid generating links to missing author pages
- clean up stale legacy author/self links so the site link checker passes

Fixes #3821

## Testing
- bun run test
- bun run lint
- git diff --check
- bun run clean && bun run build >/tmp/18f-build.log && bun x check-html-links _site --ignore-link-pattern '**/TODO/'\n- GitHub Actions: build, Check all links, validate html, Run linter, CodeQL, Hound all passing